### PR TITLE
Fix check-api-changes script

### DIFF
--- a/ci/prow/check-api-changes
+++ b/ci/prow/check-api-changes
@@ -2,11 +2,11 @@
 
 set -euxo pipefail
 
-make generate manifests
+make generate manifests bundle
 
 
 if [[ $(git diff) ]]; then
-   echo 'Please run `make generate manifests` and repush'
+   echo 'Please run `make generate manifests bundle` and repush'
    echo 'The following differences were found:'
    echo $(git diff)
    exit 1


### PR DESCRIPTION
Change the use of make generate manifests for make generate manifests bundle so
 we make sure we push both targets in the PRs.