### PR TITLE
Separate in-cluster build and image existence verification

### DIFF
--- a/controllers/node_kernel_reconciler_test.go
+++ b/controllers/node_kernel_reconciler_test.go
@@ -14,96 +14,94 @@ import (
 	runtimectrl "sigs.k8s.io/controller-runtime"
 )
 
-var _ = Describe("NodeKernelReconciler", func() {
-	Describe("Reconcile", func() {
-		var (
-			gCtrl *gomock.Controller
-			clnt  *client.MockClient
+var _ = Describe("NodeKernelReconciler_Reconcile", func() {
+	var (
+		gCtrl *gomock.Controller
+		clnt  *client.MockClient
+	)
+	BeforeEach(func() {
+		gCtrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(gCtrl)
+	})
+	const (
+		kernelVersion = "1.2.3"
+		labelName     = "label-name"
+		nodeName      = "node-name"
+	)
+
+	It("should return an error if the node cannot be found anymore", func() {
+		ctx := context.Background()
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+
+		nkr := NewNodeKernelReconciler(clnt, labelName, nil)
+		req := runtimectrl.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName},
+		}
+
+		_, err := nkr.Reconcile(ctx, req)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should set the label if it does not exist", func() {
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+			},
+		}
+
+		ctx := context.Background()
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, n *v1.Node) error {
+					n.ObjectMeta = node.ObjectMeta
+					n.Status = node.Status
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
 		)
-		BeforeEach(func() {
-			gCtrl = gomock.NewController(GinkgoT())
-			clnt = client.NewMockClient(gCtrl)
-		})
-		const (
-			kernelVersion = "1.2.3"
-			labelName     = "label-name"
-			nodeName      = "node-name"
+
+		nkr := NewNodeKernelReconciler(clnt, labelName, nil)
+		req := runtimectrl.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName},
+		}
+
+		res, err := nkr.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(res))
+	})
+
+	It("should set the label if it already exists", func() {
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nodeName,
+				Labels: map[string]string{kernelVersion: "4.5.6"},
+			},
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+			},
+		}
+
+		ctx := context.Background()
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, n *v1.Node) error {
+					n.ObjectMeta = node.ObjectMeta
+					n.Status = node.Status
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
 		)
 
-		It("should return an error if the node cannot be found anymore", func() {
-			ctx := context.Background()
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+		nkr := NewNodeKernelReconciler(clnt, labelName, nil)
+		req := runtimectrl.Request{
+			NamespacedName: types.NamespacedName{Name: nodeName},
+		}
 
-			nkr := NewNodeKernelReconciler(clnt, labelName, nil)
-			req := runtimectrl.Request{
-				NamespacedName: types.NamespacedName{Name: nodeName},
-			}
-
-			_, err := nkr.Reconcile(ctx, req)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should set the label if it does not exist", func() {
-			node := v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-				Status: v1.NodeStatus{
-					NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
-				},
-			}
-
-			ctx := context.Background()
-			gomock.InOrder(
-				clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ interface{}, _ interface{}, n *v1.Node) error {
-						n.ObjectMeta = node.ObjectMeta
-						n.Status = node.Status
-						return nil
-					},
-				),
-				clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
-			)
-
-			nkr := NewNodeKernelReconciler(clnt, labelName, nil)
-			req := runtimectrl.Request{
-				NamespacedName: types.NamespacedName{Name: nodeName},
-			}
-
-			res, err := nkr.Reconcile(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(Equal(res))
-		})
-
-		It("should set the label if it already exists", func() {
-			node := v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   nodeName,
-					Labels: map[string]string{kernelVersion: "4.5.6"},
-				},
-				Status: v1.NodeStatus{
-					NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
-				},
-			}
-
-			ctx := context.Background()
-			gomock.InOrder(
-				clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ interface{}, _ interface{}, n *v1.Node) error {
-						n.ObjectMeta = node.ObjectMeta
-						n.Status = node.Status
-						return nil
-					},
-				),
-				clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
-			)
-
-			nkr := NewNodeKernelReconciler(clnt, labelName, nil)
-			req := runtimectrl.Request{
-				NamespacedName: types.NamespacedName{Name: nodeName},
-			}
-
-			res, err := nkr.Reconcile(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(Equal(res))
-		})
+		res, err := nkr.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(res))
 	})
 })

--- a/internal/build/helper.go
+++ b/internal/build/helper.go
@@ -12,7 +12,6 @@ import (
 type Helper interface {
 	ApplyBuildArgOverrides(args []v1beta1.BuildArg, overrides ...v1beta1.BuildArg) []v1beta1.BuildArg
 	GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build
-	GetRelevantPullOptions(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.PullOptions
 }
 
 type helper struct{}
@@ -67,11 +66,4 @@ func (m *helper) GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMap
 	// secret and how to use, and if we need to take care of repeated secrets names
 	buildConfig.Secrets = append(buildConfig.Secrets, km.Build.Secrets...)
 	return buildConfig
-}
-
-func (m *helper) GetRelevantPullOptions(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.PullOptions {
-	if km.Pull != nil {
-		return km.Pull
-	}
-	return mod.Spec.ModuleLoader.Container.Pull
 }

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -6,15 +6,12 @@ import (
 
 	"github.com/golang/mock/gomock"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/auth"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
-	registrypkg "github.com/kubernetes-sigs/kernel-module-management/internal/registry"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,11 +37,10 @@ var _ = Describe("JobManager", func() {
 	Describe("Sync", func() {
 
 		var (
-			ctrl     *gomock.Controller
-			clnt     *client.MockClient
-			registry *registrypkg.MockRegistry
-			maker    *MockMaker
-			helper   *build.MockHelper
+			ctrl   *gomock.Controller
+			clnt   *client.MockClient
+			maker  *MockMaker
+			helper *build.MockHelper
 		)
 
 		const (
@@ -55,7 +51,6 @@ var _ = Describe("JobManager", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			clnt = client.NewMockClient(ctrl)
-			registry = registrypkg.NewMockRegistry(ctrl)
 			maker = NewMockMaker(ctrl)
 			helper = build.NewMockHelper(ctrl)
 		})
@@ -66,37 +61,6 @@ var _ = Describe("JobManager", func() {
 			Build:          &kmmv1beta1.Build{Pull: *po},
 			ContainerImage: imageName,
 		}
-
-		It("should return an error if there was an error getting the image", func() {
-			ctx := context.Background()
-			gomock.InOrder(
-				helper.EXPECT().GetRelevantBuild(gomock.Any(), km).Return(km.Build),
-				helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()).Return(false, errors.New("random error")),
-			)
-			mgr := NewBuildManager(nil, registry, maker, helper)
-
-			_, err := mgr.Sync(ctx, kmmv1beta1.Module{}, km, "", true)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should return StatusCompleted if the image already exists", func() {
-			ctx := context.Background()
-
-			gomock.InOrder(
-				helper.EXPECT().GetRelevantBuild(gomock.Any(), km).Return(km.Build),
-				helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()).Return(true, nil),
-			)
-
-			mgr := NewBuildManager(nil, registry, maker, helper)
-
-			Expect(
-				mgr.Sync(ctx, kmmv1beta1.Module{}, km, "", true),
-			).To(
-				Equal(build.Result{Status: build.StatusCompleted}),
-			)
-		})
 
 		const (
 			moduleName    = "module-name"
@@ -118,20 +82,18 @@ var _ = Describe("JobManager", func() {
 					Status: s,
 				}
 				ctx := context.Background()
-				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
-						list.Items = []batchv1.Job{j}
-						return nil
-					},
-				)
 
 				gomock.InOrder(
 					helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-					helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-					registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()).Return(false, nil),
+					clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
+							list.Items = []batchv1.Job{j}
+							return nil
+						},
+					),
 				)
 
-				mgr := NewBuildManager(clnt, registry, maker, helper)
+				mgr := NewBuildManager(clnt, maker, helper)
 
 				res, err := mgr.Sync(ctx, mod, km, kernelVersion, true)
 
@@ -152,13 +114,11 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-				helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()),
 				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(nil, errors.New("random error")),
 			)
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any())
 
-			mgr := NewBuildManager(clnt, registry, maker, helper)
+			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
 				mgr.Sync(ctx, mod, km, kernelVersion, true),
@@ -183,8 +143,6 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-				helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()),
 				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 			)
 
@@ -193,47 +151,7 @@ var _ = Describe("JobManager", func() {
 				clnt.EXPECT().Create(ctx, &j),
 			)
 
-			mgr := NewBuildManager(clnt, registry, maker, helper)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, true),
-			).To(
-				Equal(build.Result{Requeue: true, Status: build.StatusCreated}),
-			)
-		})
-
-		It("should use a non-nil RegistryAuthGetter if the imagePullSecret is set in the module", func() {
-
-			ctx := context.Background()
-
-			j := batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "batch/v1",
-					Kind:       "Job",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-				},
-			}
-
-			mod.Spec.ImageRepoSecret = &v1.LocalObjectReference{Name: "pull-push-secret"}
-
-			gomock.InOrder(
-				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-				helper.EXPECT().GetRelevantPullOptions(gomock.Any(), km).Return(po),
-				registry.EXPECT().ImageExists(ctx, imageName, po, gomock.Any()).DoAndReturn(
-					func(_ interface{}, _ interface{}, _ interface{}, registryAuthGetter auth.RegistryAuthGetter) (bool, error) {
-						Expect(registryAuthGetter).ToNot(BeNil())
-						return false, nil
-					},
-				),
-				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()),
-				maker.EXPECT().MakeJob(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
-				clnt.EXPECT().Create(ctx, &j),
-			)
-
-			mgr := NewBuildManager(clnt, registry, maker, helper)
+			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
 				mgr.Sync(ctx, mod, km, kernelVersion, true),

--- a/internal/build/mock_helper.go
+++ b/internal/build/mock_helper.go
@@ -66,17 +66,3 @@ func (mr *MockHelperMockRecorder) GetRelevantBuild(mod, km interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantBuild", reflect.TypeOf((*MockHelper)(nil).GetRelevantBuild), mod, km)
 }
-
-// GetRelevantPullOptions mocks base method.
-func (m *MockHelper) GetRelevantPullOptions(mod v1beta1.Module, km v1beta1.KernelMapping) *v1beta1.PullOptions {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantPullOptions", mod, km)
-	ret0, _ := ret[0].(*v1beta1.PullOptions)
-	return ret0
-}
-
-// GetRelevantPullOptions indicates an expected call of GetRelevantPullOptions.
-func (mr *MockHelperMockRecorder) GetRelevantPullOptions(mod, km interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantPullOptions", reflect.TypeOf((*MockHelper)(nil).GetRelevantPullOptions), mod, km)
-}

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -1,0 +1,12 @@
+package module
+
+import (
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+)
+
+func GetRelevantPullOptions(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) *kmmv1beta1.PullOptions {
+	if km.Pull != nil {
+		return km.Pull
+	}
+	return mod.Spec.ModuleLoader.Container.Pull
+}

--- a/main.go
+++ b/main.go
@@ -123,14 +123,14 @@ func main() {
 	registryAPI := registry.NewRegistry()
 	helperAPI := build.NewHelper()
 	makerAPI := job.NewMaker(helperAPI, scheme)
-	buildAPI := job.NewBuildManager(client, registryAPI, makerAPI, helperAPI)
+	buildAPI := job.NewBuildManager(client, makerAPI, helperAPI)
 	daemonAPI := daemonset.NewCreator(client, kernelLabel, scheme)
 	kernelAPI := module.NewKernelMapper()
 	moduleStatusUpdaterAPI := statusupdater.NewModuleStatusUpdater(client, daemonAPI, metricsAPI)
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
 	preflightAPI := preflight.NewPreflightAPI(client, registryAPI, kernelAPI)
 
-	mc := controllers.NewModuleReconciler(client, buildAPI, daemonAPI, kernelAPI, metricsAPI, filter, moduleStatusUpdaterAPI)
+	mc := controllers.NewModuleReconciler(client, buildAPI, daemonAPI, kernelAPI, metricsAPI, filter, registryAPI, moduleStatusUpdaterAPI)
 
 	if err = mc.SetupWithManager(mgr, kernelLabel); err != nil {
 		setupLogger.Error(err, "unable to create controller", "controller", "Module")


### PR DESCRIPTION
This PR removes the image existance verification from
Sync API of the build package and moves it into the
handleBuild function of the module reconcilier(prior
to calling the Sync API)