### PR TITLE
Add code to the reconcile loop for signing of kmods for secureboot.

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ const (
 	existingKMMOModulesQuery = "kmmo_module_total"
 	completedKMMOStageQuery  = "kmmo_completed_stage"
 	BuildStage               = "build"
+	SignStage                = "sign"
 	ModuleLoaderStage        = "module-loader"
 	DevicePluginStage        = "device-plugin"
 )

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -179,7 +179,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
@@ -210,7 +210,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 


### PR DESCRIPTION
This is the last part of the secureboot signing code and provides the required code in the reconcile loop to detect if the CR contains a Sign stanza, and if so makes the required calls into the internal/sign library to instantiate and manage the signing job.

- It changes the handleBuild() function to check if a Sign stanza is defined, if so it outputs an intermediate image named spec.containerImage+"-unsigned"
- It then adds a handleSigning() function that will consume this intermediate image, run the signing job and produce the final spec.containerImage image

It is this final image that is then loaded by the daemonset.

It also makes sure is Sign is not defined handleBuild() still does the right thing and handleSigning() consumes sign.UnsignedImage if a Build stanza is not defined.