### PR TITLE
Removing KMM nodes' labels upon KMMO undeployment

### DIFF
--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, testing-only
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: modules.kmm.sigs.k8s.io
 spec:
@@ -117,6 +117,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
                                     metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
@@ -135,6 +136,7 @@ spec:
                                   required:
                                   - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
                                     only resources limits and requests (limits.cpu,
@@ -160,6 +162,7 @@ spec:
                                   required:
                                   - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
                                     namespace
@@ -181,6 +184,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                           - name
@@ -403,6 +407,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             user:
                               description: 'user is optional: User is the rados user
                                 name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
@@ -435,6 +440,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             volumeID:
                               description: 'volumeID used to identify the volume in
                                 cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
@@ -510,6 +516,7 @@ spec:
                                 or its keys must be defined
                               type: boolean
                           type: object
+                          x-kubernetes-map-type: atomic
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
@@ -541,6 +548,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             readOnly:
                               description: readOnly specifies a read-only configuration
                                 for the volume. Defaults to false (read/write).
@@ -596,6 +604,7 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   mode:
                                     description: 'Optional: mode bits used to set
                                       permissions on this file, must be an octal value
@@ -640,6 +649,7 @@ spec:
                                     required:
                                     - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                 - path
                                 type: object
@@ -766,6 +776,7 @@ spec:
                                       - kind
                                       - name
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     dataSourceRef:
                                       description: 'dataSourceRef specifies the object
                                         from which to populate the volume with data,
@@ -813,6 +824,7 @@ spec:
                                       - kind
                                       - name
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resources:
                                       description: 'resources represents the minimum
                                         resources the volume should have. If RecoverVolumeExpansionFailure
@@ -900,6 +912,7 @@ spec:
                                             only "value". The requirements are ANDed.
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     storageClassName:
                                       description: 'storageClassName is the name of
                                         the StorageClass required by the claim. More
@@ -994,6 +1007,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                           required:
                           - driver
                           type: object
@@ -1177,6 +1191,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             targetPortal:
                               description: targetPortal is iSCSI Target Portal. The
                                 Portal is either an IP or ip_addr:port if the port
@@ -1353,6 +1368,7 @@ spec:
                                           ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   downwardAPI:
                                     description: downwardAPI information about the
                                       downwardAPI data to project
@@ -1382,6 +1398,7 @@ spec:
                                               required:
                                               - fieldPath
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                             mode:
                                               description: 'Optional: mode bits used
                                                 to set permissions on this file, must
@@ -1433,6 +1450,7 @@ spec:
                                               required:
                                               - resource
                                               type: object
+                                              x-kubernetes-map-type: atomic
                                           required:
                                           - path
                                           type: object
@@ -1500,6 +1518,7 @@ spec:
                                           the Secret or its key must be defined
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   serviceAccountToken:
                                     description: serviceAccountToken is information
                                       about the serviceAccountToken data to project
@@ -1620,6 +1639,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             user:
                               description: 'user is the rados user name. Default is
                                 admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -1660,6 +1680,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             sslEnabled:
                               description: sslEnabled Flag enable/disable SSL communication
                                 with Gateway, default false
@@ -1780,6 +1801,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             volumeName:
                               description: volumeName is the human-readable name of
                                 the StorageOS volume.  Volume names are only unique
@@ -1839,6 +1861,7 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               moduleLoader:
                 description: ModuleLoader allows overriding some properties of the
                   container that loads the kernel module on the node. Name and image
@@ -1921,6 +1944,7 @@ spec:
                                     uid?'
                                   type: string
                               type: object
+                              x-kubernetes-map-type: atomic
                             type: array
                         required:
                         - dockerfile
@@ -2022,6 +2046,7 @@ spec:
                                           kind, uid?'
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - dockerfile
@@ -2216,9 +2241,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, testing-only
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: preflightvalidations.kmm.sigs.k8s.io
 spec:
@@ -97,9 +97,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/k8s-staging-kmm/kernel-module-management
-  newTag: main
+  newName: quay.io/yshnaidm/kmmo
+  newTag: signals


### PR DESCRIPTION
This is a raw suggestion of how we should cleanup after KMMO undeployment. Since the label are put on the nodes by the KMMO controller, the suggested solution is:
1) define our own SignalHandler, instead of the default one
   defined by controler-runtime
2) signal handler will watch for SIGINT and SIGTERM signals (
   those a signals issued by cri-o to the pod's containers
3) upon signal reception, signal handler will iterate over
   all the nodes in cluster and remove its labels from them
4) it will then block again and wait for another SIGTERM
   upon which it will exit

Notes:
1) i think it is better to use signal handler then lifecycle hook
   since it allows us more flexibality
2) no matter which mecahinizm we use, we need to make sure that
   the undeploy sequnce is exactly opposite to deploy, meaning:
   ClusterRoles and ClusterRolesBinding must be deleted after
   KMMO deployment deletion