### PR TITLE
Fixing build job deletion, in case its pods are still running

### DIFF
--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -226,7 +226,7 @@ var _ = Describe("JobManager", func() {
 						return nil
 					},
 				),
-				clnt.EXPECT().Delete(ctx, &j).Return(nil),
+				clnt.EXPECT().Delete(ctx, &j, gomock.Any()).Return(nil),
 			)
 
 			mgr := NewBuildManager(clnt, maker, helper)


### PR DESCRIPTION
When we delete build job (due to Spec change) while its pods are still running/failed, those pods are not deleted and will stay there untill deleted manually. This PR adds a Propagate option to the Delete API call that will instaract GC to remove the pods of the deleted job