### PR TITLE
Fix logr.Error accepting key-value pair instead of error

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -102,7 +102,7 @@ func (f *Filter) FindModulesForNode(node client.Object) []reconcile.Request {
 
 			requirement, err := labels.NewRequirement(k, selection.Equals, []string{v})
 			if err != nil {
-				logger.Error(err, "could not generate requirement: %v", err)
+				logger.Error(err, "could not generate requirement")
 				return reqs
 			}
 
@@ -155,7 +155,7 @@ func (f *Filter) FindManagedClusterModulesForCluster(cluster client.Object) []re
 
 			requirement, err := labels.NewRequirement(k, selection.Equals, []string{v})
 			if err != nil {
-				logger.Error(err, "could not generate requirement: %v", err)
+				logger.Error(err, "could not generate requirement")
 				return reqs
 			}
 


### PR DESCRIPTION
This PR fixes possible panics when the [logr.Error()](https://pkg.go.dev/github.com/go-logr/logr#Logger.Error) has an `error` instead of key-value string pairs as its third and onwards arguments.
 
Signed-off-by: Michail Resvanis <mresvani@redhat.com>