### PR TITLE
Moving Build Dockerfile to be defined in the ConfigMap

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -365,6 +365,9 @@ jobs:
         run: kubectl get all -n kube-system
         if: ${{ failure() }}
 
+      - name: Add a configmap that contain the kernel module build dockerfile
+        run: kubectl apply -f ci/kmm-kmod-dockerfile.yaml
+
       - name: Add an kmm-ci Module that contains a valid mapping
         run: |
           sed -e "s/KVER_CHANGEME/$(uname -r)/g" ci/module-kmm-ci-build.template.yaml | tee module-kmm-ci.yaml
@@ -374,7 +377,7 @@ jobs:
       - name: Wait for the job to be created
         run: |
           until kubectl get job -l kmm.node.kubernetes.io/module.name | grep kmm; do
-            sleep 3
+            sleep 1
           done
         timeout-minutes: 1
 

--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -60,7 +60,8 @@ type Build struct {
 	// BuildArgs is an array of build variables that are provided to the image building backend.
 	BuildArgs []BuildArg `json:"buildArgs"`
 
-	Dockerfile string `json:"dockerfile"`
+	// ConfigMap that holds Dockerfile contents
+	DockerfileConfigMap *v1.LocalObjectReference `json:"dockerfileConfigMap"`
 
 	// +optional
 	// Pull contains settings determining how to pull the base images of the build process.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -34,6 +34,11 @@ func (in *Build) DeepCopyInto(out *Build) {
 		*out = make([]BuildArg, len(*in))
 		copy(*out, *in)
 	}
+	if in.DockerfileConfigMap != nil {
+		in, out := &in.DockerfileConfigMap, &out.DockerfileConfigMap
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	out.Pull = in.Pull
 	out.Push = in.Push
 	if in.Secrets != nil {

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kmm-kmod-dockerfile
+data:
+  dockerfile: |
+    FROM registry.minikube/kmm-base:local
+
+    ARG CI_BUILD_ARG
+    ARG KERNEL_VERSION
+    ARG WITH_DEFAULT_VALUE=default-value
+
+    RUN cat /run/secrets/build-secret/ci-build-secret > /ci-build-secret
+    RUN echo $CI_BUILD_ARG > /build-arg
+    RUN echo $KERNEL_VERSION > /kernel-version
+    RUN echo $WITH_DEFAULT_VALUE > /default-value

--- a/ci/module-kmm-ci-build.template.yaml
+++ b/ci/module-kmm-ci-build.template.yaml
@@ -23,18 +23,9 @@ spec:
               insecure: true
             secrets:
               - name: build-secret
-            dockerfile: |
-              FROM registry.minikube/kmm-base:local
-
-              ARG CI_BUILD_ARG
-              ARG KERNEL_VERSION
-              ARG WITH_DEFAULT_VALUE=default-value
-
-              RUN cat /run/secrets/build-secret/ci-build-secret > /ci-build-secret
-              RUN echo $CI_BUILD_ARG > /build-arg
-              RUN echo $KERNEL_VERSION > /kernel-version
-              RUN echo $WITH_DEFAULT_VALUE > /default-value
-
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+            
             # Optional. If kanikoParams.tag is empty, the default value will be: 'latest'
             kanikoParams:
               tag: "debug"

--- a/config/crd/bases/kmm.sigs.k8s.io_managedclustermodules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_managedclustermodules.yaml
@@ -1974,8 +1974,17 @@ spec:
                                   - value
                                   type: object
                                 type: array
-                              dockerfile:
-                                type: string
+                              dockerfileConfigMap:
+                                description: ConfigMap that holds Dockerfile contents
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
                               kanikoParams:
                                 description: KanikoParams is used to customize the
                                   building process of the image.
@@ -2034,7 +2043,7 @@ spec:
                                   x-kubernetes-map-type: atomic
                                 type: array
                             required:
-                            - dockerfile
+                            - dockerfileConfigMap
                             type: object
                           containerImage:
                             description: ContainerImage is a top-level field
@@ -2078,8 +2087,18 @@ spec:
                                         - value
                                         type: object
                                       type: array
-                                    dockerfile:
-                                      type: string
+                                    dockerfileConfigMap:
+                                      description: ConfigMap that holds Dockerfile
+                                        contents
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
                                     kanikoParams:
                                       description: KanikoParams is used to customize
                                         the building process of the image.
@@ -2141,7 +2160,7 @@ spec:
                                         x-kubernetes-map-type: atomic
                                       type: array
                                   required:
-                                  - dockerfile
+                                  - dockerfileConfigMap
                                   type: object
                                 containerImage:
                                   description: ContainerImage is the name of the DriverContainer

--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -1890,8 +1890,16 @@ spec:
                               - value
                               type: object
                             type: array
-                          dockerfile:
-                            type: string
+                          dockerfileConfigMap:
+                            description: ConfigMap that holds Dockerfile contents
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
                           kanikoParams:
                             description: KanikoParams is used to customize the building
                               process of the image.
@@ -1947,7 +1955,7 @@ spec:
                               x-kubernetes-map-type: atomic
                             type: array
                         required:
-                        - dockerfile
+                        - dockerfileConfigMap
                         type: object
                       containerImage:
                         description: ContainerImage is a top-level field
@@ -1988,8 +1996,17 @@ spec:
                                     - value
                                     type: object
                                   type: array
-                                dockerfile:
-                                  type: string
+                                dockerfileConfigMap:
+                                  description: ConfigMap that holds Dockerfile contents
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
                                 kanikoParams:
                                   description: KanikoParams is used to customize the
                                     building process of the image.
@@ -2049,7 +2066,7 @@ spec:
                                     x-kubernetes-map-type: atomic
                                   type: array
                               required:
-                              - dockerfile
+                              - dockerfileConfigMap
                               type: object
                             containerImage:
                               description: ContainerImage is the name of the DriverContainer

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -95,6 +95,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list
 //+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;list;watch;delete
 

--- a/internal/build/helper.go
+++ b/internal/build/helper.go
@@ -47,7 +47,6 @@ func (m *helper) ApplyBuildArgOverrides(args []v1beta1.BuildArg, overrides ...v1
 
 func (m *helper) GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build {
 	if mod.Spec.ModuleLoader.Container.Build == nil {
-		// km.Build cannot be nil in case mod.Build is nil, checked above
 		return km.Build.DeepCopy()
 	}
 
@@ -56,9 +55,7 @@ func (m *helper) GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMap
 	}
 
 	buildConfig := mod.Spec.ModuleLoader.Container.Build.DeepCopy()
-	if km.Build.Dockerfile != "" {
-		buildConfig.Dockerfile = km.Build.Dockerfile
-	}
+	buildConfig.DockerfileConfigMap = km.Build.DockerfileConfigMap
 
 	buildConfig.BuildArgs = m.ApplyBuildArgOverrides(buildConfig.BuildArgs, km.Build.BuildArgs...)
 

--- a/internal/build/helper_test.go
+++ b/internal/build/helper_test.go
@@ -1,0 +1,134 @@
+package build
+
+import (
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("GetRelevantBuild", func() {
+
+	var nh Helper
+
+	BeforeEach(func() {
+		nh = NewHelper()
+	})
+
+	It("kernel mapping build present, module loader build absent", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Build: nil,
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Build: &kmmv1beta1.Build{
+				DockerfileConfigMap: &v1.LocalObjectReference{Name: "some kernel mapping build name"},
+			},
+		}
+
+		res := nh.GetRelevantBuild(mod, km)
+		Expect(res).To(Equal(km.Build))
+	})
+
+	It("kernel mapping build absent, module loader build present", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Build: &kmmv1beta1.Build{
+							DockerfileConfigMap: &v1.LocalObjectReference{Name: "some load module build name"},
+						},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Build: nil,
+		}
+
+		res := nh.GetRelevantBuild(mod, km)
+		Expect(res).To(Equal(mod.Spec.ModuleLoader.Container.Build))
+	})
+
+	It("kernel mapping and module loader builds are present, overrides", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Build: &kmmv1beta1.Build{
+							DockerfileConfigMap: &v1.LocalObjectReference{Name: "some load module build name"},
+							Pull: kmmv1beta1.PullOptions{
+								Insecure:              true,
+								InsecureSkipTLSVerify: true,
+							},
+						},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Build: &kmmv1beta1.Build{
+				DockerfileConfigMap: &v1.LocalObjectReference{Name: "some kernel mapping build name"},
+			},
+		}
+
+		res := nh.GetRelevantBuild(mod, km)
+		Expect(res.DockerfileConfigMap).To(Equal(km.Build.DockerfileConfigMap))
+		Expect(res.Pull).To(Equal(mod.Spec.ModuleLoader.Container.Build.Pull))
+	})
+})
+
+var _ = Describe("ApplyBuildArgOverrides", func() {
+
+	var nh Helper
+
+	BeforeEach(func() {
+		nh = NewHelper()
+	})
+
+	It("apply overrides", func() {
+		args := []kmmv1beta1.BuildArg{
+			{
+				Name:  "name1",
+				Value: "value1",
+			},
+			{
+				Name:  "name2",
+				Value: "value2",
+			},
+		}
+		overrides := []kmmv1beta1.BuildArg{
+			{
+				Name:  "name1",
+				Value: "valueOverride1",
+			},
+			{
+				Name:  "overrideName2",
+				Value: "overrideValue2",
+			},
+		}
+
+		expected := []kmmv1beta1.BuildArg{
+			{
+				Name:  "name1",
+				Value: "valueOverride1",
+			},
+			{
+				Name:  "name2",
+				Value: "value2",
+			},
+			{
+				Name:  "overrideName2",
+				Value: "overrideValue2",
+			},
+		}
+
+		res := nh.ApplyBuildArgOverrides(args, overrides...)
+		Expect(res).To(Equal(expected))
+	})
+})

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -54,7 +54,7 @@ func (jbm *jobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1b
 
 	buildConfig := jbm.helper.GetRelevantBuild(mod, m)
 
-	jobTemplate, err := jbm.maker.MakeJobTemplate(mod, buildConfig, targetKernel, targetImage, pushImage)
+	jobTemplate, err := jbm.maker.MakeJobTemplate(ctx, mod, buildConfig, targetKernel, targetImage, pushImage)
 	if err != nil {
 		return build.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Sync", func() {
 
 			gomock.InOrder(
 				helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-				maker.EXPECT().MakeJobTemplate(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeBuild).Return(&j, nil),
 				jobhelper.EXPECT().IsJobChanged(&j, &j).Return(false, nil),
 			)
@@ -97,7 +97,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-			maker.EXPECT().MakeJobTemplate(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(nil, errors.New("random error")),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km.Build, kernelVersion, km.ContainerImage, true).Return(nil, errors.New("random error")),
 		)
 
 		mgr := NewBuildManager(clnt, maker, helper, jobhelper)
@@ -124,7 +124,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-			maker.EXPECT().MakeJobTemplate(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeBuild).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("some error")),
 		)
@@ -154,7 +154,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-			maker.EXPECT().MakeJobTemplate(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&j, nil),
 			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeBuild).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 		)
@@ -197,7 +197,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantBuild(mod, km).Return(km.Build),
-			maker.EXPECT().MakeJobTemplate(mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&newJob, nil),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km.Build, kernelVersion, km.ContainerImage, true).Return(&newJob, nil),
 			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeBuild).Return(&j, nil),
 			jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(true, nil),
 			jobhelper.EXPECT().DeleteJob(ctx, &j).Return(nil),

--- a/internal/build/job/mock_maker.go
+++ b/internal/build/job/mock_maker.go
@@ -5,6 +5,7 @@
 package job
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,16 +37,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockMaker) MakeJobTemplate(mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool) (*v1.Job, error) {
+func (m *MockMaker) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, buildConfig *v1beta1.Build, targetKernel, containerImage string, pushImage bool) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, buildConfig, targetKernel, containerImage, pushImage)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, buildConfig, targetKernel, containerImage, pushImage)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockMakerMockRecorder) MakeJobTemplate(mod, buildConfig, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeJobTemplate(ctx, mod, buildConfig, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), mod, buildConfig, targetKernel, containerImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), ctx, mod, buildConfig, targetKernel, containerImage, pushImage)
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,4 +9,5 @@ const (
 	JobHashAnnotation    = "kmm.node.kubernetes.io/last-hash"
 
 	ManagedClusterModuleNameLabel = "kmm.node.kubernetes.io/managedclustermodule.name"
+	DockerfileCMKey               = "dockerfile"
 )

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -100,7 +100,7 @@ var _ = Describe("PrepareKernelMapping", func() {
 					{Name: "name1", Value: "value1"},
 					{Name: "kernel version", Value: "${KERNEL_FULL_VERSION}"},
 				},
-				Dockerfile: dockerfile,
+				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
 		}
 		expectMapping := kmmv1beta1.KernelMapping{
@@ -112,7 +112,7 @@ var _ = Describe("PrepareKernelMapping", func() {
 					{Name: "name1", Value: "value1"},
 					{Name: "kernel version", Value: "${KERNEL_FULL_VERSION}"},
 				},
-				Dockerfile: dockerfile,
+				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
 		}
 

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 	registryAPI := registry.NewRegistry()
 	helperAPI := build.NewHelper()
 	jobHelperAPI := utils.NewJobHelper(client)
-	makerAPI := job.NewMaker(helperAPI, jobHelperAPI, scheme)
+	makerAPI := job.NewMaker(client, helperAPI, jobHelperAPI, scheme)
 	buildAPI := job.NewBuildManager(client, makerAPI, helperAPI, jobHelperAPI)
 
 	signAPI := signjob.NewSignJobManager(


### PR DESCRIPTION
Currently dockerfile is defined a multiline string in the Build field of the KernelMapping. This PR does the following: 1) dockerfile is now defined in a dedicated configmap (created by customer)
   with the key being: dockerfile
2) Build struct now contains reference to the ConfigMap, instead of
   a string
3) change the flow of e2e workflow for the in-cluster build
   to use the new configuration