### PR TITLE
centralise the name of the image to build in the controller

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -141,7 +141,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	for kernelVersion, m := range mappings {
-		requeue, err := r.handleBuild(ctx, mod, m, kernelVersion)
+		requeue, err := r.handleBuild(ctx, mod, m, kernelVersion, m.ContainerImage)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle build for kernel version %s: %w", kernelVersion, err)
 		}
@@ -247,22 +247,23 @@ func (r *ModuleReconciler) getNodesListBySelector(ctx context.Context, mod *kmmv
 func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	km *kmmv1beta1.KernelMapping,
-	kernelVersion string) (bool, error) {
+	kernelVersion string,
+	containerImage string) (bool, error) {
 	if mod.Spec.ModuleLoader.Container.Build == nil && km.Build == nil {
 		return false, nil
 	}
-	exists, err := r.checkImageExists(ctx, mod, km)
+	exists, err := r.checkImageExists(ctx, mod, km, containerImage)
 	if err != nil {
-		return false, fmt.Errorf("failed to check image existence for kernel %s: %w", kernelVersion, err)
+		return false, fmt.Errorf("failed to check existence of image %s for kernel %s: %w", containerImage, kernelVersion, err)
 	}
 	if exists {
 		return false, nil
 	}
 
-	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
+	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", containerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true)
+	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, containerImage, true)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
@@ -277,10 +278,10 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	return buildRes.Requeue, nil
 }
 
-func (r *ModuleReconciler) checkImageExists(ctx context.Context, mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) (bool, error) {
+func (r *ModuleReconciler) checkImageExists(ctx context.Context, mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping, imageName string) (bool, error) {
 	registryAuthGetter := auth.NewRegistryAuthGetterFrom(r.Client, mod)
 	pullOptions := module.GetRelevantPullOptions(mod, km)
-	imageAvailable, err := r.registry.ImageExists(ctx, km.ContainerImage, pullOptions, registryAuthGetter)
+	imageAvailable, err := r.registry.ImageExists(ctx, imageName, pullOptions, registryAuthGetter)
 	if err != nil {
 		return false, fmt.Errorf("could not check if the image is available: %v", err)
 	}

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -590,7 +590,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 
 		mr := NewModuleReconciler(clnt, mockBM, mockRC, mockDC, mockKM, mockMetrics, nil, mockRegistry, mockSU)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -619,7 +619,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockRC, mockDC, mockKM, mockMetrics, nil, mockRegistry, mockSU)
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -640,12 +640,12 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		buildRes := build.Result{Requeue: true, Status: build.StatusCreated}
 		gomock.InOrder(
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockRC, mockDC, mockKM, mockMetrics, nil, mockRegistry, mockSU)
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})
@@ -666,12 +666,12 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		buildRes := build.Result{Requeue: true, Status: build.StatusCreated}
 		gomock.InOrder(
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockRC, mockDC, mockKM, mockMetrics, nil, mockRegistry, mockSU)
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})
@@ -692,12 +692,12 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		buildRes := build.Result{Requeue: false, Status: build.StatusCompleted}
 		gomock.InOrder(
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true),
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockRC, mockDC, mockKM, mockMetrics, nil, mockRegistry, mockSU)
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -61,14 +61,14 @@ func (jbm *jobManager) getJob(ctx context.Context, mod kmmv1beta1.Module, target
 	return &jobList.Items[0], nil
 }
 
-func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (build.Result, error) {
+func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (build.Result, error) {
 	logger := log.FromContext(ctx)
 
 	logger.Info("Building in-cluster")
 
 	buildConfig := jbm.helper.GetRelevantBuild(mod, m)
 
-	jobTemplate, err := jbm.maker.MakeJobTemplate(mod, buildConfig, targetKernel, m.ContainerImage, pushImage)
+	jobTemplate, err := jbm.maker.MakeJobTemplate(mod, buildConfig, targetKernel, targetImage, pushImage)
 	if err != nil {
 		return build.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -97,7 +97,7 @@ var _ = Describe("JobManager", func() {
 
 				mgr := NewBuildManager(clnt, maker, helper)
 
-				res, err := mgr.Sync(ctx, mod, km, kernelVersion, true)
+				res, err := mgr.Sync(ctx, mod, km, kernelVersion, km.ContainerImage, true)
 
 				if expectsErr {
 					Expect(err).To(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, km.ContainerImage, true),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -151,7 +151,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, km.ContainerImage, true),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -184,7 +184,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, km.ContainerImage, true),
 			).To(
 				Equal(build.Result{Requeue: true, Status: build.StatusCreated}),
 			)
@@ -232,7 +232,7 @@ var _ = Describe("JobManager", func() {
 			mgr := NewBuildManager(clnt, maker, helper)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, km.ContainerImage, true),
 			).To(
 				Equal(build.Result{Requeue: true, Status: build.StatusInProgress}),
 			)

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -22,5 +22,5 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error)
+	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (Result, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -36,16 +36,16 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage)
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -137,7 +137,7 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 	mapping *kmmv1beta1.KernelMapping,
 	mod *kmmv1beta1.Module) (bool, string) {
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage)
+	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, mapping.ContainerImage, pv.Spec.PushBuiltImage)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -296,7 +296,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	It("sync failed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{}, fmt.Errorf("some error"))
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{}, fmt.Errorf("some error"))
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
@@ -307,7 +307,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	It("sync completed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{Status: build.StatusCompleted}, nil)
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{Status: build.StatusCompleted}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
@@ -318,7 +318,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	It("sync not completed yet", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, false).Return(build.Result{Status: build.StatusInProgress}, nil)
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{Status: build.StatusInProgress}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())


### PR DESCRIPTION
The name of the image to build is assumed to be km.ContainerImage in several places in the code, this PR centralises that assumption into a single point in Reconcile(). This should make the code more maintainable in the future when that assumption may no longer be true.  

E.g if we add a signing stage to the image build process, then build itself needs to produce an intermediate image that is consumed by the signing job, and it is the signing job that needs to produce km.ContainerImage. 

(I also notice we have a module.spec.moduleLoader.container.containerImage field, which is presumably meant to be a default, but we cannot use it while the km.ContainerImage assumption is made in lots of different places, )