### PR TITLE
Fix module reconciler not being able to watch for ConfigMaps error

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -54,6 +54,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -90,7 +90,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list
+//+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;list;watch;delete
 


### PR DESCRIPTION
This fix adds the `watch` permission for `ConfigMap`s to the `Module` reconciler, in order to be able to successfully `client.Get()` the build Dockerfile `ConfigMap`. This `client.Get()` fails because the contoller-runtime client reads from its cache, instead of directly from the API server. The client needs the `watch` permission, in order to be able to build its cache.

- https://github.com/kubernetes-sigs/controller-runtime/issues/1156

Signed-off-by: Michail Resvanis <mresvani@redhat.com>