### PR TITLE
Change back nodeLibModulesPath to /lib/modules

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -23,6 +23,7 @@ const (
 	kubeletDevicePluginsVolumeName = "kubelet-device-plugins"
 	kubeletDevicePluginsPath       = "/var/lib/kubelet/device-plugins"
 	nodeLibModulesVolumeName       = "node-lib-modules"
+        nodeLibModulesPath             = "/lib/modules/"
 	nodeVarLibFirmwarePath         = "/var/lib/firmware"
 	nodeVarLibFirmwareVolumeName   = "node-var-lib-firmware"
 	devicePluginKernelVersion      = ""
@@ -116,7 +117,6 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 	nodeSelector := CopyMapStringString(mod.Spec.Selector)
 	nodeSelector[dc.kernelLabel] = kernelVersion
 
-	nodeLibModulesPath := "/lib/modules/" + kernelVersion
 
 	hostPathDirectory := v1.HostPathDirectory
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -26,6 +26,7 @@ const (
 	namespace         = "namespace"
 	kernelLabel       = "kernel-label"
 	devicePluginImage = "device-plugin-image"
+        fullModulesPath = "/lib/modules/"
 )
 
 var (
@@ -143,7 +144,6 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			imageRepoSecretName = "image-repo-secret"
 			serviceAccountName  = "driver-service-account"
 		)
-		fullModulesPath := "/lib/modules/" + kernelVersion
 		mod := kmmv1beta1.Module{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: kmmv1beta1.GroupVersion.String(),


### PR DESCRIPTION
Mounting nodeLibModulesPath as '/lib/modules/'+ kernelVersion
makes GKE fail when Module loader is run, as it tries to mount 
host '/lib/modules' at '/opt/lib/modules/<kernelVersion>+'
which results in depmod error not finding directory.
```
INFO[1403] Running: [/bin/sh -c depmod -b /opt]         
depmod: ERROR: could not open directory /opt/lib/modules/5.10.133+: No such file or directory
depmod: FATAL: could not search modules: No such file or directory
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
```