### PR TITLE
Adding sign verification to the preflight flow

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -25,6 +25,7 @@ const (
 	VerificationFalse         string = "False"
 	VerificationStageImage    string = "Image"
 	VerificationStageBuild    string = "Build"
+	VerificationStageSign     string = "Sign"
 	VerificationStageRequeued string = "Requeued"
 	VerificationStageDone     string = "Done"
 )
@@ -60,7 +61,7 @@ type CRStatus struct {
 	// image (image existence verification), build(build process verification)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build;Requeued;Done
+	// +kubebuilder:validation:Enum=Image;Build;Sign;Requeued;Done
 	VerificationStage string `json:"verificationStage"`
 
 	// LastTransitionTime is the last time the CR status transitioned from one status to another.

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -76,6 +76,7 @@ spec:
                       enum:
                       - Image
                       - Build
+                      - Sign
                       - Requeued
                       - Done
                       type: string

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -41,7 +41,7 @@ func ShouldBeBuilt(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) b
 	return modSpec.ModuleLoader.Container.Build != nil || km.Build != nil
 }
 
-// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// ShouldBeSigned indicates whether the specified KernelMapping of the
 // Module should be signed or not.
 func ShouldBeSigned(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
 	return modSpec.ModuleLoader.Container.Sign != nil || km.Sign != nil

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -102,3 +102,18 @@ func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, ker
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
 }
+
+// verifySign mocks base method.
+func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mapping, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifySign indicates an expected call of verifySign.
+func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mapping, mod interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mapping, mod)
+}

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 	kernelAPI := module.NewKernelMapper()
 	moduleStatusUpdaterAPI := statusupdater.NewModuleStatusUpdater(client, daemonAPI, metricsAPI)
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
-	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, preflightStatusUpdaterAPI, kernelAPI)
+	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, signAPI, registryAPI, preflightStatusUpdaterAPI, kernelAPI)
 
 	mc := controllers.NewModuleReconciler(client, buildAPI, signAPI, rbacAPI, daemonAPI, kernelAPI, metricsAPI, filter, moduleStatusUpdaterAPI)
 


### PR DESCRIPTION
This PR add the sign verification stage to the preflight: in case image verification has failed and either build section is not defined or build verification was successful, preflight will now verify sign , if it was defined in the Module