### PR TITLE
Fixing CI to use the KMM image build from the PR.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 env:
   GO_VERSION: 1.18
+  IMG: kmm:local
 
 jobs:
   build-operator-image:
@@ -16,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build the image
-        run: make docker-build IMG=kmm:local
+        run: make docker-build
 
       - name: Export the image
         run: docker save -o kmm_local.tar kmm:local


### PR DESCRIPTION
ATM, we are deploying the default image in all our e2e tests and completely ignoring the image build with the src code of a specific PR.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>