### PR TITLE
Build/Sign job selection should be done based on owner field also

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -403,7 +403,7 @@ func (r *ModuleReconciler) garbageCollect(ctx context.Context,
 	logger.Info("Garbage-collected DaemonSets", "names", deleted)
 
 	// Garbage collect for successfully finished build jobs
-	deleted, err = r.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace)
+	deleted, err = r.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect build objects: %v", err)
 	}

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -143,7 +143,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -198,7 +198,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -263,7 +263,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -362,7 +362,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -474,7 +474,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 					d.SetLabels(map[string]string{"test": "test"})
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -554,7 +554,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, nil).Return(nil),
 		)
 

--- a/internal/build/job/manager.go
+++ b/internal/build/job/manager.go
@@ -36,8 +36,8 @@ func NewBuildManager(
 	}
 }
 
-func (jbm *jobManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
-	jobs, err := jbm.jobHelper.GetModuleJobs(ctx, modName, namespace, utils.JobTypeBuild)
+func (jbm *jobManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
+	jobs, err := jbm.jobHelper.GetModuleJobs(ctx, modName, namespace, utils.JobTypeBuild, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get build jobs for module %s: %v", modName, err)
 	}
@@ -101,7 +101,7 @@ func (jbm *jobManager) Sync(
 		return build.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeBuild)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeBuild, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return build.Result{}, fmt.Errorf("error getting the build: %v", err)

--- a/internal/build/job/manager_test.go
+++ b/internal/build/job/manager_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Sync", func() {
 
 			gomock.InOrder(
 				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, &mod, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild, &mod).Return(&j, nil),
 				jobhelper.EXPECT().IsJobChanged(&j, &j).Return(false, nil),
 			)
 
@@ -247,7 +247,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, &mod, true).Return(&j, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild, &mod).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("some error")),
 		)
 
@@ -276,7 +276,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, &mod, true).Return(&j, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild, &mod).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 		)
 
@@ -318,7 +318,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, &mod, true).Return(&newJob, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeBuild, &mod).Return(&j, nil),
 			jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(true, nil),
 			jobhelper.EXPECT().DeleteJob(ctx, &j).Return(nil),
 		)
@@ -384,7 +384,7 @@ var _ = Describe("GarbageCollect", func() {
 				returnedError = nil
 			}
 
-			jobhelper.EXPECT().GetModuleJobs(context.Background(), mod.Name, mod.Namespace, utils.JobTypeBuild).Return([]batchv1.Job{job1, job2}, returnedError)
+			jobhelper.EXPECT().GetModuleJobs(context.Background(), mod.Name, mod.Namespace, utils.JobTypeBuild, &mod).Return([]batchv1.Job{job1, job2}, returnedError)
 			if !expectsErr {
 				if job1.Status.Succeeded == 1 {
 					jobhelper.EXPECT().DeleteJob(context.Background(), &job1).Return(nil)
@@ -394,7 +394,7 @@ var _ = Describe("GarbageCollect", func() {
 				}
 			}
 
-			names, err := mgr.GarbageCollect(context.Background(), mod.Name, mod.Namespace)
+			names, err := mgr.GarbageCollect(context.Background(), mod.Name, mod.Namespace, &mod)
 
 			if expectsErr {
 				Expect(err).To(HaveOccurred())

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -24,7 +24,7 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
 	ShouldSync(
 		ctx context.Context,

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -37,18 +37,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace, owner)
 }
 
 // ShouldSync mocks base method.

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -73,7 +73,7 @@ func (jbm *signJobManager) Sync(
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -214,7 +214,7 @@ var _ = Describe("JobManager", func() {
 				gomock.InOrder(
 					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 					maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
 				)
@@ -270,7 +270,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, errors.New("random error")),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
 			)
 
 			mgr := NewSignJobManager(nil, maker, jobhelper, nil)
@@ -298,7 +298,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
@@ -328,7 +328,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 
@@ -359,7 +359,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
 			)

--- a/internal/utils/jobhelper_test.go
+++ b/internal/utils/jobhelper_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
@@ -60,7 +61,12 @@ var _ = Describe("GetModuleJobByKernel", func() {
 		mod := kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace"},
 		}
-		j := batchv1.Job{}
+		j := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob", Namespace: "moduleNamespace"},
+		}
+
+		err := controllerutil.SetControllerReference(&mod, &j, scheme)
+		Expect(err).NotTo(HaveOccurred())
 
 		labels := map[string]string{
 			constants.ModuleNameLabel:    "moduleName",
@@ -80,7 +86,7 @@ var _ = Describe("GetModuleJobByKernel", func() {
 			},
 		)
 
-		job, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
+		job, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType", &mod)
 
 		Expect(job).To(Equal(&j))
 		Expect(err).NotTo(HaveOccurred())
@@ -106,7 +112,7 @@ var _ = Describe("GetModuleJobByKernel", func() {
 
 		clnt.EXPECT().List(ctx, &jobList, opts).Return(errors.New("random error"))
 
-		_, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
+		_, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType", &mod)
 
 		Expect(err).To(HaveOccurred())
 	})
@@ -117,6 +123,18 @@ var _ = Describe("GetModuleJobByKernel", func() {
 		mod := kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace"},
 		}
+
+		j1 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob1", Namespace: "moduleNamespace"},
+		}
+		j2 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob2", Namespace: "moduleNamespace"},
+		}
+
+		err := controllerutil.SetControllerReference(&mod, &j1, scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = controllerutil.SetControllerReference(&mod, &j2, scheme)
+		Expect(err).NotTo(HaveOccurred())
 
 		labels := map[string]string{
 			constants.ModuleNameLabel:    "moduleName",
@@ -131,14 +149,62 @@ var _ = Describe("GetModuleJobByKernel", func() {
 
 		clnt.EXPECT().List(ctx, gomock.Any(), opts).DoAndReturn(
 			func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
-				list.Items = []batchv1.Job{batchv1.Job{}, batchv1.Job{}}
+				list.Items = []batchv1.Job{j1, j2}
 				return nil
 			},
 		)
 
-		_, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType")
+		_, err = jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType", &mod)
 
 		Expect(err).To(HaveOccurred())
+	})
+	It("more then 1 job exists, but only one is owned by the module", func() {
+		ctx := context.Background()
+
+		mod := kmmv1beta1.Module{
+			TypeMeta:   metav1.TypeMeta{Kind: "some kind", APIVersion: "some version"},
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace", UID: "some uuid"},
+		}
+
+		anotherMod := kmmv1beta1.Module{
+			TypeMeta:   metav1.TypeMeta{Kind: "some kind", APIVersion: "some version"},
+			ObjectMeta: metav1.ObjectMeta{Name: "anotherModuleName", Namespace: "moduleNamespace", UID: "another uuid"},
+		}
+
+		j1 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob1", Namespace: "moduleNamespace"},
+		}
+		j2 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob2", Namespace: "moduleNamespace"},
+		}
+
+		err := controllerutil.SetControllerReference(&mod, &j1, scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = controllerutil.SetControllerReference(&anotherMod, &j2, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		labels := map[string]string{
+			constants.ModuleNameLabel:    "moduleName",
+			constants.TargetKernelTarget: "targetKernel",
+			constants.JobType:            "jobType",
+		}
+
+		opts := []sigclient.ListOption{
+			sigclient.MatchingLabels(labels),
+			sigclient.InNamespace("moduleNamespace"),
+		}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), opts).DoAndReturn(
+			func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
+				list.Items = []batchv1.Job{j1, j2}
+				return nil
+			},
+		)
+
+		job, err := jh.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "jobType", &mod)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(job).To(Equal(&j1))
 	})
 })
 
@@ -162,6 +228,17 @@ var _ = Describe("GetModuleJobs", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace"},
 		}
 
+		j1 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob1", Namespace: "moduleNamespace"},
+		}
+		j2 := batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleJob12", Namespace: "moduleNamespace"},
+		}
+		err := controllerutil.SetControllerReference(&mod, &j1, scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = controllerutil.SetControllerReference(&mod, &j2, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
 		labels := map[string]string{
 			constants.ModuleNameLabel: "moduleName",
 			constants.JobType:         "jobType",
@@ -174,12 +251,12 @@ var _ = Describe("GetModuleJobs", func() {
 
 		clnt.EXPECT().List(ctx, gomock.Any(), opts).DoAndReturn(
 			func(_ interface{}, list *batchv1.JobList, _ ...interface{}) error {
-				list.Items = []batchv1.Job{batchv1.Job{}, batchv1.Job{}}
+				list.Items = []batchv1.Job{j1, j2}
 				return nil
 			},
 		)
 
-		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
+		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType", &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(jobs)).To(Equal(2))
@@ -204,7 +281,7 @@ var _ = Describe("GetModuleJobs", func() {
 
 		clnt.EXPECT().List(ctx, gomock.Any(), opts).Return(fmt.Errorf("some error"))
 
-		_, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
+		_, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType", &mod)
 
 		Expect(err).To(HaveOccurred())
 	})
@@ -233,7 +310,7 @@ var _ = Describe("GetModuleJobs", func() {
 			},
 		)
 
-		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType")
+		jobs, err := jh.GetModuleJobs(ctx, mod.Name, mod.Namespace, "jobType", &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(jobs)).To(Equal(0))

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/batch/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockJobHelper is a mock of JobHelper interface.
@@ -80,33 +81,33 @@ func (mr *MockJobHelperMockRecorder) GetJobStatus(job interface{}) *gomock.Call 
 }
 
 // GetModuleJobByKernel mocks base method.
-func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobByKernel indicates an expected call of GetModuleJobByKernel.
-func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType, owner)
 }
 
 // GetModuleJobs mocks base method.
-func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string, owner v10.Object) ([]v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType, owner)
 	ret0, _ := ret[0].([]v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobs indicates an expected call of GetModuleJobs.
-func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType, owner)
 }
 
 // IsJobChanged mocks base method.


### PR DESCRIPTION
Currently, our code queries for jobs in 2 scenarious: 1) check if there is a running kaniko build/sign job for specific module/kernel 2) get all the job of the module during garbage collection scenario

With introduction of preflight flow we need to deferentiate the jobs also by owner, since preflight flow also uses and garbage collects build/sign jobs