### PR TITLE
Ignore mocks in test coverage report via codecov config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/mock_*.go"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,11 +35,6 @@ jobs:
     - name: Build
       run: make
 
-    - name: Generate a coverage file without mocks
-      run: |
-        mv cover.out cover-with-mocks.out
-        grep -Ev '^.+/mock_.+\.go:.+$' cover-with-mocks.out > cover.out
-
     - name: Upload the coverage to Codecov
       uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
This PR adds [codecov](https://docs.codecov.com/docs/codecov-yaml) configuration to [ignore](https://docs.codecov.com/docs/codecovyml-reference#ignore) mocks when generating its test coverage report. As a result, the CI step to manually remove mocks from the Go test coverage output can be removed.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>