### PR TITLE
adding build verification to preflight

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -21,10 +21,12 @@ import (
 )
 
 const (
-	VerificationTrue       string = "True"
-	VerificationFalse      string = "False"
-	VerificationStageImage string = "Image"
-	VerificationStageBuild string = "Build"
+	VerificationTrue          string = "True"
+	VerificationFalse         string = "False"
+	VerificationStageImage    string = "Image"
+	VerificationStageBuild    string = "Build"
+	VerificationStageRequeued string = "Requeued"
+	VerificationStageDone     string = "Done"
 )
 
 // PreflightValidationSpec describes the desired state of the resource, such as the kernel version
@@ -53,7 +55,7 @@ type CRStatus struct {
 	// image (image existence verification), build(build process verification)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build
+	// +kubebuilder:validation:Enum=Image;Build;Requeued;Done
 	VerificationStage string `json:"verificationStage"`
 
 	// LastTransitionTime is the last time the CR status transitioned from one status to another.

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -72,6 +72,8 @@ spec:
                       enum:
                       - Image
                       - Build
+                      - Requeued
+                      - Done
                       type: string
                     verificationStatus:
                       description: 'Status of Module CR verification: true (verified),

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -36,16 +36,69 @@ func (m *MockPreflightAPI) EXPECT() *MockPreflightAPIMockRecorder {
 }
 
 // PreflightUpgradeCheck mocks base method.
-func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, pv *v1beta1.PreflightValidation, mod *v1beta1.Module, kernelVersion string) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, pv, mod, kernelVersion)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // PreflightUpgradeCheck indicates an expected call of PreflightUpgradeCheck.
-func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, pv, mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, pv, mod, kernelVersion)
+}
+
+// MockpreflightHelperAPI is a mock of preflightHelperAPI interface.
+type MockpreflightHelperAPI struct {
+	ctrl     *gomock.Controller
+	recorder *MockpreflightHelperAPIMockRecorder
+}
+
+// MockpreflightHelperAPIMockRecorder is the mock recorder for MockpreflightHelperAPI.
+type MockpreflightHelperAPIMockRecorder struct {
+	mock *MockpreflightHelperAPI
+}
+
+// NewMockpreflightHelperAPI creates a new mock instance.
+func NewMockpreflightHelperAPI(ctrl *gomock.Controller) *MockpreflightHelperAPI {
+	mock := &MockpreflightHelperAPI{ctrl: ctrl}
+	mock.recorder = &MockpreflightHelperAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockpreflightHelperAPI) EXPECT() *MockpreflightHelperAPIMockRecorder {
+	return m.recorder
+}
+
+// verifyBuild mocks base method.
+func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifyBuild", ctx, mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifyBuild indicates an expected call of verifyBuild.
+func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, mapping, mod, kernelVersion)
+}
+
+// verifyImage mocks base method.
+func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifyImage", ctx, mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifyImage indicates an expected call of verifyImage.
+func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
 }

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/golang/mock/gomock"
 	v1stream "github.com/google/go-containerregistry/pkg/v1/stream"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/statusupdater"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,22 +25,23 @@ const (
 )
 
 var (
-	ctrl            *gomock.Controller
-	mockRegistryAPI *registry.MockRegistry
-	mockKernelAPI   *module.MockKernelMapper
-	clnt            *client.MockClient
-	p               *preflight
-	mod             *kmmv1beta1.Module
+	mod *kmmv1beta1.Module
+	pv  *kmmv1beta1.PreflightValidation
 )
 
 func TestPreflight(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mockRegistryAPI = registry.NewMockRegistry(ctrl)
-		mockKernelAPI = module.NewMockKernelMapper(ctrl)
+		pv = &kmmv1beta1.PreflightValidation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "preflight-name",
+				Namespace: "preflight-namespace",
+			},
+			Spec: kmmv1beta1.PreflightValidationSpec{
+				KernelVersion: "some kernel version",
+			},
+		}
 		mod = &kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: moduleName,
@@ -47,32 +50,49 @@ func TestPreflight(t *testing.T) {
 				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
 					Container: kmmv1beta1.ModuleLoaderContainerSpec{
 						Modprobe: kmmv1beta1.ModprobeSpec{
-							ModuleName: "simple-kmod.ko",
+							ModuleName: "simple-kmod",
 							DirName:    "/opt",
 						},
 					},
 				},
 			},
 		}
-		p = NewPreflightAPI(clnt,
-			mockRegistryAPI,
-			mockKernelAPI).(*preflight)
+	})
+
+	RunSpecs(t, "Preflight Suite")
+}
+
+var _ = Describe("preflight_PreflightUpgradeCheck", func() {
+	var (
+		ctrl              *gomock.Controller
+		mockKernelAPI     *module.MockKernelMapper
+		mockStatusUpdater *statusupdater.MockPreflightStatusUpdater
+		preflightHelper   *MockpreflightHelperAPI
+		p                 *preflight
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockKernelAPI = module.NewMockKernelMapper(ctrl)
+		mockStatusUpdater = statusupdater.NewMockPreflightStatusUpdater(ctrl)
+		preflightHelper = NewMockpreflightHelperAPI(ctrl)
+		p = &preflight{
+			kernelAPI:     mockKernelAPI,
+			helper:        preflightHelper,
+			statusUpdater: mockStatusUpdater,
+		}
+
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
 	})
 
-	RunSpecs(t, "Preflight Suite")
-}
-
-var _ = Describe("preflight upgrade", func() {
-
 	It("Failed to find mapping", func() {
 		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{}
 		mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(nil, fmt.Errorf("some error"))
 
-		res, message := p.PreflightUpgradeCheck(context.Background(), mod, kernelVersion)
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("Failed to find kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)))
@@ -82,38 +102,135 @@ var _ = Describe("preflight upgrade", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{}
 
-		mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
-		mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(nil, fmt.Errorf("some error"))
+		gomock.InOrder(
+			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
+			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(nil, fmt.Errorf("some error")),
+		)
 
-		res, message := p.PreflightUpgradeCheck(context.Background(), mod, kernelVersion)
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("Failed to substitute template in kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)))
 	})
+
+	It("verify image success, no build", func() {
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+
+		gomock.InOrder(
+			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
+			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
+			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(true, "some message"),
+		)
+
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
+
+		Expect(res).To(BeTrue())
+		Expect(message).To(Equal("some message"))
+	})
+
+	It("verify image failed, no build", func() {
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+
+		gomock.InOrder(
+			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
+			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
+			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
+		)
+
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
+
+		Expect(res).To(BeFalse())
+		Expect(message).To(Equal("some error message"))
+	})
+
+	It("verify image failed, build exists, successful", func() {
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage, Build: &kmmv1beta1.Build{}}
+		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+
+		gomock.InOrder(
+			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
+			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
+			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild),
+			preflightHelper.EXPECT().verifyBuild(context.Background(), &mapping, mod, kernelVersion).Return(true, "some message"),
+		)
+
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
+
+		Expect(res).To(BeTrue())
+		Expect(message).To(Equal("some message"))
+	})
+
+	It("verify image failed, build exists, failed", func() {
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage, Build: &kmmv1beta1.Build{}}
+		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+
+		gomock.InOrder(
+			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
+			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
+			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
+			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild),
+			preflightHelper.EXPECT().verifyBuild(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
+		)
+
+		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod, kernelVersion)
+
+		Expect(res).To(BeFalse())
+		Expect(message).To(Equal("some error message"))
+	})
 })
 
-var _ = Describe("verifyImage", func() {
+var _ = Describe("preflightHelper_verifyImage", func() {
+	var (
+		ctrl            *gomock.Controller
+		mockRegistryAPI *registry.MockRegistry
+		clnt            *client.MockClient
+		ph              *preflightHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockRegistryAPI = registry.NewMockRegistry(ctrl)
+		ph = &preflightHelper{
+			client:      clnt,
+			registryAPI: mockRegistryAPI,
+		}
+
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
 
 	It("good flow", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		digests := []string{"digest0", "digest1"}
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
-		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(&digestLayer, nil)
-		mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(true)
+		gomock.InOrder(
+			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil),
+			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(&digestLayer, nil),
+			mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(true),
+		)
 
-		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
 
 		Expect(res).To(BeTrue())
-		Expect(message).To(Equal(VerificationStatusReasonVerified))
+		Expect(message).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "image accessible and verified")))
 	})
 
 	It("get layers digest failed", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(nil, nil, fmt.Errorf("some error"))
 
-		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s inaccessible or does not exists", containerImage)))
@@ -123,10 +240,12 @@ var _ = Describe("verifyImage", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		digests := []string{"digest0", "digest1"}
 		repoConfig := &registry.RepoPullConfig{}
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
-		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(nil, fmt.Errorf("some error"))
+		gomock.InOrder(
+			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil),
+			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(nil, fmt.Errorf("some error")),
+		)
 
-		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s, layer %s is inaccessible", containerImage, digests[1])))
@@ -137,14 +256,73 @@ var _ = Describe("verifyImage", func() {
 		digests := []string{"digest0"}
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
-		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[0], repoConfig).Return(&digestLayer, nil)
-		mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(false)
+		gomock.InOrder(
+			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil),
+			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[0], repoConfig).Return(&digestLayer, nil),
+			mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(false),
+		)
 
-		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s does not contain kernel module for kernel %s on any layer", containerImage, kernelVersion)))
 	})
 
+})
+
+var _ = Describe("preflightHelper_verifyBuild", func() {
+	var (
+		ctrl         *gomock.Controller
+		mockBuildAPI *build.MockManager
+		clnt         *client.MockClient
+		ph           *preflightHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockBuildAPI = build.NewMockManager(ctrl)
+		ph = &preflightHelper{
+			client:   clnt,
+			buildAPI: mockBuildAPI,
+		}
+
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("sync failed", func() {
+		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{}, fmt.Errorf("some error"))
+
+		res, msg := ph.verifyBuild(context.Background(), &mapping, mod, kernelVersion)
+		Expect(res).To(BeFalse())
+		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
+
+	})
+
+	It("sync completed", func() {
+		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{Status: build.StatusCompleted}, nil)
+
+		res, msg := ph.verifyBuild(context.Background(), &mapping, mod, kernelVersion)
+		Expect(res).To(BeTrue())
+		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")))
+
+	})
+
+	It("sync not completed yet", func() {
+		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{Status: build.StatusInProgress}, nil)
+
+		res, msg := ph.verifyBuild(context.Background(), &mapping, mod, kernelVersion)
+		Expect(res).To(BeFalse())
+		Expect(msg).To(Equal("Waiting for build verification"))
+
+	})
 })

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -84,7 +84,8 @@ func (r *registry) GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (
 }
 
 func (r *registry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
-	fullPath := filepath.Join(pathPrefix, modulesLocationPath, kernelVersion, moduleFileName)
+	// in layers headers, there is no root prefix
+	fullPath := filepath.Join(strings.TrimPrefix(pathPrefix, "/"), modulesLocationPath, kernelVersion, moduleFileName)
 	_, err := r.getHeaderStreamFromLayer(layer, fullPath)
 	return err == nil
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -339,7 +339,7 @@ var _ = Describe("VerifyModuleExists", func() {
 	reg := NewRegistry()
 
 	It("file is not present", func() {
-		const fileName = "/etc/fileName"
+		const fileName = "etc/fileName"
 		layer, err := prepareLayer(fileName, []byte("some data"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -348,7 +348,7 @@ var _ = Describe("VerifyModuleExists", func() {
 	})
 
 	It("file is present", func() {
-		const fileName = "/opt/lib/modules/somekernel/module_name.ko"
+		const fileName = "opt/lib/modules/somekernel/module_name.ko"
 		layer, err := prepareLayer(fileName, []byte("some data"))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -128,7 +128,7 @@ func main() {
 	kernelAPI := module.NewKernelMapper()
 	moduleStatusUpdaterAPI := statusupdater.NewModuleStatusUpdater(client, daemonAPI, metricsAPI)
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
-	preflightAPI := preflight.NewPreflightAPI(client, registryAPI, kernelAPI)
+	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, preflightStatusUpdaterAPI, kernelAPI)
 
 	mc := controllers.NewModuleReconciler(client, buildAPI, daemonAPI, kernelAPI, metricsAPI, filter, registryAPI, moduleStatusUpdaterAPI)
 


### PR DESCRIPTION
In case image of the Module is not available or
is does not contain the correct driver version,
preflight will check if Build configuration exists in Module yaml, and if it does, then it will try to build it. In case build is successful, then the module is considered to be verified