### PR TITLE
Include .git in image builds

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,2 @@
+# Explicitly include .git in Google Cloud Builds as it is needed by Dockerfile.
+!.git


### PR DESCRIPTION
Explicitly include .git in Google Cloud Builds

To include VCS data in the controller binary, our image build process
requires .git to be present in the working directory.
Google Cloud Build, the system used by the Kubernetes project to build
container images, ignores .git by default.
Explicitly include .git in the GCB environment through a .gcloudignore
file.

Reference: https://github.com/GoogleCloudPlatform/cloud-builders/issues/236#issuecomment-374629200