### PR TITLE
Update of Build configuration in Module should trigger new Job

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   - jobs
   verbs:
   - create
+  - delete
   - list
   - watch
 - apiGroups:

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -87,7 +87,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;list;watch
+//+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;list;watch;delete
 
 // Reconcile lists all nodes and looks for kernels that match its mappings.
 // For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -617,6 +617,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/internal/build/job/mock_maker.go
+++ b/internal/build/job/mock_maker.go
@@ -35,17 +35,17 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 	return m.recorder
 }
 
-// MakeJob mocks base method.
-func (m *MockMaker) MakeJob(mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool) (*v1.Job, error) {
+// MakeJobTemplate mocks base method.
+func (m *MockMaker) MakeJobTemplate(mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJob", mod, buildConfig, targetKernel, containerImage, pushImage)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, buildConfig, targetKernel, containerImage, pushImage)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MakeJob indicates an expected call of MakeJob.
-func (mr *MockMakerMockRecorder) MakeJob(mod, buildConfig, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
+// MakeJobTemplate indicates an expected call of MakeJobTemplate.
+func (mr *MockMakerMockRecorder) MakeJobTemplate(mod, buildConfig, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJob", reflect.TypeOf((*MockMaker)(nil).MakeJob), mod, buildConfig, targetKernel, containerImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), mod, buildConfig, targetKernel, containerImage, pushImage)
 }


### PR DESCRIPTION
Currently once the Build job is created, it cannot be changed. Therefore even if user changes Build configuration in the module, the existing job will not be changed. This fixes it by doing the following 1) when job is created, Template data is hashed and saved as annotation
   in the job
2) when checking job status, hash of the new contents is compared
   to the existing one
3) in case hashes differ, the current job is deleted, which will
   trigger new job creation in the next reconcilation loop
4) in case job is in progress, reconcile should use RequeueAfter
   field with predefined value, otherwise it will cause exponential
   requeing timeouts