### PR TITLE
Adding back the `build-secret` to the e2e test.

### DIFF
--- a/ci/module-kmm-ci-build.yaml
+++ b/ci/module-kmm-ci-build.yaml
@@ -16,6 +16,8 @@ spec:
           build:
             baseImageRegistryTLS:
               insecure: true
+            secrets:
+              - name: build-secret
             dockerfileConfigMap:
               name: kmm-kmod-dockerfile
             # Optional. If kanikoParams.tag is empty, the default value will be: 'latest'

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -11,6 +11,9 @@ if minikube ssh -- lsmod | grep kmm_ci_a; then
  exit 1
 fi
 
+echo "Create a build secret..."
+oc create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+
 echo "Add a configmap that contain the kernel module build dockerfile..."
 kubectl apply -f ci/kmm-kmod-dockerfile.yaml
 
@@ -23,10 +26,14 @@ echo "Waiting for the build pod to be created..."
 timeout 1m bash -c 'until kubectl get pods -o json | jq -er ".items[].metadata.name | select(.? | match(\"build\"))"; do sleep 1; done'
 POD_NAME=$(kubectl get pods -o json | jq -r '.items[].metadata.name | select(.? | match("build"))')
 
+# we can't exec a command nor get the logs on a pod that isn't `Running` yet.
+kubectl wait pod/${POD_NAME} --for jsonpath='{.status.phase}'=Running --timeout=60s
+
+# Check that the build secret is available to the build pod
+timeout 1m bash -c "until kubectl exec ${POD_NAME} -- grep super-secret-value /run/secrets/build-secret/ci-build-secret; do sleep 3; done"
+
 # The build job/pod is deleted once done so we won't be able to get this info later on in the troubleshooting section.
 echo "Print the build logs..."
-# we can't get the logs on a pod that isn't `Running` yet.
-kubectl wait pod/${POD_NAME} --for jsonpath='{.status.phase}'=Running --timeout=60s
 kubectl logs pod/${POD_NAME} -f
 
 echo "Check that the module gets loaded on the node..."


### PR DESCRIPTION
The decision to remove it was a mistake. It was confused with `imageRepoSecret`.

The build arg is supposed to be available to the `build` Dockerfile at `/run/secrets/build-secret/filename`.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>