### PR TITLE
Configure related images via environment variables

### DIFF
--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -41,6 +41,11 @@ spec:
         - /manager
         image: controller:latest
         name: manager
+        env:
+          - name: RELATED_IMAGES_BUILD
+            value: gcr.io/kaniko-project/executor:latest
+          - name: RELATED_IMAGES_SIGN
+            value: gcr.io/k8s-staging-kmm/kernel-module-management-signimage:latest
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -3,6 +3,7 @@ package signjob
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -133,7 +134,7 @@ func (m *signer) MakeJobTemplate(
 			Containers: []v1.Container{
 				{
 					Name:         "signimage",
-					Image:        "quay.io/chrisp262/kmod-signer:latest",
+					Image:        os.Getenv("RELATED_IMAGES_SIGN"),
 					Args:         args,
 					VolumeMounts: volumeMounts,
 				},

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -28,8 +28,8 @@ var _ = Describe("MakeJobTemplate", func() {
 	const (
 		unsignedImage = "my.registry/my/image"
 		signedImage   = "my.registry/my/image-signed"
+		signerImage   = "some-signer-image:some-tag"
 		filesToSign   = "/modules/simple-kmod.ko:/modules/simple-procfs-kmod.ko"
-		dockerfile    = "FROM test"
 		kernelVersion = "1.2.3"
 		moduleName    = "module-name"
 		namespace     = "some-namespace"
@@ -73,6 +73,8 @@ var _ = Describe("MakeJobTemplate", func() {
 	privateSignData := map[string][]byte{constants.PrivateSignDataKey: []byte(privateKey)}
 
 	DescribeTable("should set fields correctly", func(imagePullSecret *v1.LocalObjectReference) {
+		GinkgoT().Setenv("RELATED_IMAGES_SIGN", signerImage)
+
 		ctx := context.Background()
 		nodeSelector := map[string]string{"arch": "x64"}
 
@@ -152,7 +154,7 @@ var _ = Describe("MakeJobTemplate", func() {
 						Containers: []v1.Container{
 							{
 								Name:  "signimage",
-								Image: "quay.io/chrisp262/kmod-signer:latest",
+								Image: signerImage,
 								Args: []string{
 									"-signedimage", signedImage,
 									"-unsignedimage", unsignedImage,


### PR DESCRIPTION
This allows us to patch those variables with the digest equivalent of the images.
Unfortunately `operator-sdk` does not seem to identify them properly for an unknown reason; that means that the images are not listed under the CSV's `relatedImages` field, nor are they automatically replaced with their digest equivalent.

/cc @ybettan @yevgeny-shnaidman 