### PR TITLE
Adding build option to disable pushes to registry

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -234,7 +234,7 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion)
+	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}

--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -16,7 +16,7 @@ import (
 //go:generate mockgen -source=maker.go -package=job -destination=mock_maker.go
 
 type Maker interface {
-	MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel, containerImage string) (*batchv1.Job, error)
+	MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel, containerImage string, pushImage bool) (*batchv1.Job, error)
 }
 
 type maker struct {
@@ -28,8 +28,13 @@ func NewMaker(helper build.Helper, scheme *runtime.Scheme) Maker {
 	return &maker{helper: helper, scheme: scheme}
 }
 
-func (m *maker) MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel, containerImage string) (*batchv1.Job, error) {
-	args := []string{"--destination", containerImage}
+func (m *maker) MakeJob(mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel, containerImage string, pushImage bool) (*batchv1.Job, error) {
+	args := []string{}
+	if pushImage {
+		args = append(args, "--destination", containerImage)
+	} else {
+		args = append(args, "--no-push")
+	}
 
 	buildArgs := m.helper.ApplyBuildArgOverrides(
 		buildConfig.BuildArgs,

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -62,7 +62,7 @@ func (jbm *jobManager) getJob(ctx context.Context, mod kmmv1beta1.Module, target
 	return &jobList.Items[0], nil
 }
 
-func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string) (build.Result, error) {
+func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (build.Result, error) {
 	logger := log.FromContext(ctx)
 
 	buildConfig := jbm.helper.GetRelevantBuild(mod, m)
@@ -95,7 +95,7 @@ func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1b
 
 		logger.Info("Creating job")
 
-		job, err = jbm.maker.MakeJob(mod, buildConfig, targetKernel, m.ContainerImage)
+		job, err = jbm.maker.MakeJob(mod, buildConfig, targetKernel, m.ContainerImage, pushImage)
 		if err != nil {
 			return build.Result{}, fmt.Errorf("could not make Job: %v", err)
 		}

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -75,7 +75,7 @@ var _ = Describe("JobManager", func() {
 			)
 			mgr := NewBuildManager(nil, registry, maker, helper)
 
-			_, err := mgr.Sync(ctx, kmmv1beta1.Module{}, km, "")
+			_, err := mgr.Sync(ctx, kmmv1beta1.Module{}, km, "", true)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(nil, registry, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, kmmv1beta1.Module{}, km, ""),
+				mgr.Sync(ctx, kmmv1beta1.Module{}, km, "", true),
 			).To(
 				Equal(build.Result{Status: build.StatusCompleted}),
 			)
@@ -130,7 +130,7 @@ var _ = Describe("JobManager", func() {
 
 				mgr := NewBuildManager(clnt, registry, maker, helper)
 
-				res, err := mgr.Sync(ctx, mod, km, kernelVersion)
+				res, err := mgr.Sync(ctx, mod, km, kernelVersion, true)
 
 				if expectsErr {
 					Expect(err).To(HaveOccurred())
@@ -150,14 +150,14 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
 				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()),
-				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage).Return(nil, errors.New("random error")),
+				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(nil, errors.New("random error")),
 			)
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any())
 
 			mgr := NewBuildManager(clnt, registry, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion),
+				mgr.Sync(ctx, mod, km, kernelVersion, true),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -180,7 +180,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
 				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()),
-				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage).Return(&j, nil),
+				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 			)
 
 			gomock.InOrder(
@@ -191,7 +191,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(clnt, registry, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion),
+				mgr.Sync(ctx, mod, km, kernelVersion, true),
 			).To(
 				Equal(build.Result{Requeue: true, Status: build.StatusCreated}),
 			)
@@ -223,14 +223,14 @@ var _ = Describe("JobManager", func() {
 					},
 				),
 				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()),
-				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage).Return(&j, nil),
+				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 				clnt.EXPECT().Create(ctx, &j),
 			)
 
 			mgr := NewBuildManager(clnt, registry, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion),
+				mgr.Sync(ctx, mod, km, kernelVersion, true),
 			).To(
 				Equal(build.Result{Requeue: true, Status: build.StatusCreated}),
 			)

--- a/internal/build/job/mock_maker.go
+++ b/internal/build/job/mock_maker.go
@@ -36,16 +36,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeJob mocks base method.
-func (m *MockMaker) MakeJob(mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string) (*v1.Job, error) {
+func (m *MockMaker) MakeJob(mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJob", mod, buildConfig, targetKernel, containerImage)
+	ret := m.ctrl.Call(m, "MakeJob", mod, buildConfig, targetKernel, containerImage, pushImage)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJob indicates an expected call of MakeJob.
-func (mr *MockMakerMockRecorder) MakeJob(mod, buildConfig, targetKernel, containerImage interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeJob(mod, buildConfig, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJob", reflect.TypeOf((*MockMaker)(nil).MakeJob), mod, buildConfig, targetKernel, containerImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJob", reflect.TypeOf((*MockMaker)(nil).MakeJob), mod, buildConfig, targetKernel, containerImage, pushImage)
 }

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -22,5 +22,5 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string) (Result, error)
+	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -36,16 +36,16 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage)
 }


### PR DESCRIPTION
This PR adds additionl flag to the Build APIs
that allows to configure kaniko flag to either
push the image to registry(once it is build),
or skip the push  to registry