### PR TITLE
Fixing FIRWARE files/directories loading

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -370,7 +370,7 @@ func MakeLoadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
 	var loadCommand strings.Builder
 
 	if fw := spec.FirmwarePath; fw != "" {
-		fmt.Fprintf(&loadCommand, "cp -r %s %s && ", fw, nodeVarLibFirmwarePath)
+		fmt.Fprintf(&loadCommand, "cp -r %s/* %s && ", fw, nodeVarLibFirmwarePath)
 	}
 
 	loadCommand.WriteString("modprobe")
@@ -419,7 +419,7 @@ func MakeUnloadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
 
 	fwUnloadCommand := ""
 	if fw := spec.FirmwarePath; fw != "" {
-		fwUnloadCommand = fmt.Sprintf(" && cd %s && find |sort -r |xargs -I{} rm -d %s/$(basename %s)/{}", fw, nodeVarLibFirmwarePath, fw)
+		fwUnloadCommand = fmt.Sprintf(" && cd %s && find |sort -r |xargs -I{} rm -d %s/{}", fw, nodeVarLibFirmwarePath)
 	}
 
 	if rawArgs := spec.RawArgs; rawArgs != nil && len(rawArgs.Unload) > 0 {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -924,7 +924,7 @@ var _ = Describe("MakeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("cp -r /kmm/firmware/mymodule /var/lib/firmware && modprobe -v %s", kernelModuleName),
+				fmt.Sprintf("cp -r /kmm/firmware/mymodule/* /var/lib/firmware && modprobe -v %s", kernelModuleName),
 			}),
 		)
 	})
@@ -1005,7 +1005,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/$(basename /kmm/firmware/mymodule)/{}", kernelModuleName),
+				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/{}", kernelModuleName),
 			}),
 		)
 	})


### PR DESCRIPTION
Currently the firmware path defined in the Module CR is copied into the /var/lib/firmware host path, including the the rightmost directory. Since customed firmware base loading directory for kernel modules is /var/lib/firmware, it means that kernel modules that are expecting their firmware to be located unnder base path (/var/lib/firmware) cannot be run, since current implementation will always contain at leas one additional directory under /var/lib/firmware. This PR changes implementation, so that, if needed, firmware file can be copied directly under the base path (/var/lib/firmware)