### PR TITLE
Build signer images in CI

### DIFF
--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,24 +1,29 @@
-FROM registry.fedoraproject.org/fedora as ksource
-RUN yum install -y kernel-devel
+FROM alpine:3.16 as ksource
+RUN apk add linux-virt-dev
 
-FROM golang:1.19 as builder
+FROM golang:1.19-alpine3.16 as builder
 
 WORKDIR /workspace
+
+# Download dependencies
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+RUN apk add bash make
 
 COPY cmd cmd
 COPY api api
 COPY internal internal
 COPY Makefile Makefile
 COPY docs.mk docs.mk
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN go mod download
+
 # Build
 RUN make signimage
 
-FROM registry.fedoraproject.org/fedora
+FROM alpine:3.16
 
-COPY --from=builder /workspace/cmd/signimage/signimage /
-COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /sign-file
+COPY --from=builder /workspace/signimage /
+COPY --from=ksource /usr/src/linux-headers-*-virt/scripts/sign-file /sign-file
 
 ENTRYPOINT ["/signimage"]

--- a/Makefile
+++ b/Makefile
@@ -265,11 +265,11 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 .PHONY: signimage
-signimage: ## Build manager binary.
-	go build -o cmd/signimage/signimage cmd/signimage/signimage.go
+signimage: ## Build signer binary.
+	go build -o $@ cmd/signimage/signimage.go
 
 .PHONY: signimage-build 
-signimage-build: ## Build docker image with the manager.
+signimage-build: ## Build docker image with the signer.
 	$(PODMAN) build -f Dockerfile.signimage -t $(SIGNER_IMG)
 
 include docs.mk

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,6 +5,13 @@ steps:
     - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator:$_GIT_TAG
     - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator:latest
     - .
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/kernel-module-management-signimage:$_GIT_TAG
+      - --tag=gcr.io/$PROJECT_ID/kernel-module-management-signimage:latest
+      - --file=Dockerfile.signimage
+      - .
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:
@@ -12,3 +19,5 @@ options:
 images:
   - gcr.io/$PROJECT_ID/kernel-module-management-operator:$_GIT_TAG
   - gcr.io/$PROJECT_ID/kernel-module-management-operator:latest
+  - gcr.io/$PROJECT_ID/kernel-module-management-signimage:$_GIT_TAG
+  - gcr.io/$PROJECT_ID/kernel-module-management-signimage:latest


### PR DESCRIPTION
Use alpine base images for a smaller footprint (46 vs 209MB).
Rework the Dockerfile for better caching.

/cc @chr15p