### PR TITLE
Adjust ClusterClaim permissions to enable creation and caching

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -27,18 +27,23 @@ rules:
   - watch
 - apiGroups:
   - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
   resourceNames:
   - kernel-versions.kmm.node.kubernetes.io
   resources:
   - clusterclaims
   verbs:
-  - create
   - delete
-  - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:

--- a/controllers/node_kernel_clusterclaim.go
+++ b/controllers/node_kernel_clusterclaim.go
@@ -22,7 +22,8 @@ import (
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;list;watch
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 
 const clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 


### PR DESCRIPTION
The `NodeKernelClusterClaim` reconciler requires permissions and leverages client caching on `ClusterClaim` resources. This change adds permissions to `[create,get,list,watch]` `ClusterClaim` resources, but only `[patch,update,delete]` on the specific `ClusterClaim` that the reconciler itself has created.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>