### PR TITLE
add support for KERNEL_VERSION replacement for signing

### DIFF
--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -73,7 +73,10 @@ func (m *signer) MakeJobTemplate(
 	pushImage bool,
 	owner metav1.Object) (*batchv1.Job, error) {
 
-	signConfig := m.helper.GetRelevantSign(mod.Spec, km)
+	signConfig, err := m.helper.GetRelevantSign(mod.Spec, km, targetKernel)
+	if err != nil {
+		return nil, fmt.Errorf("calculate the signing parameters: %v", err)
+	}
 
 	args := make([]string, 0)
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -212,7 +212,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		mod.Spec.Selector = nodeSelector
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
@@ -259,7 +259,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
@@ -324,7 +324,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData

--- a/internal/sign/mock_helper.go
+++ b/internal/sign/mock_helper.go
@@ -35,15 +35,16 @@ func (m *MockHelper) EXPECT() *MockHelperMockRecorder {
 }
 
 // GetRelevantSign mocks base method.
-func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Sign {
+func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping, kernel string) (*v1beta1.Sign, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km)
+	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km, kernel)
 	ret0, _ := ret[0].(*v1beta1.Sign)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRelevantSign indicates an expected call of GetRelevantSign.
-func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km, kernel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km, kernel)
 }

--- a/internal/utils/replaceStrings.go
+++ b/internal/utils/replaceStrings.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/a8m/envsubst/parse"
+	"regexp"
+	"strings"
+)
+
+const (
+	kernelVersionMajorIdx = 0
+	kernelVersionMinorIdx = 1
+	kernelVersionPatchIdx = 2
+)
+
+func KernelComponentsAsEnvVars(kernel string) []string {
+	osConfigFieldsList := regexp.MustCompile("[.,-]").Split(kernel, -1)
+
+	envvars := []string{
+		"KERNEL_FULL_VERSION=" + kernel,
+		"KERNEL_VERSION=" + kernel,
+		"KERNEL_XYZ=" + strings.Join(osConfigFieldsList[:kernelVersionPatchIdx+1], "."),
+		"KERNEL_X=" + osConfigFieldsList[kernelVersionMajorIdx],
+		"KERNEL_Y=" + osConfigFieldsList[kernelVersionMinorIdx],
+		"KERNEL_Z=" + osConfigFieldsList[kernelVersionPatchIdx],
+	}
+
+	return envvars
+}
+
+func ReplaceInTemplates(envvars []string, templates ...string) ([]string, error) {
+	parser := parse.New("mapping", envvars, &parse.Restrictions{})
+
+	var replacedStrings []string
+	for _, v := range templates {
+		resultString, err := parser.Parse(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to substitute \"%s\" : %w", v, err)
+		}
+		replacedStrings = append(replacedStrings, resultString)
+	}
+	return replacedStrings, nil
+}


### PR DESCRIPTION
filesToSign (the filepaths of the kmods to sign) and unsignedImage (the name of the image that contains the kmods if its not built in cluster) both normally would contain the kernel version, this commit allows the embedding of "$(KERNEL_VERSION)" in them and have it replaced with the actual kernel version