### PR TITLE
Add EXTRA_MODULE variable to kmm-kmod Makefile

### DIFF
--- a/ci/kmm-kmod/Makefile
+++ b/ci/kmm-kmod/Makefile
@@ -2,10 +2,13 @@ ifndef KERNEL_SRC_DIR
 KERNEL_SRC_DIR =/lib/modules/$(shell uname -r)/build
 endif
 
+ifndef MY_MODULE
+EXTRA_MODULE=kmm_ci_b.o
+endif
 
 ccflags-y += -I$(KERNEL_SRC_DIR)/include
 obj-m += kmm_ci_a.o
-obj-m += kmm_ci_b.o
+obj-m += $(EXTRA_MODULE)
 
 all:
 	make -C $(KERNEL_SRC_DIR) $(MAKE_OPTS) M=$(PWD) modules


### PR DESCRIPTION
Add EXTRA_MODULE variable to Makefile so extra module name

can be set in args.