### PR TITLE
Fixing sign job hash annotation

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,4 +10,6 @@ const (
 
 	ManagedClusterModuleNameLabel = "kmm.node.kubernetes.io/managedclustermodule.name"
 	DockerfileCMKey               = "dockerfile"
+	PublicSignDataKey             = "cert"
+	PrivateSignDataKey            = "key"
 )

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -68,7 +68,7 @@ func (jbm *signJobManager) Sync(
 
 	labels := jbm.jobHelper.JobLabels(mod.Name, targetKernel, "sign")
 
-	jobTemplate, err := jbm.signer.MakeJobTemplate(mod, m, targetKernel, labels, imageToSign, pushImage, owner)
+	jobTemplate, err := jbm.signer.MakeJobTemplate(ctx, mod, m, targetKernel, labels, imageToSign, pushImage, owner)
 	if err != nil {
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -213,7 +213,7 @@ var _ = Describe("JobManager", func() {
 
 				gomock.InOrder(
 					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-					maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+					maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
@@ -241,7 +241,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).
 					Return(nil, errors.New("random error")),
 			)
 
@@ -269,7 +269,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
 			)
 
@@ -297,7 +297,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
@@ -327,7 +327,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
@@ -358,7 +358,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -5,6 +5,7 @@
 package signjob
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -37,16 +38,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -1,6 +1,8 @@
 package signjob
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,9 +13,12 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -28,10 +33,13 @@ var _ = Describe("MakeJobTemplate", func() {
 		kernelVersion = "1.2.3"
 		moduleName    = "module-name"
 		namespace     = "some-namespace"
+		privateKey    = "some private key"
+		publicKey     = "some public key"
 	)
 
 	var (
 		ctrl      *gomock.Controller
+		clnt      *client.MockClient
 		m         Signer
 		mod       kmmv1beta1.Module
 		helper    *sign.MockHelper
@@ -40,9 +48,10 @@ var _ = Describe("MakeJobTemplate", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
 		helper = sign.NewMockHelper(ctrl)
 		jobhelper = utils.NewMockJobHelper(ctrl)
-		m = NewSigner(scheme, helper, jobhelper)
+		m = NewSigner(clnt, scheme, helper, jobhelper)
 		mod = kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      moduleName,
@@ -60,7 +69,11 @@ var _ = Describe("MakeJobTemplate", func() {
 		"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 	}
 
+	publicSignData := map[string][]byte{constants.PublicSignDataKey: []byte(publicKey)}
+	privateSignData := map[string][]byte{constants.PrivateSignDataKey: []byte(privateKey)}
+
 	DescribeTable("should set fields correctly", func(imagePullSecret *v1.LocalObjectReference) {
+		ctx := context.Background()
 		nodeSelector := map[string]string{"arch": "x64"}
 
 		km := kmmv1beta1.KernelMapping{
@@ -190,14 +203,31 @@ var _ = Describe("MakeJobTemplate", func() {
 				)
 		}
 
+		hash, err := getHashValue(&expected.Spec.Template, []byte(publicKey), []byte(privateKey))
+		Expect(err).NotTo(HaveOccurred())
+		annotations := map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", hash)}
+		expected.SetAnnotations(annotations)
+
 		mod := mod.DeepCopy()
 		mod.Spec.Selector = nodeSelector
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = privateSignData
+					return nil
+				},
+			),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = publicSignData
+					return nil
+				},
+			),
 		)
 
-		actual, err := m.MakeJobTemplate(*mod, km, kernelVersion, labels, unsignedImage, true, mod)
+		actual, err := m.MakeJobTemplate(ctx, *mod, km, kernelVersion, labels, unsignedImage, true, mod)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(
@@ -217,7 +247,7 @@ var _ = Describe("MakeJobTemplate", func() {
 	)
 
 	DescribeTable("should set correct kmod-signer flags", func(filelist []string, pushImage bool) {
-
+		ctx := context.Background()
 		km := kmmv1beta1.KernelMapping{
 			Sign: &kmmv1beta1.Sign{
 				UnsignedImage: signedImage,
@@ -230,9 +260,21 @@ var _ = Describe("MakeJobTemplate", func() {
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = privateSignData
+					return nil
+				},
+			),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = publicSignData
+					return nil
+				},
+			),
 		)
 
-		actual, err := m.MakeJobTemplate(mod, km, kernelVersion, labels, "", pushImage, &mod)
+		actual, err := m.MakeJobTemplate(ctx, mod, km, kernelVersion, labels, "", pushImage, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-unsignedimage"))
@@ -270,20 +312,34 @@ var _ = Describe("MakeJobTemplate", func() {
 
 	DescribeTable("should set correct kmod-signer TLS flags", func(kmRegistryTLS,
 		unsignedImageRegistryTLS kmmv1beta1.TLSOptions, expectedFlag string) {
-
+		ctx := context.Background()
 		km := kmmv1beta1.KernelMapping{
 			RegistryTLS: &kmRegistryTLS,
 			Sign: &kmmv1beta1.Sign{
 				UnsignedImage:            signedImage,
 				UnsignedImageRegistryTLS: unsignedImageRegistryTLS,
+				KeySecret:                &v1.LocalObjectReference{Name: "securebootkey"},
+				CertSecret:               &v1.LocalObjectReference{Name: "securebootcert"},
 			},
 		}
 
 		gomock.InOrder(
 			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = privateSignData
+					return nil
+				},
+			),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
+					secret.Data = publicSignData
+					return nil
+				},
+			),
 		)
 
-		actual, err := m.MakeJobTemplate(mod, km, kernelVersion, labels, "", true, &mod)
+		actual, err := m.MakeJobTemplate(ctx, mod, km, kernelVersion, labels, "", true, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement(expectedFlag))

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 	signHelperAPI := sign.NewSignerHelper()
 	signAPI := signjob.NewSignJobManager(
 		client,
-		signjob.NewSigner(scheme, signHelperAPI, jobHelperAPI),
+		signjob.NewSigner(client, scheme, signHelperAPI, jobHelperAPI),
 		utils.NewJobHelper(client),
 		registryAPI,
 	)


### PR DESCRIPTION
Sign job annotation is used for deciding whether update flow should be executed on the job ( deletion and creation anew with new parameters). Currently the code includes verification of currently running job hash versus the new parameters hash, but the actual code that sets the hash annotation during job template is missing. This PR does the following:
1) add hash annotation calculation during job template creation 2) unit test