### PR TITLE
Fixing a bug in the 'sign' UT.

### DIFF
--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -1,6 +1,8 @@
 package signjob
 
 import (
+	"strings"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -11,7 +13,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	"strings"
 )
 
 var _ = Describe("MakeJobTemplate", func() {
@@ -29,11 +30,18 @@ var _ = Describe("MakeJobTemplate", func() {
 	var (
 		ctrl *gomock.Controller
 		m    Signer
+		mod  kmmv1beta1.Module
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		m = NewSigner(scheme)
+		mod = kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -45,12 +53,6 @@ var _ = Describe("MakeJobTemplate", func() {
 		"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 	}
 
-	mod := kmmv1beta1.Module{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      moduleName,
-			Namespace: namespace,
-		},
-	}
 	DescribeTable("should set fields correctly", func(imagePullSecret *v1.LocalObjectReference) {
 		nodeSelector := map[string]string{"arch": "x64"}
 
@@ -215,7 +217,6 @@ var _ = Describe("MakeJobTemplate", func() {
 		actual, err := m.MakeJobTemplate(mod, signConfig, kernelVersion, "", signedImage, labels, pushFlag)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-unsignedimage"))
-		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-pullsecret"))
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-key"))
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-cert"))
 		if pushFlag {


### PR DESCRIPTION
The code is using the same global module object for all tests, which means that if one of the specs change the module, it affects all other tests.

Each spec should be tested with a clean module.

How did it impact the code before the change:

Running
```
make unit-test TEST=github.com/kubernetes-sigs/kernel-module-management/internal/sign/job
```
was working only because all the tests were running one after the other, once we focused on the `should set correct kmod-signer flags` spec only it was failing because it was expecting some state which was modified by another spec that run before it.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>