### PR TITLE
Add an extra label to the build job to label the stage of the build

### DIFF
--- a/internal/build/job/maker_test.go
+++ b/internal/build/job/maker_test.go
@@ -73,6 +73,7 @@ var _ = Describe("MakeJobTemplate", func() {
 				Labels: map[string]string{
 					constants.ModuleNameLabel:    moduleName,
 					constants.TargetKernelTarget: kernelVersion,
+					constants.JobType:            "build",
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -37,6 +37,7 @@ func labels(mod kmmv1beta1.Module, targetKernel string) map[string]string {
 	return map[string]string{
 		constants.ModuleNameLabel:    mod.Name,
 		constants.TargetKernelTarget: targetKernel,
+		constants.JobType:            "build",
 	}
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,4 +5,5 @@ const (
 	NodeLabelerFinalizer = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget   = "kmm.node.kubernetes.io/target-kernel"
 	DaemonSetRole        = "kmm.node.kubernetes.io/role"
+	JobType              = "kmm.node.kubernetes.io/job-type"
 )


### PR DESCRIPTION
This PR adds a third label to kubernetes job objects created by kmmo for future proofing.

Currently jobs are labelled the module.name and target-kernel, and these are used to search for the job to ensure its creation, completion etc.

The manger searching for these jobs has no other way of determining which job it should be managing.

If we add multiple jobs into the build pipeline (e.g. a signing job) the build manager has no way of distinguishing between the different jobs, so when it searches for completed jobs it will detect finished signing jobs as if they were finished build (kaniko) jobs, and vice versa. This would lead to much confusion and the pipeline not running through its stages correctly.

This commit adds a third "kmm.node.kubernetes.io/build-stage" label that is set to "build" to make it explicit that this is a build job. For signing jobs it should be set to "sign" and for any other future jobs it would be set to a descriptive name. The build job manager then searches for all 3 labels (and future job managers should also search for their own build-stage label) and ignores any jobs with a different build-stage set.