### PR TITLE
Fixing ci/prow/check-commit-count.

### DIFF
--- a/ci/prow/check-commits-count
+++ b/ci/prow/check-commits-count
@@ -2,8 +2,13 @@
 
 set -euxo pipefail
 
-number_of_commits=$(git rev-list --count HEAD ^main)
-if [[ ${number_of_commits} != 1 ]]; then
+git remote add upstream https://github.com/kubernetes-sigs/kernel-module-management.git
+git fetch upstream
+
+commits_count=$(git rev-list --count HEAD ^upstream/main)
+# Look like Git (in Prow only) is adding an additional commit for each PR,
+# therefore, we are making sure there are 2 commits instead of 1
+if [[ ${commits_count} != 2 ]]; then
     echo '
     All PRs must contain a single commit.
     Please refer to https://github.com/kubernetes-sigs/kernel-module-management/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
Prow is cloning the repo using `git clone --mirror ...`.

In addition to that, the changes are directly tested in the `main`
branch, therefore, the only way to get the diff is to add the `upstream`
remote and check the diff against `upstream/main` instead of `main`.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>
