### PR TITLE
Adjust ManagedClusterModuleReconciler ManagedCluster watch predicate

### DIFF
--- a/controllers/hub/managedclustermodule_reconciler.go
+++ b/controllers/hub/managedclustermodule_reconciler.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hubv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
@@ -164,7 +163,10 @@ func (r *ManagedClusterModuleReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		Watches(
 			&source.Kind{Type: &clusterv1.ManagedCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.filter.FindManagedClusterModulesForCluster),
-			builder.WithPredicates(predicate.LabelChangedPredicate{})).
+			builder.WithPredicates(
+				r.filter.ManagedClusterModuleReconcilerManagedClusterPredicate(),
+			),
+		).
 		Named(ManagedClusterModuleReconcilerName).
 		Complete(r)
 }

--- a/controllers/node_kernel_clusterclaim.go
+++ b/controllers/node_kernel_clusterclaim.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/api/cluster/v1alpha1"
@@ -19,6 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;list;watch
@@ -26,8 +28,6 @@ import (
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 
 const (
-	clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
-
 	NodeKernelClusterClaimReconcilerName = "NodeKernelClusterClaim"
 )
 
@@ -68,7 +68,7 @@ func (r *NodeKernelClusterClaimReconciler) Reconcile(ctx context.Context, req ct
 	sort.Strings(kernelsSlice)
 
 	cc := v1alpha1.ClusterClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: clusterClaimName},
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KernelVersionsClusterClaimName},
 	}
 
 	logger.Info("Creating or patching ClusterClaim")
@@ -109,7 +109,7 @@ func (r *NodeKernelClusterClaimReconciler) SetupWithManager(mgr ctrl.Manager) er
 			}),
 			builder.WithPredicates(
 				predicate.NewPredicateFuncs(func(object client.Object) bool {
-					return object.GetName() == clusterClaimName
+					return object.GetName() == constants.KernelVersionsClusterClaimName
 				}),
 			),
 		).

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -16,12 +16,9 @@ import (
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
-)
-
-const (
-	clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 )
 
 //go:generate mockgen -source=cluster.go -package=cluster -destination=mock_cluster.go
@@ -188,7 +185,7 @@ func (c *clusterAPI) kernelMappingsByKernelVersion(
 
 func (c *clusterAPI) kernelVersions(cluster clusterv1.ManagedCluster) ([]string, error) {
 	for _, clusterClaim := range cluster.Status.ClusterClaims {
-		if clusterClaim.Name != clusterClaimName {
+		if clusterClaim.Name != constants.KernelVersionsClusterClaimName {
 			continue
 		}
 		return strings.Split(clusterClaim.Value, "\n"), nil

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -195,7 +196,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -300,7 +301,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -371,7 +372,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -443,7 +444,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -514,7 +515,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -586,7 +587,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -658,7 +659,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -730,7 +731,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,8 +9,9 @@ const (
 	JobHashAnnotation    = "kmm.node.kubernetes.io/last-hash"
 	KernelLabel          = "kmm.node.kubernetes.io/kernel-version.full"
 
-	ManagedClusterModuleNameLabel = "kmm.node.kubernetes.io/managedclustermodule.name"
-	DockerfileCMKey               = "dockerfile"
-	PublicSignDataKey             = "cert"
-	PrivateSignDataKey            = "key"
+	ManagedClusterModuleNameLabel  = "kmm.node.kubernetes.io/managedclustermodule.name"
+	KernelVersionsClusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
+	DockerfileCMKey                = "dockerfile"
+	PublicSignDataKey              = "cert"
+	PrivateSignDataKey             = "key"
 )


### PR DESCRIPTION
This change updates the `ManagedClusterModule` reconciler's `ManagedCluster` watch predicate, in order to enqueue update events of changed KMM `ClusterClaim`s. This way whenever a new kernel version is available on a `ManagedCluster`, the `ManagedClusterModule` reconciler will reconcile the affected `ManagedClusterModule`s.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>