### PR TITLE
Fix failing firmware requests

### DIFF
--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -86,7 +86,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			Name: "node-var-lib-firmware",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: "/var/lib/firmware/module-name",
+					Path: "/var/lib/firmware",
 					Type: &hostPathDirectoryOrCreate,
 				},
 			},
@@ -94,7 +94,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		volm := v1.VolumeMount{
 			Name:      "node-var-lib-firmware",
-			MountPath: "/var/lib/firmware/module-name",
+			MountPath: "/var/lib/firmware",
 		}
 
 		mod := kmmv1beta1.Module{
@@ -924,7 +924,7 @@ var _ = Describe("MakeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("cp -r /kmm/firmware/mymodule /var/lib/firmware/module-name && modprobe -v %s", kernelModuleName),
+				fmt.Sprintf("cp -r /kmm/firmware/mymodule /var/lib/firmware && modprobe -v %s", kernelModuleName),
 			}),
 		)
 	})
@@ -1005,7 +1005,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -rv %s && rm -rf /var/lib/firmware/module-name", kernelModuleName),
+				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/$(basename /kmm/firmware/mymodule)/{}", kernelModuleName),
 			}),
 		)
 	})


### PR DESCRIPTION
This PR fixes failing firmware requests, which are caused by the additional firmware path directory, named after the Module CR, which is created by KMM when copying the firmware files from the module-loader container to the host directory (and default firmware search path) `/var/lib/firmware`.

Modules request firmware files using a relative path, e.g. `vendor/device/firmware.bin`, which is appended to the default firmware search path. The additional firmware path directory makes the firmware requests unresolvable.

Specifically, this change:

- removes the additional firmware path directory, named after the Module CR
- ensures that only the copied firmware files are removed after the module is unloaded and non-empty firmware directories are skipped (this was not needed before, because each Module CR had its own firmware subpath under `/var/lib/firmware` and the whole subpath could be removed)

> It should be noted that this change assumes that `find` and `xargs` are available in the module-loader container. The `ubi-minimal` base image does not included them by default and the `findutils` package needs to be installed. 

Fixes https://github.com/kubernetes-sigs/kernel-module-management/issues/109

Signed-off-by: Michail Resvanis <mresvani@redhat.com>
