### PR TITLE
Trim plus sign in kernel versions

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/auth"
@@ -177,7 +178,7 @@ func (r *ModuleReconciler) getRelevantKernelMappingsAndNodes(ctx context.Context
 
 	for _, node := range targetedNodes {
 		osConfig := r.kernelAPI.GetNodeOSConfig(&node)
-		kernelVersion := node.Status.NodeInfo.KernelVersion
+		kernelVersion := strings.TrimSuffix(node.Status.NodeInfo.KernelVersion, "+")
 
 		nodeLogger := logger.WithValues(
 			"node", node.Name,

--- a/controllers/node_kernel_reconciler.go
+++ b/controllers/node_kernel_reconciler.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +38,7 @@ func (r *NodeKernelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("could not get node: %v", err)
 	}
 
-	kernelVersion := node.Status.NodeInfo.KernelVersion
+	kernelVersion := strings.TrimSuffix(node.Status.NodeInfo.KernelVersion, "+")
 
 	logger.Info(
 		"Patching node label",


### PR DESCRIPTION
Google Kubernetes Engine using COS as nodes set kernel versions ending in a '+' sign which 
breaks KMM as it is not a valid ending for Kubernetes labelling syntax.