### PR TITLE
Bump some dependencies

### DIFF
--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,7 +1,7 @@
 FROM alpine:3.17 as ksource
 RUN apk add linux-virt-dev
 
-FROM golang:1.19-alpine3.16 as builder
+FROM golang:1.19-alpine3.17 as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/kernel-module-management
 
-go 1.18
+go 1.19
 
 require (
 	github.com/a8m/envsubst v1.3.0


### PR DESCRIPTION
Align `go.mod` with the version we use to build images.
Use the same Alpine version to build and run `signimage`.