### PR TITLE
Implement ManagedClusterModuleStatus for KMM-Hub

### DIFF
--- a/api-hub/v1beta1/managedclustermodule_types.go
+++ b/api-hub/v1beta1/managedclustermodule_types.go
@@ -38,6 +38,14 @@ type ManagedClusterModuleSpec struct {
 
 // ManagedClusterModuleStatus defines the observed state of ManagedClusterModule.
 type ManagedClusterModuleStatus struct {
+	// Number of ManifestWorks to be applied.
+	NumberDesired int32 `json:"numberDesired"`
+
+	// Number of ManifestWorks that have been successfully applied.
+	NumberApplied int32 `json:"numberApplied"`
+
+	// Number of ManifestWorks that could not be successfully applied.
+	NumberDegraded int32 `json:"numberDegraded"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	signjob "github.com/kubernetes-sigs/kernel-module-management/internal/sign/job"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/statusupdater"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -133,6 +134,7 @@ func main() {
 		client,
 		manifestwork.NewCreator(client, scheme),
 		cluster.NewClusterAPI(client, module.NewKernelMapper(), buildAPI, signAPI, operatorNamespace),
+		statusupdater.NewManagedClusterModuleStatusUpdater(client),
 		filterAPI,
 	)
 

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2412,6 +2412,24 @@ spec:
           status:
             description: ManagedClusterModuleStatus defines the observed state of
               ManagedClusterModule.
+            properties:
+              numberApplied:
+                description: Number of ManifestWorks that have been successfully applied.
+                format: int32
+                type: integer
+              numberDegraded:
+                description: Number of ManifestWorks that could not be successfully
+                  applied.
+                format: int32
+                type: integer
+              numberDesired:
+                description: Number of ManifestWorks to be applied.
+                format: int32
+                type: integer
+            required:
+            - numberApplied
+            - numberDegraded
+            - numberDesired
             type: object
         type: object
     served: true

--- a/internal/manifestwork/manifestwork.go
+++ b/internal/manifestwork/manifestwork.go
@@ -24,6 +24,7 @@ import (
 
 type ManifestWorkCreator interface {
 	GarbageCollect(ctx context.Context, clusters clusterv1.ManagedClusterList, mcm hubv1beta1.ManagedClusterModule) error
+	GetOwnedManifestWorks(ctx context.Context, mcm hubv1beta1.ManagedClusterModule) (*workv1.ManifestWorkList, error)
 	SetManifestWorkAsDesired(ctx context.Context, mw *workv1.ManifestWork, mcm hubv1beta1.ManagedClusterModule) error
 }
 
@@ -61,6 +62,10 @@ func (mwg *manifestWorkGenerator) GarbageCollect(ctx context.Context, clusters c
 	}
 
 	return nil
+}
+
+func (mwg *manifestWorkGenerator) GetOwnedManifestWorks(ctx context.Context, mcm hubv1beta1.ManagedClusterModule) (*workv1.ManifestWorkList, error) {
+	return mwg.getOwnedManifestWorks(ctx, mcm)
 }
 
 func (mwg *manifestWorkGenerator) SetManifestWorkAsDesired(ctx context.Context, mw *workv1.ManifestWork, mcm hubv1beta1.ManagedClusterModule) error {

--- a/internal/manifestwork/mock_manifestwork.go
+++ b/internal/manifestwork/mock_manifestwork.go
@@ -51,6 +51,21 @@ func (mr *MockManifestWorkCreatorMockRecorder) GarbageCollect(ctx, clusters, mcm
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManifestWorkCreator)(nil).GarbageCollect), ctx, clusters, mcm)
 }
 
+// GetOwnedManifestWorks mocks base method.
+func (m *MockManifestWorkCreator) GetOwnedManifestWorks(ctx context.Context, mcm v1beta1.ManagedClusterModule) (*v10.ManifestWorkList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwnedManifestWorks", ctx, mcm)
+	ret0, _ := ret[0].(*v10.ManifestWorkList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOwnedManifestWorks indicates an expected call of GetOwnedManifestWorks.
+func (mr *MockManifestWorkCreatorMockRecorder) GetOwnedManifestWorks(ctx, mcm interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnedManifestWorks", reflect.TypeOf((*MockManifestWorkCreator)(nil).GetOwnedManifestWorks), ctx, mcm)
+}
+
 // SetManifestWorkAsDesired mocks base method.
 func (m *MockManifestWorkCreator) SetManifestWorkAsDesired(ctx context.Context, mw *v10.ManifestWork, mcm v1beta1.ManagedClusterModule) error {
 	m.ctrl.T.Helper()

--- a/internal/statusupdater/mock_statusupdater.go
+++ b/internal/statusupdater/mock_statusupdater.go
@@ -9,10 +9,12 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
+	v1beta10 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
+	v11 "open-cluster-management.io/api/work/v1"
 )
 
 // MockModuleStatusUpdater is a mock of ModuleStatusUpdater interface.
@@ -39,7 +41,7 @@ func (m *MockModuleStatusUpdater) EXPECT() *MockModuleStatusUpdaterMockRecorder 
 }
 
 // ModuleUpdateStatus mocks base method.
-func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v1beta1.Module, kernelMappingNodes, targetedNodes []v10.Node, dsByKernelVersion map[string]*v1.DaemonSet) error {
+func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v1beta10.Module, kernelMappingNodes, targetedNodes []v10.Node, dsByKernelVersion map[string]*v1.DaemonSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModuleUpdateStatus", ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
 	ret0, _ := ret[0].(error)
@@ -50,6 +52,43 @@ func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v
 func (mr *MockModuleStatusUpdaterMockRecorder) ModuleUpdateStatus(ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModuleUpdateStatus", reflect.TypeOf((*MockModuleStatusUpdater)(nil).ModuleUpdateStatus), ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
+}
+
+// MockManagedClusterModuleStatusUpdater is a mock of ManagedClusterModuleStatusUpdater interface.
+type MockManagedClusterModuleStatusUpdater struct {
+	ctrl     *gomock.Controller
+	recorder *MockManagedClusterModuleStatusUpdaterMockRecorder
+}
+
+// MockManagedClusterModuleStatusUpdaterMockRecorder is the mock recorder for MockManagedClusterModuleStatusUpdater.
+type MockManagedClusterModuleStatusUpdaterMockRecorder struct {
+	mock *MockManagedClusterModuleStatusUpdater
+}
+
+// NewMockManagedClusterModuleStatusUpdater creates a new mock instance.
+func NewMockManagedClusterModuleStatusUpdater(ctrl *gomock.Controller) *MockManagedClusterModuleStatusUpdater {
+	mock := &MockManagedClusterModuleStatusUpdater{ctrl: ctrl}
+	mock.recorder = &MockManagedClusterModuleStatusUpdaterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockManagedClusterModuleStatusUpdater) EXPECT() *MockManagedClusterModuleStatusUpdaterMockRecorder {
+	return m.recorder
+}
+
+// ManagedClusterModuleUpdateStatus mocks base method.
+func (m *MockManagedClusterModuleStatusUpdater) ManagedClusterModuleUpdateStatus(ctx context.Context, mcm *v1beta1.ManagedClusterModule, ownedManifestWorks []v11.ManifestWork) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagedClusterModuleUpdateStatus", ctx, mcm, ownedManifestWorks)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ManagedClusterModuleUpdateStatus indicates an expected call of ManagedClusterModuleUpdateStatus.
+func (mr *MockManagedClusterModuleStatusUpdaterMockRecorder) ManagedClusterModuleUpdateStatus(ctx, mcm, ownedManifestWorks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedClusterModuleUpdateStatus", reflect.TypeOf((*MockManagedClusterModuleStatusUpdater)(nil).ManagedClusterModuleUpdateStatus), ctx, mcm, ownedManifestWorks)
 }
 
 // MockPreflightStatusUpdater is a mock of PreflightStatusUpdater interface.
@@ -76,7 +115,7 @@ func (m *MockPreflightStatusUpdater) EXPECT() *MockPreflightStatusUpdaterMockRec
 }
 
 // PreflightPresetStatuses mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightPresetStatuses(ctx context.Context, pv *v1beta1.PreflightValidation, existingModules sets.String, newModules []string) error {
+func (m *MockPreflightStatusUpdater) PreflightPresetStatuses(ctx context.Context, pv *v1beta10.PreflightValidation, existingModules sets.String, newModules []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightPresetStatuses", ctx, pv, existingModules, newModules)
 	ret0, _ := ret[0].(error)
@@ -90,7 +129,7 @@ func (mr *MockPreflightStatusUpdaterMockRecorder) PreflightPresetStatuses(ctx, p
 }
 
 // PreflightSetVerificationStage mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightSetVerificationStage(ctx context.Context, preflight *v1beta1.PreflightValidation, moduleName, stage string) error {
+func (m *MockPreflightStatusUpdater) PreflightSetVerificationStage(ctx context.Context, preflight *v1beta10.PreflightValidation, moduleName, stage string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightSetVerificationStage", ctx, preflight, moduleName, stage)
 	ret0, _ := ret[0].(error)
@@ -104,7 +143,7 @@ func (mr *MockPreflightStatusUpdaterMockRecorder) PreflightSetVerificationStage(
 }
 
 // PreflightSetVerificationStatus mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightSetVerificationStatus(ctx context.Context, preflight *v1beta1.PreflightValidation, moduleName, verificationStatus, message string) error {
+func (m *MockPreflightStatusUpdater) PreflightSetVerificationStatus(ctx context.Context, preflight *v1beta10.PreflightValidation, moduleName, verificationStatus, message string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightSetVerificationStatus", ctx, preflight, moduleName, verificationStatus, message)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
This PR adds the implementation of the `ManagedClusterModuleStatus`. The latter reflects the number of desired, applied and degraded `ManifestWork` CRs owned by the respective `ManagedClusterModule` CR.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>