### PR TITLE
Decouple build and sign from ModuleReconciler

### DIFF
--- a/internal/build/helper_test.go
+++ b/internal/build/helper_test.go
@@ -31,7 +31,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			},
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res).To(Equal(km.Build))
 	})
 
@@ -51,7 +51,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			Build: nil,
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res).To(Equal(mod.Spec.ModuleLoader.Container.Build))
 	})
 
@@ -77,7 +77,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			},
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res.DockerfileConfigMap).To(Equal(km.Build.DockerfileConfigMap))
 		Expect(res.BaseImageRegistryTLS).To(Equal(mod.Spec.ModuleLoader.Container.Build.BaseImageRegistryTLS))
 	})

--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	"github.com/mitchellh/hashstructure"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,13 +14,28 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+)
+
+const (
+	dockerfileVolumeName = "dockerfile"
 )
 
 //go:generate mockgen -source=maker.go -package=job -destination=mock_maker.go
 
 type Maker interface {
-	MakeJobTemplate(ctx context.Context, mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel,
-		containerImage string, pushImage bool, registryTLS *kmmv1beta1.TLSOptions) (*batchv1.Job, error)
+	MakeJobTemplate(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		km kmmv1beta1.KernelMapping,
+		targetKernel string,
+		owner metav1.Object,
+		pushImage bool) (*batchv1.Job, error)
 }
 
 type maker struct {
@@ -39,7 +50,11 @@ type hashData struct {
 	PodTemplate *v1.PodTemplateSpec
 }
 
-func NewMaker(client client.Client, helper build.Helper, jobHelper utils.JobHelper, scheme *runtime.Scheme) Maker {
+func NewMaker(
+	client client.Client,
+	helper build.Helper,
+	jobHelper utils.JobHelper,
+	scheme *runtime.Scheme) Maker {
 	return &maker{
 		client:    client,
 		helper:    helper,
@@ -48,8 +63,93 @@ func NewMaker(client client.Client, helper build.Helper, jobHelper utils.JobHelp
 	}
 }
 
-func (m *maker) MakeJobTemplate(ctx context.Context, mod kmmv1beta1.Module, buildConfig *kmmv1beta1.Build, targetKernel,
-	containerImage string, pushImage bool, registryTLS *kmmv1beta1.TLSOptions) (*batchv1.Job, error) {
+func (m *maker) MakeJobTemplate(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	km kmmv1beta1.KernelMapping,
+	targetKernel string,
+	owner metav1.Object,
+	pushImage bool) (*batchv1.Job, error) {
+
+	buildConfig := m.helper.GetRelevantBuild(mod.Spec, km)
+
+	containerImage := km.ContainerImage
+
+	// if build AND sign are specified, then we will build an intermediate image
+	// and let sign produce the one specified in its targetImage
+	if module.ShouldBeSigned(mod.Spec, km) {
+		containerImage = module.IntermediateImageName(mod.Name, mod.Namespace, containerImage)
+	}
+
+	specTemplate := m.specTemplate(
+		mod.Spec,
+		buildConfig,
+		targetKernel,
+		containerImage,
+		km.RegistryTLS,
+		pushImage)
+
+	specTemplateHash, err := m.getHashAnnotationValue(ctx, buildConfig.DockerfileConfigMap.Name, mod.Namespace, &specTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("could not hash job's definitions: %v", err)
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: mod.Name + "-build-",
+			Namespace:    mod.Namespace,
+			Labels:       m.jobHelper.JobLabels(mod.Name, targetKernel, utils.JobTypeBuild),
+			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
+		},
+		Spec: batchv1.JobSpec{
+			Completions: pointer.Int32(1),
+			Template:    specTemplate,
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(owner, job, m.scheme); err != nil {
+		return nil, fmt.Errorf("could not set the owner reference: %v", err)
+	}
+
+	return job, nil
+}
+
+func (m *maker) specTemplate(
+	modSpec kmmv1beta1.ModuleSpec,
+	buildConfig *kmmv1beta1.Build,
+	targetKernel string,
+	containerImage string,
+	registryTLS *kmmv1beta1.TLSOptions,
+	pushImage bool) v1.PodTemplateSpec {
+
+	kanikoImageTag := "latest"
+	if buildConfig.KanikoParams != nil && buildConfig.KanikoParams.Tag != "" {
+		kanikoImageTag = buildConfig.KanikoParams.Tag
+	}
+
+	return v1.PodTemplateSpec{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Args:         m.containerArgs(buildConfig, targetKernel, containerImage, registryTLS, pushImage),
+					Name:         "kaniko",
+					Image:        "gcr.io/kaniko-project/executor:" + kanikoImageTag,
+					VolumeMounts: volumeMounts(modSpec, buildConfig),
+				},
+			},
+			NodeSelector:  modSpec.Selector,
+			RestartPolicy: v1.RestartPolicyOnFailure,
+			Volumes:       volumes(modSpec, buildConfig),
+		},
+	}
+}
+
+func (m *maker) containerArgs(
+	buildConfig *kmmv1beta1.Build,
+	targetKernel string,
+	containerImage string,
+	registryTLS *kmmv1beta1.TLSOptions,
+	pushImage bool) []string {
 
 	args := []string{}
 	if pushImage {
@@ -85,13 +185,47 @@ func (m *maker) MakeJobTemplate(ctx context.Context, mod kmmv1beta1.Module, buil
 		}
 	}
 
-	const dockerfileVolumeName = "dockerfile"
+	return args
+}
 
-	dockerFileVolume := v1.Volume{
-		Name: dockerfileVolumeName,
+func (m *maker) getHashAnnotationValue(ctx context.Context, configMapName, namespace string, podTemplate *v1.PodTemplateSpec) (uint64, error) {
+	dockerfileCM := &corev1.ConfigMap{}
+	namespacedName := types.NamespacedName{Name: configMapName, Namespace: namespace}
+	if err := m.client.Get(ctx, namespacedName, dockerfileCM); err != nil {
+		return 0, fmt.Errorf("failed to get dockerfile ConfigMap %s: %v", namespacedName, err)
+	}
+	data, ok := dockerfileCM.Data[constants.DockerfileCMKey]
+	if !ok {
+		return 0, fmt.Errorf("invalid Dockerfile ConfigMap %s format, %s key is missing", namespacedName, constants.DockerfileCMKey)
+	}
+
+	return getHashValue(podTemplate, data)
+}
+
+func volumes(modSpec kmmv1beta1.ModuleSpec, buildConfig *kmmv1beta1.Build) []v1.Volume {
+	volumes := []v1.Volume{dockerfileVolume(dockerfileVolumeName, buildConfig.DockerfileConfigMap)}
+	if irs := modSpec.ImageRepoSecret; irs != nil {
+		volumes = append(volumes, makeImagePullSecretVolume(irs))
+	}
+	volumes = append(volumes, makeBuildSecretVolumes(buildConfig.Secrets)...)
+	return volumes
+}
+
+func volumeMounts(modSpec kmmv1beta1.ModuleSpec, buildConfig *kmmv1beta1.Build) []v1.VolumeMount {
+	volumeMounts := []v1.VolumeMount{dockerfileVolumeMount(dockerfileVolumeName)}
+	if irs := modSpec.ImageRepoSecret; irs != nil {
+		volumeMounts = append(volumeMounts, makeImagePullSecretVolumeMount(irs))
+	}
+	volumeMounts = append(volumeMounts, makeBuildSecretVolumeMounts(buildConfig.Secrets)...)
+	return volumeMounts
+}
+
+func dockerfileVolume(name string, dockerfileConfigMap *v1.LocalObjectReference) v1.Volume {
+	return v1.Volume{
+		Name: name,
 		VolumeSource: v1.VolumeSource{
 			ConfigMap: &v1.ConfigMapVolumeSource{
-				LocalObjectReference: *buildConfig.DockerfileConfigMap,
+				LocalObjectReference: *dockerfileConfigMap,
 				Items: []v1.KeyToPath{
 					{
 						Key:  constants.DockerfileCMKey,
@@ -101,80 +235,14 @@ func (m *maker) MakeJobTemplate(ctx context.Context, mod kmmv1beta1.Module, buil
 			},
 		},
 	}
+}
 
-	dockerFileVolumeMount := v1.VolumeMount{
-		Name:      dockerfileVolumeName,
+func dockerfileVolumeMount(name string) v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      name,
 		ReadOnly:  true,
 		MountPath: "/workspace",
 	}
-
-	volumes := []v1.Volume{dockerFileVolume}
-	volumeMounts := []v1.VolumeMount{dockerFileVolumeMount}
-	if irs := mod.Spec.ImageRepoSecret; irs != nil {
-		volumes = append(volumes, makeImagePullSecretVolume(irs))
-		volumeMounts = append(volumeMounts, makeImagePullSecretVolumeMount(irs))
-	}
-	volumes = append(volumes, makeBuildSecretVolumes(buildConfig.Secrets)...)
-	volumeMounts = append(volumeMounts, makeBuildSecretVolumeMounts(buildConfig.Secrets)...)
-
-	kanikoImageTag := "latest"
-	if buildConfig.KanikoParams != nil && buildConfig.KanikoParams.Tag != "" {
-		kanikoImageTag = buildConfig.KanikoParams.Tag
-	}
-
-	specTemplate := v1.PodTemplateSpec{
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Args:         args,
-					Name:         "kaniko",
-					Image:        "gcr.io/kaniko-project/executor:" + kanikoImageTag,
-					VolumeMounts: volumeMounts,
-				},
-			},
-			NodeSelector:  mod.Spec.Selector,
-			RestartPolicy: v1.RestartPolicyOnFailure,
-			Volumes:       volumes,
-		},
-	}
-	specTemplateHash, err := m.getHashAnnotationValue(ctx, buildConfig, mod.Namespace, &specTemplate)
-	if err != nil {
-		return nil, fmt.Errorf("could not hash job's definitions: %v", err)
-	}
-
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: mod.Name + "-build-",
-			Namespace:    mod.Namespace,
-			Labels:       m.jobHelper.JobLabels(mod, targetKernel, utils.JobTypeBuild),
-			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
-		},
-		Spec: batchv1.JobSpec{
-			Completions: pointer.Int32(1),
-			Template:    specTemplate,
-		},
-	}
-
-	if err := controllerutil.SetControllerReference(&mod, job, m.scheme); err != nil {
-		return nil, fmt.Errorf("could not set the owner reference: %v", err)
-	}
-
-	return job, nil
-}
-
-func (m *maker) getHashAnnotationValue(ctx context.Context, buildConfig *kmmv1beta1.Build, namespace string, podTemplate *v1.PodTemplateSpec) (uint64, error) {
-	dockerfileCM := &corev1.ConfigMap{}
-	namespacedName := types.NamespacedName{Name: buildConfig.DockerfileConfigMap.Name, Namespace: namespace}
-	err := m.client.Get(ctx, namespacedName, dockerfileCM)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get dockerfile ConfigMap %s: %v", namespacedName, err)
-	}
-	data, ok := dockerfileCM.Data[constants.DockerfileCMKey]
-	if !ok {
-		return 0, fmt.Errorf("invalid Dockerfile ConfigMap %s format, %s key is missing", namespacedName, constants.DockerfileCMKey)
-	}
-
-	return getHashValue(podTemplate, data)
 }
 
 func getHashValue(podTemplate *v1.PodTemplateSpec, dockerfile string) (uint64, error) {
@@ -190,7 +258,6 @@ func getHashValue(podTemplate *v1.PodTemplateSpec, dockerfile string) (uint64, e
 }
 
 func makeImagePullSecretVolume(secretRef *v1.LocalObjectReference) v1.Volume {
-
 	if secretRef == nil {
 		return v1.Volume{}
 	}
@@ -212,7 +279,6 @@ func makeImagePullSecretVolume(secretRef *v1.LocalObjectReference) v1.Volume {
 }
 
 func makeImagePullSecretVolumeMount(secretRef *v1.LocalObjectReference) v1.VolumeMount {
-
 	if secretRef == nil {
 		return v1.VolumeMount{}
 	}
@@ -225,7 +291,6 @@ func makeImagePullSecretVolumeMount(secretRef *v1.LocalObjectReference) v1.Volum
 }
 
 func makeBuildSecretVolumes(secretRefs []v1.LocalObjectReference) []v1.Volume {
-
 	volumes := make([]v1.Volume, 0, len(secretRefs))
 
 	for _, secretRef := range secretRefs {
@@ -245,7 +310,6 @@ func makeBuildSecretVolumes(secretRefs []v1.LocalObjectReference) []v1.Volume {
 }
 
 func makeBuildSecretVolumeMounts(secretRefs []v1.LocalObjectReference) []v1.VolumeMount {
-
 	secretVolumeMounts := make([]v1.VolumeMount, 0, len(secretRefs))
 
 	for _, secretRef := range secretRefs {

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -5,33 +5,41 @@ import (
 	"errors"
 	"fmt"
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
 type jobManager struct {
 	client    client.Client
 	maker     Maker
-	helper    build.Helper
 	jobHelper utils.JobHelper
+	registry  registry.Registry
 }
 
-func NewBuildManager(client client.Client, maker Maker, helper build.Helper, jobHelper utils.JobHelper) *jobManager {
+func NewBuildManager(
+	client client.Client,
+	maker Maker,
+	jobHelper utils.JobHelper,
+	registry registry.Registry) *jobManager {
 	return &jobManager{
 		client:    client,
 		maker:     maker,
-		helper:    helper,
 		jobHelper: jobHelper,
+		registry:  registry,
 	}
 }
 
-func (jbm *jobManager) GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error) {
-	jobs, err := jbm.jobHelper.GetModuleJobs(ctx, mod, utils.JobTypeBuild)
+func (jbm *jobManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
+	jobs, err := jbm.jobHelper.GetModuleJobs(ctx, modName, namespace, utils.JobTypeBuild)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get build jobs for module %s: %v", mod.Name, err)
+		return nil, fmt.Errorf("failed to get build jobs for module %s: %v", modName, err)
 	}
 
 	deleteNames := make([]string, 0, len(jobs))
@@ -47,19 +55,53 @@ func (jbm *jobManager) GarbageCollect(ctx context.Context, mod kmmv1beta1.Module
 	return deleteNames, nil
 }
 
-func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (build.Result, error) {
+func (jbm *jobManager) ShouldSync(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	m kmmv1beta1.KernelMapping) (bool, error) {
+
+	// if there is no build specified skip
+	if !module.ShouldBeBuilt(mod.Spec, m) {
+		return false, nil
+	}
+
+	targetImage := m.ContainerImage
+
+	// if build AND sign are specified, then we will build an intermediate image
+	// and let sign produce the one specified in targetImage
+	if module.ShouldBeSigned(mod.Spec, m) {
+		targetImage = module.IntermediateImageName(mod.Name, mod.Namespace, targetImage)
+	}
+
+	// build is specified and targetImage is either the final image or the intermediate image
+	// tag, depending on whether sign is specified or not. Either way, if targetImage exists
+	// we can skip building it
+	exists, err := module.ImageExists(ctx, jbm.client, jbm.registry, mod.Spec, mod.Namespace, m, targetImage)
+	if err != nil {
+		return false, fmt.Errorf("failed to check existence of image %s: %w", targetImage, err)
+	}
+
+	return !exists, nil
+}
+
+func (jbm *jobManager) Sync(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	m kmmv1beta1.KernelMapping,
+	targetKernel string,
+	pushImage bool,
+	owner metav1.Object) (build.Result, error) {
+
 	logger := log.FromContext(ctx)
 
 	logger.Info("Building in-cluster")
 
-	buildConfig := jbm.helper.GetRelevantBuild(mod, m)
-
-	jobTemplate, err := jbm.maker.MakeJobTemplate(ctx, mod, buildConfig, targetKernel, targetImage, pushImage, m.RegistryTLS)
+	jobTemplate, err := jbm.maker.MakeJobTemplate(ctx, mod, m, targetKernel, owner, pushImage)
 	if err != nil {
 		return build.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod, targetKernel, utils.JobTypeBuild)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeBuild)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return build.Result{}, fmt.Errorf("error getting the build: %v", err)

--- a/internal/build/job/mock_maker.go
+++ b/internal/build/job/mock_maker.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/batch/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockMaker is a mock of Maker interface.
@@ -37,16 +38,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockMaker) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool, registryTLS *v1beta1.TLSOptions) (*v1.Job, error) {
+func (m *MockMaker) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, owner v10.Object, pushImage bool) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, buildConfig, targetKernel, containerImage, pushImage, registryTLS)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, owner, pushImage)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockMakerMockRecorder) MakeJobTemplate(ctx, mod, buildConfig, targetKernel, containerImage, pushImage, registryTLS interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, owner, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), ctx, mod, buildConfig, targetKernel, containerImage, pushImage, registryTLS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, owner, pushImage)
 }

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -3,6 +3,8 @@ package build
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 )
 
@@ -22,6 +24,18 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (Result, error)
-	GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error)
+
+	ShouldSync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping) (bool, error)
+
+	Sync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping,
+		targetKernel string,
+		pushImage bool,
+		owner metav1.Object) (Result, error)
 }

--- a/internal/build/mock_helper.go
+++ b/internal/build/mock_helper.go
@@ -54,15 +54,15 @@ func (mr *MockHelperMockRecorder) ApplyBuildArgOverrides(args interface{}, overr
 }
 
 // GetRelevantBuild mocks base method.
-func (m *MockHelper) GetRelevantBuild(mod v1beta1.Module, km v1beta1.KernelMapping) *v1beta1.Build {
+func (m *MockHelper) GetRelevantBuild(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Build {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantBuild", mod, km)
+	ret := m.ctrl.Call(m, "GetRelevantBuild", modSpec, km)
 	ret0, _ := ret[0].(*v1beta1.Build)
 	return ret0
 }
 
 // GetRelevantBuild indicates an expected call of GetRelevantBuild.
-func (mr *MockHelperMockRecorder) GetRelevantBuild(mod, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantBuild(modSpec, km interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantBuild", reflect.TypeOf((*MockHelper)(nil).GetRelevantBuild), mod, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantBuild", reflect.TypeOf((*MockHelper)(nil).GetRelevantBuild), modSpec, km)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockManager is a mock of Manager interface.
@@ -36,31 +37,46 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, mod v1beta1.Module) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, mod interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace)
+}
+
+// ShouldSync mocks base method.
+func (m_2 *MockManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldSync indicates an expected call of ShouldSync.
+func (mr *MockManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mod, m)
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage, owner)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage, owner)
 }

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -1,12 +1,74 @@
 package module
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/auth"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
 )
 
-func GetRelevantTLSOptions(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) *kmmv1beta1.TLSOptions {
+func TLSOptions(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.TLSOptions {
 	if km.RegistryTLS != nil {
 		return km.RegistryTLS
 	}
-	return mod.Spec.ModuleLoader.Container.RegistryTLS
+	return modSpec.ModuleLoader.Container.RegistryTLS
+}
+
+// AppendToTag adds the specified tag to the image name cleanly, i.e. by avoiding messing up
+// the name or getting "name:-tag"
+func AppendToTag(name string, tag string) string {
+	separator := ":"
+	if strings.Contains(name, ":") {
+		separator = "_"
+	}
+	return name + separator + tag
+}
+
+// IntermediateImageName returns the image name of the pre-signed module image name
+func IntermediateImageName(name, namespace, targetImage string) string {
+	return AppendToTag(targetImage, namespace+"_"+name+"_kmm_unsigned")
+}
+
+// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// Module should be built or not.
+func ShouldBeBuilt(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
+	return modSpec.ModuleLoader.Container.Build != nil || km.Build != nil
+}
+
+// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// Module should be signed or not.
+func ShouldBeSigned(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
+	return modSpec.ModuleLoader.Container.Sign != nil || km.Sign != nil
+}
+
+func ImageExists(
+	ctx context.Context,
+	client client.Client,
+	reg registry.Registry,
+	modSpec kmmv1beta1.ModuleSpec,
+	namespace string,
+	km kmmv1beta1.KernelMapping,
+	imageName string) (bool, error) {
+
+	var registryAuthGetter auth.RegistryAuthGetter
+	if modSpec.ImageRepoSecret != nil {
+		registryAuthGetter = auth.NewRegistryAuthGetter(client, types.NamespacedName{
+			Name:      modSpec.ImageRepoSecret.Name,
+			Namespace: namespace,
+		})
+	}
+
+	tlsOptions := TLSOptions(modSpec, km)
+	exists, err := reg.ImageExists(ctx, imageName, tlsOptions, registryAuthGetter)
+	if err != nil {
+		return false, fmt.Errorf("could not check if the image is available: %v", err)
+	}
+
+	return exists, nil
 }

--- a/internal/module/helper_test.go
+++ b/internal/module/helper_test.go
@@ -1,0 +1,294 @@
+package module
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
+)
+
+var _ = Describe("TLSOptions", func() {
+	It("should return the KernelMapping's TLSOptions if it's defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			RegistryTLS: &kmmv1beta1.TLSOptions{},
+		}
+
+		Expect(
+			TLSOptions(mod.Spec, km),
+		).To(
+			Equal(km.RegistryTLS),
+		)
+	})
+
+	It("should return the Module's TLSOptions if the KernelMapping's TLSOptions is not defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						RegistryTLS: &kmmv1beta1.TLSOptions{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			TLSOptions(mod.Spec, km),
+		).To(
+			Equal(mod.Spec.ModuleLoader.Container.RegistryTLS),
+		)
+	})
+})
+
+var _ = Describe("AppendToTag", func() {
+	It("should append a tag to the image name", func() {
+		name := "some-container-image-name"
+		tag := "a-kmm-tag"
+
+		Expect(
+			AppendToTag(name, tag),
+		).To(
+			Equal(name + ":" + tag),
+		)
+	})
+
+	It("should add a suffix to the already present tag", func() {
+		name := "some-container-image-name:with-a-tag"
+		tag := "a-kmm-tag-suffix"
+
+		Expect(
+			AppendToTag(name, tag),
+		).To(
+			Equal(name + "_" + tag),
+		)
+	})
+})
+
+var _ = Describe("IntermediateImageName", func() {
+	It("should add the kmm_unsigned suffix to the target image name", func() {
+		Expect(
+			IntermediateImageName("module-name", "test-namespace", "some-image-name"),
+		).To(
+			Equal("some-image-name:test-namespace_module-name_kmm_unsigned"),
+		)
+	})
+})
+
+var _ = Describe("ShouldBeBuilt", func() {
+	It("should return true if the Module's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Build: &kmmv1beta1.Build{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true if the KernelMapping's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Build: &kmmv1beta1.Build{},
+		}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return false if neither the Module's nor the KernelMapping's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeFalse(),
+		)
+	})
+})
+
+var _ = Describe("ShouldBeSigned", func() {
+	It("should return true if the Module's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Sign: &kmmv1beta1.Sign{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true if the KernelMapping's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Sign: &kmmv1beta1.Sign{},
+		}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return false if neither the Module's nor the KernelMapping's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeFalse(),
+		)
+	})
+})
+
+var _ = Describe("ImageExists", func() {
+	const (
+		imageName = "image-name"
+		namespace = "test"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+
+		mockRegistry *registry.MockRegistry
+
+		mod kmmv1beta1.Module
+		km  kmmv1beta1.KernelMapping
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+
+		mockRegistry = registry.NewMockRegistry(ctrl)
+
+		mod = kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+
+		km = kmmv1beta1.KernelMapping{}
+
+		ctx = context.Background()
+	})
+
+	It("should return true if the image exists", func() {
+		gomock.InOrder(
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(true, nil),
+		)
+
+		exists, err := ImageExists(ctx, clnt, mockRegistry, mod.Spec, namespace, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+
+	It("should return false if the image does not exist", func() {
+		gomock.InOrder(
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(false, nil),
+		)
+
+		exists, err := ImageExists(ctx, clnt, mockRegistry, mod.Spec, namespace, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should return an error if the registry call fails", func() {
+		gomock.InOrder(
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(false, errors.New("some-error")),
+		)
+
+		exists, err := ImageExists(ctx, clnt, mockRegistry, mod.Spec, namespace, km, imageName)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("some-error"))
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should use the ImageRepoSecret if one is specified", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{
+					Name: "secret",
+				},
+			},
+		}
+
+		gomock.InOrder(
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, gomock.Not(gomock.Nil())).Return(false, nil),
+		)
+
+		exists, err := ImageExists(ctx, clnt, mockRegistry, mod.Spec, namespace, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+})

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -106,7 +106,7 @@ func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.K
 	moduleFileName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName + ".ko"
 	baseDir := mod.Spec.ModuleLoader.Container.Modprobe.DirName
 
-	tlsOptions := module.GetRelevantTLSOptions(mod, mapping)
+	tlsOptions := module.TLSOptions(mod.Spec, *mapping)
 	registryAuthGetter := auth.NewRegistryAuthGetterFrom(p.client, mod)
 	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, tlsOptions, registryAuthGetter)
 	if err != nil {
@@ -137,7 +137,7 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 	mapping *kmmv1beta1.KernelMapping,
 	mod *kmmv1beta1.Module) (bool, string) {
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, mapping.ContainerImage, pv.Spec.PushBuiltImage)
+	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -296,33 +296,36 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	It("sync failed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{}, fmt.Errorf("some error"))
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{}, fmt.Errorf("some error"))
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
-
 	})
 
 	It("sync completed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{Status: build.StatusCompleted}, nil)
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{Status: build.StatusCompleted}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
 		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")))
-
 	})
 
 	It("sync not completed yet", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, mapping.ContainerImage, false).Return(build.Result{Status: build.StatusInProgress}, nil)
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{Status: build.StatusInProgress}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal("Waiting for build verification"))
-
 	})
 })

--- a/internal/sign/helper.go
+++ b/internal/sign/helper.go
@@ -7,7 +7,7 @@ import (
 //go:generate mockgen -source=helper.go -package=sign -destination=mock_helper.go
 
 type Helper interface {
-	GetRelevantSign(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign
+	GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign
 }
 
 type helper struct{}
@@ -16,18 +16,17 @@ func NewSignerHelper() Helper {
 	return &helper{}
 }
 
-func (m *helper) GetRelevantSign(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign {
-
-	if mod.Spec.ModuleLoader.Container.Sign == nil {
+func (m *helper) GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign {
+	if modSpec.ModuleLoader.Container.Sign == nil {
 		// km.Sign cannot be nil in case mod.Sign is nil, checked above
 		return km.Sign.DeepCopy()
 	}
 
 	if km.Sign == nil {
-		return mod.Spec.ModuleLoader.Container.Sign.DeepCopy()
+		return modSpec.ModuleLoader.Container.Sign.DeepCopy()
 	}
 
-	signConfig := mod.Spec.ModuleLoader.Container.Sign.DeepCopy()
+	signConfig := modSpec.ModuleLoader.Container.Sign.DeepCopy()
 
 	if km.Sign.UnsignedImage != "" {
 		signConfig.UnsignedImage = km.Sign.UnsignedImage

--- a/internal/sign/helper_test.go
+++ b/internal/sign/helper_test.go
@@ -1,12 +1,13 @@
 package sign
 
 import (
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 var _ = Describe("GetRelevantSign", func() {
@@ -35,7 +36,7 @@ var _ = Describe("GetRelevantSign", func() {
 
 	DescribeTable("should set fields correctly", func(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) {
 
-		actual := h.GetRelevantSign(mod, km)
+		actual := h.GetRelevantSign(mod.Spec, km)
 		Expect(
 			cmp.Diff(expected, actual),
 		).To(

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/batch/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockSigner is a mock of Signer interface.
@@ -36,16 +37,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, signConfig *v1beta1.Sign, targetKernel, imageToSign, targetImage string, labels map[string]string, pushImage bool) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -3,10 +3,26 @@ package sign
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
+//go:generate mockgen -source=manager.go -package=sign -destination=mock_manager.go
+
 type SignManager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, imageToSign string, targetImage string, pushImage bool) (utils.Result, error)
+	ShouldSync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping) (bool, error)
+
+	Sync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping,
+		targetKernel string,
+		imageToSign string,
+		pushImage bool,
+		owner metav1.Object) (utils.Result, error)
 }

--- a/internal/sign/mock_helper.go
+++ b/internal/sign/mock_helper.go
@@ -35,15 +35,15 @@ func (m *MockHelper) EXPECT() *MockHelperMockRecorder {
 }
 
 // GetRelevantSign mocks base method.
-func (m *MockHelper) GetRelevantSign(mod v1beta1.Module, km v1beta1.KernelMapping) *v1beta1.Sign {
+func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Sign {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantSign", mod, km)
+	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km)
 	ret0, _ := ret[0].(*v1beta1.Sign)
 	return ret0
 }
 
 // GetRelevantSign indicates an expected call of GetRelevantSign.
-func (mr *MockHelperMockRecorder) GetRelevantSign(mod, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), mod, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km)
 }

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -10,7 +10,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	jobHelper "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+	utils "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockSignManager is a mock of SignManager interface.
@@ -36,17 +37,32 @@ func (m *MockSignManager) EXPECT() *MockSignManagerMockRecorder {
 	return m.recorder
 }
 
-// Sync mocks base method.
-func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign, targetImage string, pushImage bool) (jobHelper.Result, error) {
+// ShouldSync mocks base method.
+func (m_2 *MockSignManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage)
-	ret0, _ := ret[0].(jobHelper.Result)
+	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldSync indicates an expected call of ShouldSync.
+func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mod, m)
+}
+
+// Sync mocks base method.
+func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Result, error) {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+	ret0, _ := ret[0].(utils.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
 }

--- a/internal/utils/jobhelper_test.go
+++ b/internal/utils/jobhelper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,7 @@ var _ = Describe("JobLabels", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "moduleName"},
 		}
 		mgr := NewJobHelper(clnt)
-		labels := mgr.JobLabels(mod, "targetKernel", "jobType")
+		labels := mgr.JobLabels(mod.Name, "targetKernel", "jobType")
 
 		Expect(labels).To(HaveKeyWithValue(constants.ModuleNameLabel, "moduleName"))
 		Expect(labels).To(HaveKeyWithValue(constants.TargetKernelTarget, "targetKernel"))
@@ -79,7 +80,7 @@ var _ = Describe("GetModuleJobByKernel", func() {
 			},
 		)
 
-		job, err := jh.GetModuleJobByKernel(ctx, mod, "targetKernel", "jobType")
+		job, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
 
 		Expect(job).To(Equal(&j))
 		Expect(err).NotTo(HaveOccurred())
@@ -105,7 +106,7 @@ var _ = Describe("GetModuleJobByKernel", func() {
 
 		clnt.EXPECT().List(ctx, &jobList, opts).Return(errors.New("random error"))
 
-		_, err := jh.GetModuleJobByKernel(ctx, mod, "targetKernel", "jobType")
+		_, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
 
 		Expect(err).To(HaveOccurred())
 	})
@@ -135,7 +136,7 @@ var _ = Describe("GetModuleJobByKernel", func() {
 			},
 		)
 
-		_, err := jh.GetModuleJobByKernel(ctx, mod, "targetKernel", "jobType")
+		_, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
 
 		Expect(err).To(HaveOccurred())
 	})
@@ -178,7 +179,7 @@ var _ = Describe("GetModuleJobs", func() {
 			},
 		)
 
-		jobs, err := jh.GetModuleJobs(ctx, mod, "jobType")
+		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(jobs)).To(Equal(2))
@@ -203,7 +204,7 @@ var _ = Describe("GetModuleJobs", func() {
 
 		clnt.EXPECT().List(ctx, gomock.Any(), opts).Return(fmt.Errorf("some error"))
 
-		_, err := jh.GetModuleJobs(ctx, mod, "jobType")
+		_, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
 
 		Expect(err).To(HaveOccurred())
 	})
@@ -232,7 +233,7 @@ var _ = Describe("GetModuleJobs", func() {
 			},
 		)
 
-		jobs, err := jh.GetModuleJobs(ctx, mod, "jobType")
+		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(jobs)).To(Equal(0))

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/batch/v1"
 )
 
@@ -81,33 +80,33 @@ func (mr *MockJobHelperMockRecorder) GetJobStatus(job interface{}) *gomock.Call 
 }
 
 // GetModuleJobByKernel mocks base method.
-func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, mod v1beta1.Module, targetKernel, jobType string) (*v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, mod, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobByKernel indicates an expected call of GetModuleJobByKernel.
-func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, mod, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, mod, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType)
 }
 
 // GetModuleJobs mocks base method.
-func (m *MockJobHelper) GetModuleJobs(ctx context.Context, mod v1beta1.Module, jobType string) ([]v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, mod, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType)
 	ret0, _ := ret[0].([]v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobs indicates an expected call of GetModuleJobs.
-func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, mod, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, mod, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType)
 }
 
 // IsJobChanged mocks base method.
@@ -126,15 +125,15 @@ func (mr *MockJobHelperMockRecorder) IsJobChanged(existingJob, newJob interface{
 }
 
 // JobLabels mocks base method.
-func (m *MockJobHelper) JobLabels(mod v1beta1.Module, targetKernel, jobType string) map[string]string {
+func (m *MockJobHelper) JobLabels(modName, targetKernel, jobType string) map[string]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobLabels", mod, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "JobLabels", modName, targetKernel, jobType)
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
 // JobLabels indicates an expected call of JobLabels.
-func (mr *MockJobHelperMockRecorder) JobLabels(mod, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) JobLabels(modName, targetKernel, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobLabels", reflect.TypeOf((*MockJobHelper)(nil).JobLabels), mod, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobLabels", reflect.TypeOf((*MockJobHelper)(nil).JobLabels), modName, targetKernel, jobType)
 }


### PR DESCRIPTION
This PR decouples the `build` and `sign` internal APIs from the `ModuleReconciler`, in order to be able to use them in other reconcilers as well, i.e. the `ManagedClusterModuleReconciler`.