### PR TITLE
add code/dockerfile for building the secureboot signing job image

### DIFF
--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,0 +1,24 @@
+FROM registry.fedoraproject.org/fedora as ksource
+RUN yum install -y kernel-devel
+
+FROM golang:1.19 as builder
+
+WORKDIR /workspace
+
+COPY cmd cmd
+COPY api api
+COPY internal internal
+COPY Makefile Makefile
+COPY docs.mk docs.mk
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+# Build
+RUN make signimage
+
+FROM registry.fedoraproject.org/fedora
+
+COPY --from=builder /workspace/cmd/signimage/signimage /
+COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /sign-file
+
+ENTRYPOINT ["/signimage"]

--- a/cmd/signimage/README.md
+++ b/cmd/signimage/README.md
@@ -1,0 +1,48 @@
+A utility to pull down an image, extract named kernel modules from it, sign them with the provided keys, and add them back in as a new layer, then upload that new image under a new tag.
+
+It operates as a wrapper around the sign-file binary provided as part of the kernel-devel package (a wrapper rather than a reimplementation to ensure its bug-for-bug compatabile, rather then having awhole new set of bugs of its own). sign-file is distributed as part of the kernel source so in theory is kernel version specific but in reality it hasn't changed to 5+ years, and for kernel modules to be whitelisted across major RHEL versions the signing format also has to be compatable so this is not a major concer.
+
+Configuration is done via command line switches or failing that via environment variables
+
+```
+Usage of signimage:
+  -cert string
+        path to file containing public key for signing
+  -filestosign string
+        colon seperated list of kmods to sign
+  -key string
+        path to file containing private key for signing
+  -pullsecret string
+        path to file containing credentials for pulling images
+  -pushsecret string
+        path to file containing credentials for pushing images (defaults to the pullsecret)
+  -signedimage string
+        name of the signed image to produce (defaults to "${unsignedimage}-signed")
+  -unsignedimage string
+        name of the image to sign
+```
+
+Environment variables:
+
+
+- UNSIGNEDIMAGE  the image to pull down
+- SIGNEDIMAGE  the tag for the new (signed) image
+- FILESTOSIGN  a colon seperated list of the full paths to files to sign
+- KEYSECRET  the path to the private key
+- CERTSECRET  the path to the public key 
+- PULLSECRET  path to file containing push credentials
+- PUSHSECRET  path to file containing pull credentials
+
+
+
+## Examples
+An example of its use as a Kubernetes job can be found in the ```kmod_signer_job.yaml``` file
+
+Or the from the command line
+```
+./signimage -unsignedimage quay.io/<org>/<image>:<tag> \
+	-pullsecret <pullsecretname> \
+	-key <keyfilename> \
+	-cert <certfilename> \
+	-filestosign </var/lib/kmod1.ko>[:</var/lib/kmod2.ko>]...
+

--- a/cmd/signimage/signimage.go
+++ b/cmd/signimage/signimage.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"flag"
+	"fmt"
+	"github.com/docker/cli/cli/config"
+	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
+	"io"
+	"k8s.io/klog/v2/klogr"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func checkArg(arg *string, varname string, fallback string) {
+	if *arg == "" {
+		if fallback != "" {
+			*arg = fallback
+		} else {
+			fmt.Printf("%s not found:\n", varname)
+			flag.PrintDefaults()
+			os.Exit(0)
+		}
+	}
+}
+
+/*
+** Convert a relative path to an absolute path
+** filenames in image manifests are normally relative but can be "path/file" or "./path/file"
+** or occasionaly be absolute "/path/file" (in baselayers) depending on how they were created.
+** and we need to turn them into absolute paths for easy string comparisons against the
+** filesToSign list we've been passed from the CR via the cli
+** the easiest way to do this is force it to be abs, then clean it up
+ */
+func canonicalisePath(path string) string {
+	return filepath.Clean("/" + path)
+}
+
+func signFile(filename string, publickey string, privatekey string) error {
+	logger.Info("running /sign-file", "algo", "sha256", "privatekey", privatekey, "publickey", publickey, "filename", filepath.Base(filename))
+	out, err := exec.Command("/sign-file", "sha256", privatekey, publickey, filename).Output()
+	if err != nil {
+		return fmt.Errorf("signing %s returned: %s\n error: %v\n", filename, out, err)
+	}
+	return nil
+}
+
+func getAuthFromFile(configfile string, repo string) (authn.Authenticator, error) {
+
+	if configfile == "" {
+		logger.Info("no pull secret defined, default to Anonymous")
+		return authn.Anonymous, nil
+	}
+
+	f, err := os.Open(configfile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	cf, err := config.LoadFromReader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg dockertypes.AuthConfig
+
+	cfg, err = cf.GetAuthConfig(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	return authn.FromConfig(authn.AuthConfig{
+		Username:      cfg.Username,
+		Password:      cfg.Password,
+		Auth:          cfg.Auth,
+		IdentityToken: cfg.IdentityToken,
+		RegistryToken: cfg.RegistryToken,
+	}), nil
+
+}
+
+func die(exitval int, message string, err error) {
+	fmt.Fprintf(os.Stderr, "\n%s\n", message)
+	logger.Info("ERROR "+message, "err", err)
+	logger.Error(err, message)
+	os.Exit(exitval)
+}
+
+func processFile(filename string, header *tar.Header, tarreader io.Reader, data []interface{}) error {
+
+	registryObj := data[0].(registry.Registry)
+	extractionDir := data[1].(string)
+	filesList := data[2].(string)
+	privKeyFile := data[3].(string)
+	pubKeyFile := data[4].(string)
+	kmodsToSign := data[5].(map[string]string)
+
+	canonfilename := canonicalisePath(filename)
+
+	//either the kmod has not yet been found, or we didn't define a list to search for
+	if kmodsToSign[canonfilename] == "not found" ||
+		(filesList == "" &&
+			kmodsToSign[canonfilename] == "" &&
+			canonfilename[len(canonfilename)-3:] == ".ko") {
+
+		logger.Info("Found kmod", "kmod", canonfilename, "matches kmod in image", header.Name)
+		//its a file we wanted and haven't already seen
+		//extract to the local filesystem
+		err := registryObj.ExtractFileToFile(extractionDir+"/"+header.Name, header, tarreader)
+		if err != nil {
+			return err
+		}
+		kmodsToSign[canonfilename] = extractionDir + "/" + header.Name
+		logger.Info("Signing kmod", "kmod", canonfilename)
+
+		//sign it
+		err = signFile(kmodsToSign[canonfilename], pubKeyFile, privKeyFile)
+		if err != nil {
+			return fmt.Errorf("error signing file %s", canonfilename)
+		}
+		logger.Info("Signed successfully", "kmod", canonfilename)
+		return nil
+
+	}
+	return nil
+}
+
+func addFileToTarball(sourcename string, filename string, tarwriter *tar.Writer) error {
+	finfo, err := os.Stat(sourcename)
+	if err != nil {
+		return fmt.Errorf("failed to stat %s: %w", filename, err)
+	}
+
+	if finfo.IsDir() {
+		return nil
+	}
+	hdr := &tar.Header{
+		Name:     filename,
+		Mode:     int64(finfo.Mode()),
+		Typeflag: 0,
+		Size:     finfo.Size(),
+	}
+
+	if err := tarwriter.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("failed to write tar header: %w", err)
+	}
+
+	f, err := os.Open(sourcename)
+	if err != nil {
+		return fmt.Errorf("failed to open file to add to the tar: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(tarwriter, f); err != nil {
+		return fmt.Errorf("failed to read file into the tar: %w", err)
+	}
+
+	return nil
+}
+
+var logger logr.Logger
+
+func main() {
+	// get the env vars we are using for setup, or set some sensible defaults
+	var err error
+	var unsignedImageName string
+	var signedImageName string
+	var pullSecret string
+	var pushSecret string
+	var extractionDir string
+	var filesList string
+	var privKeyFile string
+	var pubKeyFile string
+	var nopush bool
+
+	logger = klogr.New()
+
+	flag.StringVar(&unsignedImageName, "unsignedimage", "", "name of the image to sign")
+	flag.StringVar(&signedImageName, "signedimage", "", "name of the signed image to produce")
+	flag.StringVar(&filesList, "filestosign", "", "colon seperated list of kmods to sign")
+	flag.StringVar(&privKeyFile, "key", "", "path to file containing private key for signing")
+	flag.StringVar(&pubKeyFile, "cert", "", "path to file containing public key for signing")
+	flag.StringVar(&pullSecret, "pullsecret", "", "path to file containing credentials for pulling images")
+	flag.StringVar(&pullSecret, "pushsecret", "", "path to file containing credentials for pushing images")
+	flag.BoolVar(&nopush, "no-push", false, "do not push the resulting image")
+
+	flag.Parse()
+
+	checkArg(&unsignedImageName, "unsignedimage", "")
+	checkArg(&signedImageName, "signedimage", unsignedImageName+"signed")
+	checkArg(&filesList, "filestosign", "")
+	checkArg(&privKeyFile, "key", "")
+	checkArg(&pubKeyFile, "cert", "")
+	checkArg(&pullSecret, "pullsecret", "")
+	checkArg(&pushSecret, "pushsecret", pullSecret)
+	// if we've made it this far the arguments are sane
+
+	// get a temp dir to copy kmods into for signing
+	extractionDir, err = os.MkdirTemp("/tmp/", "kmod_signer")
+	if err != nil {
+		die(1, "could not create temp dir", err)
+	}
+	defer os.RemoveAll(extractionDir)
+
+	// sets up a tar archive we will use for a new layer
+	var b bytes.Buffer
+	tarwriter := tar.NewWriter(&b)
+
+	//make a map of the files to sign so we can track what we want to sign
+	kmodsToSign := make(map[string]string)
+	for _, x := range strings.Split(filesList, ":") {
+		if canonicalisePath(x) != x {
+			err = fmt.Errorf("%s not an sbsolute path", x)
+			die(9, "paths for files to sign must be absolute", err)
+		}
+		kmodsToSign[x] = "not found"
+	}
+
+	a, err := getAuthFromFile(pullSecret, strings.Split(unsignedImageName, "/")[0])
+	if err != nil {
+		die(2, "failed to get auth", err)
+	}
+
+	r := registry.NewRegistry()
+
+	img, err := r.GetImageByName(unsignedImageName, a)
+	if err != nil {
+		die(3, "could not Image()", err)
+	}
+
+	logger.Info("Successfully pulled image", "image", unsignedImageName)
+	logger.Info("Looking for files", "filelist", strings.Replace(filesList, ":", " ", -1))
+
+	/*
+	** loop through all the layers in the image from the top down
+	 */
+	err = r.WalkFilesInImage(img, processFile, r, extractionDir, filesList, privKeyFile, pubKeyFile, kmodsToSign)
+	if err != nil {
+		die(9, "failed to search image", err)
+	}
+
+	/*
+	** check if we found everything, if not then explode
+	 */
+	missingKmods := 0
+	for k, v := range kmodsToSign {
+		if v == "not found" {
+			missingKmods = 1
+			logger.Info("Failed to find expected kmod", "kmod", k)
+		} else {
+			err := addFileToTarball(v, k, tarwriter)
+			if err != nil {
+				die(1, "failed to add signed kmods to tarball", nil)
+			}
+
+		}
+	}
+	if missingKmods != 0 {
+		die(4, "Failed to find all expected kmods", fmt.Errorf("Failed to find all expected kmods"))
+	}
+
+	outputTarFile := extractionDir + "/layerfile.tar"
+	err = os.WriteFile(outputTarFile, b.Bytes(), 0700)
+	if err != nil {
+		die(5, "failed to write layer to tarball", err)
+	}
+
+	//create a new image from our old image with our tarball as a new layer
+	signedImage, err := r.AddLayerToImage(outputTarFile, img)
+	if err != nil {
+		die(6, "failed to add layer to image", err)
+	}
+
+	logger.Info("Appended new layer to image", "image", signedImageName)
+
+	if !nopush {
+		a, err = getAuthFromFile(pushSecret, strings.Split(signedImageName, "/")[0])
+		if err != nil {
+			die(7, "failed to get push auth", err)
+		}
+
+		// write the image back to the name:tag set via the args
+		err := r.WriteImageByName(signedImageName, signedImage, a)
+		if err != nil {
+			die(8, "failed to write signed image", err)
+		}
+		// we're done successfully, so we need a nice friendly message to say that
+		logger.Info("Pushed image back to repo", "image", signedImageName)
+	}
+	os.Exit(0)
+}

--- a/internal/registry/mock_registry_api.go
+++ b/internal/registry/mock_registry_api.go
@@ -5,11 +5,16 @@
 package registry
 
 import (
+	tar "archive/tar"
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	authn "github.com/google/go-containerregistry/pkg/authn"
+	name "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	types "github.com/google/go-containerregistry/pkg/v1/types"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	auth "github.com/kubernetes-sigs/kernel-module-management/internal/auth"
 )
@@ -37,6 +42,65 @@ func (m *MockRegistry) EXPECT() *MockRegistryMockRecorder {
 	return m.recorder
 }
 
+// AddLayerToImage mocks base method.
+func (m *MockRegistry) AddLayerToImage(tarfile string, image v1.Image) (v1.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddLayerToImage", tarfile, image)
+	ret0, _ := ret[0].(v1.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddLayerToImage indicates an expected call of AddLayerToImage.
+func (mr *MockRegistryMockRecorder) AddLayerToImage(tarfile, image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLayerToImage", reflect.TypeOf((*MockRegistry)(nil).AddLayerToImage), tarfile, image)
+}
+
+// ExtractBytesFromTar mocks base method.
+func (m *MockRegistry) ExtractBytesFromTar(size int64, tarreader io.Reader) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractBytesFromTar", size, tarreader)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExtractBytesFromTar indicates an expected call of ExtractBytesFromTar.
+func (mr *MockRegistryMockRecorder) ExtractBytesFromTar(size, tarreader interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractBytesFromTar", reflect.TypeOf((*MockRegistry)(nil).ExtractBytesFromTar), size, tarreader)
+}
+
+// ExtractFileToFile mocks base method.
+func (m *MockRegistry) ExtractFileToFile(destination string, header *tar.Header, tarreader io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExtractFileToFile", destination, header, tarreader)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExtractFileToFile indicates an expected call of ExtractFileToFile.
+func (mr *MockRegistryMockRecorder) ExtractFileToFile(destination, header, tarreader interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractFileToFile", reflect.TypeOf((*MockRegistry)(nil).ExtractFileToFile), destination, header, tarreader)
+}
+
+// GetImageByName mocks base method.
+func (m *MockRegistry) GetImageByName(imageName string, auth authn.Authenticator) (v1.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageByName", imageName, auth)
+	ret0, _ := ret[0].(v1.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetImageByName indicates an expected call of GetImageByName.
+func (mr *MockRegistryMockRecorder) GetImageByName(imageName, auth interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByName", reflect.TypeOf((*MockRegistry)(nil).GetImageByName), imageName, auth)
+}
+
 // GetLayerByDigest mocks base method.
 func (m *MockRegistry) GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (v1.Layer, error) {
 	m.ctrl.T.Helper()
@@ -50,6 +114,21 @@ func (m *MockRegistry) GetLayerByDigest(digest string, pullConfig *RepoPullConfi
 func (mr *MockRegistryMockRecorder) GetLayerByDigest(digest, pullConfig interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerByDigest", reflect.TypeOf((*MockRegistry)(nil).GetLayerByDigest), digest, pullConfig)
+}
+
+// GetLayerMediaType mocks base method.
+func (m *MockRegistry) GetLayerMediaType(image v1.Image) (types.MediaType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLayerMediaType", image)
+	ret0, _ := ret[0].(types.MediaType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLayerMediaType indicates an expected call of GetLayerMediaType.
+func (mr *MockRegistryMockRecorder) GetLayerMediaType(image interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayerMediaType", reflect.TypeOf((*MockRegistry)(nil).GetLayerMediaType), image)
 }
 
 // GetLayersDigests mocks base method.
@@ -83,6 +162,21 @@ func (mr *MockRegistryMockRecorder) ImageExists(ctx, image, po, registryAuthGett
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageExists", reflect.TypeOf((*MockRegistry)(nil).ImageExists), ctx, image, po, registryAuthGetter)
 }
 
+// ParseReference mocks base method.
+func (m *MockRegistry) ParseReference(imageName string) (name.Reference, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ParseReference", imageName)
+	ret0, _ := ret[0].(name.Reference)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ParseReference indicates an expected call of ParseReference.
+func (mr *MockRegistryMockRecorder) ParseReference(imageName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseReference", reflect.TypeOf((*MockRegistry)(nil).ParseReference), imageName)
+}
+
 // VerifyModuleExists mocks base method.
 func (m *MockRegistry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
 	m.ctrl.T.Helper()
@@ -95,4 +189,37 @@ func (m *MockRegistry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVers
 func (mr *MockRegistryMockRecorder) VerifyModuleExists(layer, pathPrefix, kernelVersion, moduleFileName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyModuleExists", reflect.TypeOf((*MockRegistry)(nil).VerifyModuleExists), layer, pathPrefix, kernelVersion, moduleFileName)
+}
+
+// WalkFilesInImage mocks base method.
+func (m *MockRegistry) WalkFilesInImage(image v1.Image, fn func(string, *tar.Header, io.Reader, []interface{}) error, data ...interface{}) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{image, fn}
+	for _, a := range data {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WalkFilesInImage", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WalkFilesInImage indicates an expected call of WalkFilesInImage.
+func (mr *MockRegistryMockRecorder) WalkFilesInImage(image, fn interface{}, data ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{image, fn}, data...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkFilesInImage", reflect.TypeOf((*MockRegistry)(nil).WalkFilesInImage), varargs...)
+}
+
+// WriteImageByName mocks base method.
+func (m *MockRegistry) WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteImageByName", imageName, image, auth)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteImageByName indicates an expected call of WriteImageByName.
+func (mr *MockRegistryMockRecorder) WriteImageByName(imageName, image, auth interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageByName", reflect.TypeOf((*MockRegistry)(nil).WriteImageByName), imageName, image, auth)
 }

--- a/internal/registry/registry_helper_test.go
+++ b/internal/registry/registry_helper_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -24,7 +23,7 @@ func (ul *uncompressedLayer) DiffID() (v1.Hash, error) {
 }
 
 func (ul *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewBuffer(ul.content)), nil
+	return io.NopCloser(bytes.NewBuffer(ul.content)), nil
 }
 
 func (ul *uncompressedLayer) MediaType() (types.MediaType, error) {


### PR DESCRIPTION
This commit adds a stand alone binary (signimage.go) and an associated Dockerfile that together will provide the image for use in the signing job.

The dockerfile compiles signimage, and retrieves the sign-file binary from the kernel-devel package. sign-file is the binary provided by the kernel developers for signing kmods, and while its operation is not super-complex and could be handled within signimage.go, we use it to ensure maximum compatibility. 

The signimage.go binary takes an image name, pulls it down, loops through each file in each layer and if its a kernel modules extracts it to a temporary directory, and runs sign-file on it. All signed kmods are then added back as a (single) new layer, and the new image pushed back to the registry.

It is intended that this output image is the driver container named in km.containerImage