### PR TITLE
Create ./bin when installing operator-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,9 @@ OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 .PHONY: operator-sdk
 operator-sdk:
 	@if [ ! -f ${OPERATOR_SDK} ]; then \
+		set -e ;\
 		echo "Downloading ${OPERATOR_SDK}"; \
+		mkdir -p $(dir ${OPERATOR_SDK}) ;\
 		curl -Lo ${OPERATOR_SDK} 'https://github.com/operator-framework/operator-sdk/releases/download/v1.25.2/operator-sdk_linux_amd64'; \
 		chmod +x ${OPERATOR_SDK}; \
 	fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,10 +40,6 @@ steps:
       curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       chmod +x /usr/local/bin/kubectl
 
-      # install operator-sdk
-      curl -Lo /usr/local/bin/operator-sdk 'https://github.com/operator-framework/operator-sdk/releases/download/v1.25.2/operator-sdk_linux_amd64'
-      chmod +x /usr/local/bin/operator-sdk
-
       # Include the destination directory of `go install` in $PATH
       export PATH=$(go env GOPATH)/bin:${PATH}
 


### PR DESCRIPTION
Do not install operator-sdk manually in cloudbuild.yaml.

/cc @ybettan 