### PR TITLE
Add the kernel - ClusterClaim reconciler

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,6 +27,20 @@ rules:
   - watch
 - apiGroups:
   - cluster.open-cluster-management.io
+  resourceNames:
+  - kernel-versions.kmm.node.kubernetes.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
   resources:
   - managedclusters
   verbs:

--- a/controllers/node_kernel_clusterclaim.go
+++ b/controllers/node_kernel_clusterclaim.go
@@ -1,0 +1,112 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"open-cluster-management.io/api/cluster/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=create;delete;get;list;patch;update;watch
+
+const clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
+
+type NodeKernelClusterClaimReconciler struct {
+	client client.Client
+}
+
+func NewNodeKernelClusterClaimReconciler(client client.Client) *NodeKernelClusterClaimReconciler {
+	return &NodeKernelClusterClaimReconciler{client: client}
+}
+
+func (r *NodeKernelClusterClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	nodeList := v1.NodeList{}
+
+	logger.Info("Listing all nodes")
+
+	if err := r.client.List(ctx, &nodeList); err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not list nodes: %v", err)
+	}
+
+	kernelsMap := make(map[string]struct{})
+
+	for _, n := range nodeList.Items {
+		kernelsMap[n.Status.NodeInfo.KernelVersion] = struct{}{}
+	}
+
+	// The map's order is unpredictable; we do not want to update the ClusterClaim if the value only
+	// changed because of a different order in the kernel versions.
+	// Copy the kernels into a slice and sort it alphabetically.
+	kernelsSlice := make([]string, 0, len(kernelsMap))
+
+	for k := range kernelsMap {
+		kernelsSlice = append(kernelsSlice, k)
+	}
+
+	sort.Strings(kernelsSlice)
+
+	cc := v1alpha1.ClusterClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterClaimName},
+	}
+
+	logger.Info("Creating or patching ClusterClaim")
+
+	opRes, err := controllerutil.CreateOrPatch(ctx, r.client, &cc, func() error {
+		cc.Spec = v1alpha1.ClusterClaimSpec{
+			Value: strings.Join(kernelsSlice, "\n"),
+		}
+
+		return nil
+	})
+
+	logger.Info("Reconciled ClusterClaim", "res", opRes)
+
+	return ctrl.Result{}, err
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeKernelClusterClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.
+		NewControllerManagedBy(mgr).
+		Named("node-kernel-clusterclaim").
+		// Each time a Node's .status.nodeInfo.kernelVersion is updated, enqueue a reconciliation request
+		For(
+			&v1.Node{},
+			builder.WithPredicates(
+				filter.NodeUpdateKernelChangedPredicate(),
+			),
+		).
+		// Each time our ClusterClaim is updated, enqueue an empty reconciliation request.
+		// We list all nodes during reconciliation, so sending an empty request is OK.
+		Watches(
+			&source.Kind{
+				Type: &v1alpha1.ClusterClaim{},
+			},
+			handler.EnqueueRequestsFromMapFunc(func(_ client.Object) []reconcile.Request {
+				return []reconcile.Request{{}}
+			}),
+			builder.WithPredicates(
+				predicate.NewPredicateFuncs(func(object client.Object) bool {
+					return object.GetName() == clusterClaimName
+				}),
+			),
+		).
+		Complete(r)
+}

--- a/controllers/node_kernel_clusterclaim_test.go
+++ b/controllers/node_kernel_clusterclaim_test.go
@@ -1,0 +1,91 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"open-cluster-management.io/api/cluster/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("NodeKernelClusterClaimReconciler_Reconcile", func() {
+	var (
+		gCtrl      *gomock.Controller
+		kubeClient *client.MockClient
+	)
+
+	BeforeEach(func() {
+		gCtrl = gomock.NewController(GinkgoT())
+		kubeClient = client.NewMockClient(gCtrl)
+	})
+
+	It("should work as expected", func() {
+		const ccName = "kernel-versions.kmm.node.kubernetes.io"
+
+		ctx := context.Background()
+
+		cc := v1alpha1.ClusterClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: ccName},
+		}
+
+		initialCC := cc.DeepCopy()
+
+		cc.Spec.Value = "a1\na2\nb"
+
+		gomock.InOrder(
+			kubeClient.
+				EXPECT().
+				List(ctx, &v1.NodeList{}).
+				Do(func(_ context.Context, nl *v1.NodeList, _ ...metav1.ListOptions) {
+					nl.Items = []v1.Node{
+						{
+							Status: v1.NodeStatus{
+								NodeInfo: v1.NodeSystemInfo{KernelVersion: "b"},
+							},
+						},
+						{
+							Status: v1.NodeStatus{
+								NodeInfo: v1.NodeSystemInfo{KernelVersion: "a1"},
+							},
+						},
+						{
+							Status: v1.NodeStatus{
+								NodeInfo: v1.NodeSystemInfo{KernelVersion: "a2"},
+							},
+						},
+						{
+							Status: v1.NodeStatus{
+								NodeInfo: v1.NodeSystemInfo{KernelVersion: "b"},
+							},
+						},
+						{
+							Status: v1.NodeStatus{
+								NodeInfo: v1.NodeSystemInfo{KernelVersion: "a1"},
+							},
+						},
+					}
+				}),
+			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: ccName}, initialCC),
+			kubeClient.
+				EXPECT().
+				Patch(ctx, &cc, gomock.AssignableToTypeOf(ctrlclient.MergeFrom(initialCC))).
+				Do(func(_ context.Context, obj *v1alpha1.ClusterClaim, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) {
+					Expect(
+						p.Data(&cc),
+					).To(
+						Equal([]byte(`{"spec":{"value":"a1\na2\nb"}}`)),
+					)
+				}),
+		)
+
+		_, err := NewNodeKernelClusterClaimReconciler(kubeClient).Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -54,6 +54,24 @@ func (f *Filter) NodeKernelReconcilerPredicate(labelName string) predicate.Predi
 	return predicate.And(skipDeletions, labelMismatch)
 }
 
+func NodeUpdateKernelChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
+			oldNode, ok := updateEvent.ObjectOld.(*v1.Node)
+			if !ok {
+				return false
+			}
+
+			newNode, ok := updateEvent.ObjectNew.(*v1.Node)
+			if !ok {
+				return false
+			}
+
+			return oldNode.Status.NodeInfo.KernelVersion != newNode.Status.NodeInfo.KernelVersion
+		},
+	}
+}
+
 func (f *Filter) FindModulesForNode(node client.Object) []reconcile.Request {
 	logger := f.logger.WithValues("node", node.GetName())
 

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -230,6 +230,38 @@ var _ = Describe("NodeKernelReconcilerPredicate", func() {
 	})
 })
 
+var _ = Describe("NodeUpdateKernelChangedPredicate", func() {
+	updateFunc := NodeUpdateKernelChangedPredicate().Update
+
+	node1 := v1.Node{
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{KernelVersion: "v1"},
+		},
+	}
+
+	node2 := v1.Node{
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{KernelVersion: "v2"},
+		},
+	}
+
+	DescribeTable(
+		"should work as expected",
+		func(updateEvent event.UpdateEvent, expectedResult bool) {
+			Expect(
+				updateFunc(updateEvent),
+			).To(
+				Equal(expectedResult),
+			)
+		},
+		Entry(nil, event.UpdateEvent{ObjectOld: &v1.Pod{}, ObjectNew: &v1.Node{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &v1.Node{}, ObjectNew: &v1.Pod{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &v1.Node{}, ObjectNew: &v1.Pod{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &node1, ObjectNew: &node1}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &node1, ObjectNew: &node2}, true),
+	)
+})
+
 var _ = Describe("FindModulesForNode", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())


### PR DESCRIPTION
This reconciler collects all kernel versions running in the cluster and populates a ClusterClaim with them.
To minimize updates to the ClusterClaim (which triggers a sync back to the ManagedCluster), kernel versions are sorted alphabetically and separated by a new line.
This controller is not started by any manager yet because we still have to determine if we add it to the mainline KMM or if we create a dedicated image for Spoke clusters.

/cc @mresvanis @yevgeny-shnaidman @ybettan