### PR TITLE
Add check-api-changes script to CI

### DIFF
--- a/ci/prow/check-api-changes
+++ b/ci/prow/check-api-changes
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+make generate manifests
+
+
+if [[ $(git diff) ]]; then
+   echo 'Please run `make generate manifests` and repush'
+   echo 'The following differences were found:'
+   echo $(git diff)
+   exit 1
+fi


### PR DESCRIPTION
When API code changes, we need to regenerate CRD configs using make generate manifests.
This script checks that regenerated files are pushed in the same PR which changes the API
 code so CRD configs are not merged in next unrelated PRs.