### PR TITLE
Add qbarrand to reviewers and approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,8 @@
 
 approvers:
   - adrianchiris
+  - qbarrand
   - zvonkok
   - mrunalp
+reviewers:
+  - qbarrand

--- a/ci/prow/lint
+++ b/ci/prow/lint
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/ci/prow/unit-tests
+++ b/ci/prow/unit-tests
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash


### PR DESCRIPTION
~Add contributors of https://github.com/qbarrand/oot-operator.~
Only add @qbarrand for now as other contributors are not members of the `kubernetes-sigs` org yet.
Add empty CI scripts to pass the mandatory CI.