### PR TITLE
Modify Makefile in kmm-kmod

### DIFF
--- a/ci/kmm-kmod/Makefile
+++ b/ci/kmm-kmod/Makefile
@@ -1,4 +1,7 @@
-KERNEL_SRC_DIR =
+ifndef KERNEL_SRC_DIR
+KERNEL_SRC_DIR =/lib/modules/$(shell uname -r)/build
+endif
+
 
 ccflags-y += -I$(KERNEL_SRC_DIR)/include
 obj-m += kmm_ci_a.o


### PR DESCRIPTION
Modify Makefile to use running kernel version if KERNEL_SRC_DIR is not set.