### PR TITLE
Load firmware from the module loader

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -135,6 +135,11 @@ type ModprobeSpec struct {
 	// The resulting commands will be: `modprobe ${RawArgs}`.
 	// +optional
 	RawArgs *ModprobeArgs `json:"rawArgs,omitempty"`
+
+	// FirmwarePath is the path of the firmware(s).
+	// The firmware(s) will be copied to the host for the kernel to find them.
+	// +optional
+	FirmwarePath string `json:"firmwarePath,omitempty"`
 }
 
 type ModuleLoaderContainerSpec struct {

--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -2074,6 +2074,11 @@ spec:
                             description: DirName is the root directory for modules.
                               It adds `-d ${DirName}` to the modprobe command-line.
                             type: string
+                          firmwarePath:
+                            description: FirmwarePath is the path of the firmware(s).
+                              The firmware(s) will be copied to the host for the kernel
+                              to find them.
+                            type: string
                           moduleName:
                             description: ModuleName is the name of the Module to be
                               loaded.

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
@@ -24,6 +25,8 @@ const (
 	nodeLibModulesVolumeName       = "node-lib-modules"
 	nodeUsrLibModulesPath          = "/usr/lib/modules"
 	nodeUsrLibModulesVolumeName    = "node-usr-lib-modules"
+	nodeVarLibFirmwarePath         = "/var/lib/firmware"
+	nodeVarLibFirmwareVolumeName   = "node-var-lib-firmware"
 	devicePluginKernelVersion      = ""
 )
 
@@ -116,6 +119,91 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 	nodeSelector[dc.kernelLabel] = kernelVersion
 
 	hostPathDirectory := v1.HostPathDirectory
+	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+
+	container := v1.Container{
+		Command:         []string{"sleep", "infinity"},
+		Name:            "module-loader",
+		Image:           image,
+		ImagePullPolicy: mod.Spec.ModuleLoader.Container.ImagePullPolicy,
+		Lifecycle: &v1.Lifecycle{
+			PostStart: &v1.LifecycleHandler{
+				Exec: &v1.ExecAction{
+					Command: MakeLoadCommand(mod.Spec.ModuleLoader.Container.Modprobe, mod.Name),
+				},
+			},
+			PreStop: &v1.LifecycleHandler{
+				Exec: &v1.ExecAction{
+					Command: MakeUnloadCommand(mod.Spec.ModuleLoader.Container.Modprobe, mod.Name),
+				},
+			},
+		},
+		SecurityContext: &v1.SecurityContext{
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			Capabilities: &v1.Capabilities{
+				Add: []v1.Capability{"SYS_MODULE"},
+			},
+			RunAsUser: pointer.Int64(0),
+			SELinuxOptions: &v1.SELinuxOptions{
+				Type: "spc_t",
+			},
+		},
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      nodeLibModulesVolumeName,
+				ReadOnly:  true,
+				MountPath: nodeLibModulesPath,
+			},
+			{
+				Name:      nodeUsrLibModulesVolumeName,
+				ReadOnly:  true,
+				MountPath: nodeUsrLibModulesPath,
+			},
+		},
+	}
+
+	volumes := []v1.Volume{
+		{
+			Name: nodeLibModulesVolumeName,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: nodeLibModulesPath,
+					Type: &hostPathDirectory,
+				},
+			},
+		},
+		{
+			Name: nodeUsrLibModulesVolumeName,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: nodeUsrLibModulesPath,
+					Type: &hostPathDirectory,
+				},
+			},
+		},
+	}
+
+	if fw := mod.Spec.ModuleLoader.Container.Modprobe.FirmwarePath; fw != "" {
+		moduleFirmwarePath := fmt.Sprintf("%s/%s", nodeVarLibFirmwarePath, mod.Name)
+
+		firmwareVolume := v1.Volume{
+			Name: nodeVarLibFirmwareVolumeName,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: moduleFirmwarePath,
+					Type: &hostPathDirectoryOrCreate,
+				},
+			},
+		}
+		volumes = append(volumes, firmwareVolume)
+
+		firmwareVolumeMount := v1.VolumeMount{
+			Name:      nodeVarLibFirmwareVolumeName,
+			MountPath: moduleFirmwarePath,
+		}
+
+		container.VolumeMounts = append(container.VolumeMounts, firmwareVolumeMount)
+	}
 
 	ds.Spec = appsv1.DaemonSetSpec{
 		Template: v1.PodTemplateSpec{
@@ -124,72 +212,12 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 				Finalizers: []string{constants.NodeLabelerFinalizer},
 			},
 			Spec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Command:         []string{"sleep", "infinity"},
-						Name:            "module-loader",
-						Image:           image,
-						ImagePullPolicy: mod.Spec.ModuleLoader.Container.ImagePullPolicy,
-						Lifecycle: &v1.Lifecycle{
-							PostStart: &v1.LifecycleHandler{
-								Exec: &v1.ExecAction{
-									Command: MakeLoadCommand(mod.Spec.ModuleLoader.Container.Modprobe),
-								},
-							},
-							PreStop: &v1.LifecycleHandler{
-								Exec: &v1.ExecAction{
-									Command: MakeUnloadCommand(mod.Spec.ModuleLoader.Container.Modprobe),
-								},
-							},
-						},
-						SecurityContext: &v1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.Bool(false),
-							Capabilities: &v1.Capabilities{
-								Add: []v1.Capability{"SYS_MODULE"},
-							},
-							RunAsUser: pointer.Int64(0),
-							SELinuxOptions: &v1.SELinuxOptions{
-								Type: "spc_t",
-							},
-						},
-						VolumeMounts: []v1.VolumeMount{
-							{
-								Name:      nodeLibModulesVolumeName,
-								ReadOnly:  true,
-								MountPath: nodeLibModulesPath,
-							},
-							{
-								Name:      nodeUsrLibModulesVolumeName,
-								ReadOnly:  true,
-								MountPath: nodeUsrLibModulesPath,
-							},
-						},
-					},
-				},
+				Containers:         []v1.Container{container},
 				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
 				NodeSelector:       nodeSelector,
 				PriorityClassName:  "system-node-critical",
 				ServiceAccountName: mod.Spec.ModuleLoader.ServiceAccountName,
-				Volumes: []v1.Volume{
-					{
-						Name: nodeLibModulesVolumeName,
-						VolumeSource: v1.VolumeSource{
-							HostPath: &v1.HostPathVolumeSource{
-								Path: nodeLibModulesPath,
-								Type: &hostPathDirectory,
-							},
-						},
-					},
-					{
-						Name: nodeUsrLibModulesVolumeName,
-						VolumeSource: v1.VolumeSource{
-							HostPath: &v1.HostPathVolumeSource{
-								Path: nodeUsrLibModulesPath,
-								Type: &hostPathDirectory,
-							},
-						},
-					},
-				},
+				Volumes:            volumes,
 			},
 		},
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},
@@ -339,43 +367,70 @@ func OverrideLabels(labels, overrides map[string]string) map[string]string {
 	return labels
 }
 
-func MakeLoadCommand(spec kmmv1beta1.ModprobeSpec) []string {
-	loadCommand := []string{"modprobe"}
+func MakeLoadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
+	loadCommandShell := []string{
+		"/bin/sh",
+		"-c",
+	}
+
+	loadCommand := "modprobe"
 
 	if ra := spec.RawArgs; ra != nil && len(ra.Load) > 0 {
-		return append(loadCommand, ra.Load...)
+		loadCommand = fmt.Sprintf("%s %s", loadCommand, strings.Join(ra.Load, " "))
+		return append(loadCommandShell, loadCommand)
+	}
+
+	if fw := spec.FirmwarePath; fw != "" {
+		loadCommand = fmt.Sprintf("cp -r %s %s/%s && %s", fw, nodeVarLibFirmwarePath, modName, loadCommand)
 	}
 
 	if a := spec.Args; a != nil && len(a.Load) > 0 {
-		loadCommand = append(loadCommand, a.Load...)
+		loadCommand = fmt.Sprintf("%s %s", loadCommand, strings.Join(a.Load, " "))
 	} else {
-		loadCommand = append(loadCommand, "-v")
+		loadCommand = fmt.Sprintf("%s -v", loadCommand)
 	}
 
 	if dirName := spec.DirName; dirName != "" {
-		loadCommand = append(loadCommand, "-d", dirName)
+		loadCommand = fmt.Sprintf("%s -d %s", loadCommand, dirName)
 	}
 
-	loadCommand = append(loadCommand, spec.ModuleName)
-	return append(loadCommand, spec.Parameters...)
+	loadCommand = fmt.Sprintf("%s %s", loadCommand, spec.ModuleName)
+
+	if p := spec.Parameters; len(p) > 0 {
+		loadCommand = fmt.Sprintf("%s %s", loadCommand, strings.Join(spec.Parameters, " "))
+	}
+
+	return append(loadCommandShell, loadCommand)
 }
 
-func MakeUnloadCommand(spec kmmv1beta1.ModprobeSpec) []string {
-	unloadCommand := []string{"modprobe"}
+func MakeUnloadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
+	unloadCommandShell := []string{
+		"/bin/sh",
+		"-c",
+	}
+
+	unloadCommand := "modprobe"
 
 	if ra := spec.RawArgs; ra != nil && len(ra.Unload) > 0 {
-		return append(unloadCommand, ra.Unload...)
+		unloadCommand = fmt.Sprintf("%s %s", unloadCommand, strings.Join(ra.Unload, " "))
+		return append(unloadCommandShell, unloadCommand)
 	}
 
 	if a := spec.Args; a != nil && len(a.Unload) > 0 {
-		unloadCommand = append(unloadCommand, a.Unload...)
+		unloadCommand = fmt.Sprintf("%s %s", unloadCommand, strings.Join(a.Unload, " "))
 	} else {
-		unloadCommand = append(unloadCommand, "-rv")
+		unloadCommand = fmt.Sprintf("%s -rv", unloadCommand)
 	}
 
 	if dirName := spec.DirName; dirName != "" {
-		unloadCommand = append(unloadCommand, "-d", dirName)
+		unloadCommand = fmt.Sprintf("%s -d %s", unloadCommand, dirName)
 	}
 
-	return append(unloadCommand, spec.ModuleName)
+	unloadCommand = fmt.Sprintf("%s %s", unloadCommand, spec.ModuleName)
+
+	if fw := spec.FirmwarePath; fw != "" {
+		unloadCommand = fmt.Sprintf("%s && rm -rf %s/%s", unloadCommand, nodeVarLibFirmwarePath, modName)
+	}
+
+	return append(unloadCommandShell, unloadCommand)
 }


### PR DESCRIPTION
It is common for kernel module to come with firmware(s). On immutable operating systems like CoreOS, the standard firmware path `/lib/firmware` is read-only. So, we need to let the kernel know where to lookup firmware file(s).

This change adds the `FirmwarePath` attribute to the `ModprobeSpec` definition and modify the `MakeLoadCommand` and `MakeUnloadCommand` methods to leverage it.

It also adds a `Volume` and a `VolumeMount` to expose the `/var/lib/firmware/<Module.Name>` host directory (created if it doesn't exist) inside the pod. The `/var/lib/firmware` is [the recommended path for firmwares in OpenShift with RHCOS
nodes](https://access.redhat.com/documentation/fr-fr/openshift_container_platform/4.10/html-single/post-installation_configuration/index#rhcos-load-firmware-blobs_post-install-machine-configuration-tasks). Putting the firmware in a `Module.Name` subfolder avoids multiple
Modules to override each others firmware. It also simplifies the removal of the firmware files.

The `MakeLoadCommand` adds a step to copy the `FirmwarePath` to `/var/lib/firmware/<Module.Name>` to the `modprobe` command. The `MakeUnloadCommand` removes the firmware folder previously copied after unloading the module. The commands use `/usr/bin -c` to allow shell control like `&&`.