### PR TITLE
Making the e2e-incluster-build job to actually build in cluster.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -148,6 +148,7 @@ jobs:
     needs: [build-operator-image]
 
     steps:
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -156,31 +157,10 @@ jobs:
         with:
           start-args: --addons registry,registry-aliases
 
-      - name: Expose the registry outside the cluster
-        run: kubectl apply -f ci/registry-nodeport.yaml
-
-      - name: Install skopeo
-        run: |
-          sudo apt -y update
-          sudo apt -y install skopeo
-
       - name: Download container images
         uses: actions/download-artifact@v3
         with:
           name: ci-images
-
-      - name: Save the kernel version
-        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
-
-      - name: Build the DriverContainer image
-        uses: ./.github/actions/build-drivercontainer-image
-        with:
-          kernel-version: ${{ env.KERNEL_VERSION }}
-
-      - name: Import DriverContainer base into the internal-registry
-        run: |
-          MINIKUBE_REGISTRY_EXT="$(minikube service registry-nodeport -n kube-system --format '{{.IP}}:{{.Port}}' --url)"
-          skopeo copy --dest-tls-verify=false docker-archive:kmm-kmod_local.tar docker://${MINIKUBE_REGISTRY_EXT}/kmm-base:local
 
       - name: Import the KMMO image into minikube
         run: minikube image load kmm_local.tar

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -4,13 +4,32 @@ metadata:
   name: kmm-kmod-dockerfile
 data:
   dockerfile: |
-    FROM registry.minikube/kmm-base:local
+    FROM ubuntu as builder
 
-    ARG CI_BUILD_ARG
     ARG KERNEL_VERSION
-    ARG WITH_DEFAULT_VALUE=default-value
 
-    RUN cat /run/secrets/build-secret/ci-build-secret > /ci-build-secret
-    RUN echo $CI_BUILD_ARG > /build-arg
-    RUN echo $KERNEL_VERSION > /kernel-version
-    RUN echo $WITH_DEFAULT_VALUE > /default-value
+    RUN apt-get update && \
+        apt-get install -y \
+        git \
+        make \
+        gcc \
+        linux-headers-${KERNEL_VERSION}
+
+    WORKDIR /usr/src
+
+    RUN git clone https://github.com/kubernetes-sigs/kernel-module-management.git
+
+    WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod
+
+    RUN KERNEL_SRC_DIR=/usr/src/linux-headers-${KERNEL_VERSION} make all
+
+    FROM ubuntu
+
+    ARG KERNEL_VERSION
+
+    RUN apt-get update && \
+        apt-get install -y kmod
+
+    COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
+    COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+    RUN depmod -b /opt

--- a/ci/module-kmm-ci-build.template.yaml
+++ b/ci/module-kmm-ci-build.template.yaml
@@ -2,7 +2,7 @@
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
-  name: kmm-ci-build
+  name: kmm-ci
 spec:
   moduleLoader:
     container:

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -5,38 +5,31 @@ set -euxo pipefail
 echo "Deploy KMMO..."
 make deploy
 
-echo "Wait until the KMMO Deployment is Available"
-timeout 1m kubectl wait --for condition=Available deployments.apps -n kmm-operator-system kmm-operator-controller-manager 
-
 echo "Create a build secret..."
 kubectl create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+
 echo "Add a configmap that contain the kernel module build dockerfile..."
 kubectl apply -f ci/kmm-kmod-dockerfile.yaml
 
 echo "Add an kmm-ci Module that contains a valid mapping..."
-sed -e "s/KVER_CHANGEME/$(uname -r)/g" ci/module-kmm-ci-build.template.yaml | tee module-kmm-ci.yaml
+sed -e "s/KVER_CHANGEME/$(minikube ssh -- uname -r)/g" ci/module-kmm-ci-build.template.yaml | tee module-kmm-ci.yaml
 kubectl apply -f module-kmm-ci.yaml
 
-echo "Wait for the job to be created..."
-timeout 1m bash -c 'until kubectl get job -l kmm.node.kubernetes.io/module.name | grep kmm; do sleep 1; done'
+# Wait for the build pod to be created. `kubectl wait` doesn't support such option,
+# see https://github.com/kubernetes/kubernetes/issues/83242.
+echo "Waiting for the build pod to be created..."
+timeout 1m bash -c 'until kubectl get pods -o json | jq -er ".items[].metadata.name | select(.? | match(\"build\"))"; do sleep 1; done'
+POD_NAME=$(kubectl get pods -o json | jq -r '.items[].metadata.name | select(.? | match("build"))')
+
+# The build job/pod is deleted once done so we won't be able to get this info later on in the troubleshooting section.
+echo "Print the build logs..."
+# we can't get the logs on a pod that isn't `Running` yet.
+kubectl wait pod/${POD_NAME} --for jsonpath='{.status.phase}'=Running --timeout=60s
+kubectl logs pod/${POD_NAME} -f
 
 echo "Check that the module gets loaded on the node..."
-timeout 1m bash -c 'until minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
+timeout 10m bash -c 'until minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
 
-echo "Check that the DriverContainer prints the secret's value to the standard output..."
-POD_NAME=$(kubectl get pod -l kmm.node.kubernetes.io/module.name --template='{{ (index .items 0).metadata.name }}')
-KERNEL_VERSION=$(uname -r)
-echo "Looking for the build secret"
-timeout 1m bash -c "until kubectl exec $POD_NAME -- grep super-secret-value /ci-build-secret; do sleep 3; done"
-
-echo "Looking for the build argument"
-timeout 1m bash -c "until kubectl exec $POD_NAME -- grep some-build-arg /build-arg; do sleep 3; done"
-
-echo "Looking for the kernel version"
-timeout 1m bash -c "until kubectl exec $POD_NAME -- grep $KERNEL_VERSION /kernel-version; do sleep 3; done"
-
-echo "Looking for the build argument with a default value"
-timeout 1m bash -c "until kubectl exec $POD_NAME -- grep default-value /default-value; do sleep 3; done"
 
 echo "Remove the Module..."
 kubectl delete -f module-kmm-ci.yaml


### PR DESCRIPTION
Until now, we were just building the driver container in the Github
runner, loading it into minikube and then the Dockerfile loaded as a
ConfigMap was just downloading that image, adding some files and pushing
instead of actually build the driver container in cluster.

This commit is fixing that flow.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>