### PR TITLE
Configure the ManifestWork to report the Module.Status

### DIFF
--- a/internal/manifestwork/manifestwork.go
+++ b/internal/manifestwork/manifestwork.go
@@ -20,6 +20,33 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 )
 
+var moduleStatusJSONPaths = []workv1.JsonPath{
+	{
+		Name: "devicePlugin.availableNumber",
+		Path: ".status.devicePlugin.availableNumber",
+	},
+	{
+		Name: "devicePlugin.desiredNumber",
+		Path: ".status.devicePlugin.desiredNumber",
+	},
+	{
+		Name: "devicePlugin.nodesMatchingSelectorNumber",
+		Path: ".status.devicePlugin.nodesMatchingSelectorNumber",
+	},
+	{
+		Name: "moduleLoader.availableNumber",
+		Path: ".status.moduleLoader.availableNumber",
+	},
+	{
+		Name: "moduleLoader.desiredNumber",
+		Path: ".status.moduleLoader.desiredNumber",
+	},
+	{
+		Name: "moduleLoader.nodesMatchingSelectorNumber",
+		Path: ".status.moduleLoader.nodesMatchingSelectorNumber",
+	},
+}
+
 //go:generate mockgen -source=manifestwork.go -package=manifestwork -destination=mock_manifestwork.go
 
 type ManifestWorkCreator interface {
@@ -90,7 +117,8 @@ func (mwg *manifestWorkGenerator) SetManifestWorkAsDesired(ctx context.Context, 
 			Name:      mcm.Name,
 			Namespace: mcm.Spec.SpokeNamespace,
 		},
-		Spec: mcm.Spec.ModuleSpec,
+		Spec:   mcm.Spec.ModuleSpec,
+		Status: kmmv1beta1.ModuleStatus{},
 	}
 
 	manifest := workv1.Manifest{
@@ -106,6 +134,22 @@ func (mwg *manifestWorkGenerator) SetManifestWorkAsDesired(ctx context.Context, 
 	mw.Spec = workv1.ManifestWorkSpec{
 		Workload: workv1.ManifestsTemplate{
 			Manifests: []workv1.Manifest{manifest},
+		},
+		ManifestConfigs: []workv1.ManifestConfigOption{
+			{
+				ResourceIdentifier: workv1.ResourceIdentifier{
+					Group:     mod.GroupVersionKind().Group,
+					Resource:  "modules",
+					Name:      mod.Name,
+					Namespace: mod.Namespace,
+				},
+				FeedbackRules: []workv1.FeedbackRule{
+					{
+						Type:      workv1.JSONPathsType,
+						JsonPaths: moduleStatusJSONPaths,
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -142,8 +142,15 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 	})
 
 	It("should work as expected", func() {
+		const (
+			mcmName        = "test"
+			spokeNamespace = "test-namespace"
+		)
+
 		mcm := hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{Name: mcmName},
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
+				SpokeNamespace: spokeNamespace,
 				ModuleSpec: kmmv1beta1.ModuleSpec{
 					Selector: map[string]string{"key": "value"},
 				},
@@ -152,10 +159,24 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 
 		mw := &workv1.ManifestWork{}
 
+		expectedResourceIdentifier := workv1.ResourceIdentifier{
+			Group:     "kmm.sigs.x-k8s.io",
+			Resource:  "modules",
+			Name:      mcm.Name,
+			Namespace: spokeNamespace,
+		}
+
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(constants.ManagedClusterModuleNameLabel).To(BeKeyOf(mw.Labels))
 		Expect(mw.Spec.Workload.Manifests).To(HaveLen(1))
 		Expect((mw.Spec.Workload.Manifests[0].RawExtension.Object).(*kmmv1beta1.Module).Spec).To(Equal(mcm.Spec.ModuleSpec))
+
+		Expect(mw.Spec.ManifestConfigs).To(HaveLen(1))
+		Expect(mw.Spec.ManifestConfigs[0].ResourceIdentifier).To(Equal(expectedResourceIdentifier))
+
+		Expect(mw.Spec.ManifestConfigs[0].FeedbackRules).To(HaveLen(1))
+		Expect(mw.Spec.ManifestConfigs[0].FeedbackRules[0].Type).To(Equal(workv1.JSONPathsType))
+		Expect(mw.Spec.ManifestConfigs[0].FeedbackRules[0].JsonPaths).To(Equal(moduleStatusJSONPaths))
 	})
 })


### PR DESCRIPTION
This change configures the `ManifestWork`, via its `FeedbackRules` [field](https://github.com/open-cluster-management-io/api/blob/b57d18bd356abdf57633bd2cfcc227656f72418f/work/v1/types.go#L82), to report back to the Hub the `Module.Status`. This way, admins on the Hub can check the applied `ManifestWork`s for the status of the Spokes' `Module`s. 

The `ManifestWork` `FeedbackRules` can be configured either with the `WellKnownStatusType` or the `JSONPathsType`. The `Module` CRD is not a well-known Kubernetes resource and the `JSONPathsType` accepts only `Integer`, `String` and `Boolean` types. As such, we have to explicitly define all fields of the `Module.Status` to be included in the `ManifestWork`'s `FeedbackRules`.

https://open-cluster-management.io/concepts/manifestwork/#status-tracking

Signed-off-by: Michail Resvanis <mresvani@redhat.com>