### PR TITLE
Updating the `in-cluster-build` job to correctly use build secrets.

### DIFF
--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -17,6 +17,8 @@ data:
 
     WORKDIR /usr/src
 
+    RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+
     RUN git clone https://github.com/kubernetes-sigs/kernel-module-management.git
 
     WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -29,9 +29,6 @@ POD_NAME=$(kubectl get pods -o json | jq -r '.items[].metadata.name | select(.? 
 # we can't exec a command nor get the logs on a pod that isn't `Running` yet.
 kubectl wait pod/${POD_NAME} --for jsonpath='{.status.phase}'=Running --timeout=60s
 
-# Check that the build secret is available to the build pod
-timeout 1m bash -c "until kubectl exec ${POD_NAME} -- grep super-secret-value /run/secrets/build-secret/ci-build-secret; do sleep 3; done"
-
 # The build job/pod is deleted once done so we won't be able to get this info later on in the troubleshooting section.
 echo "Print the build logs..."
 kubectl logs pod/${POD_NAME} -f


### PR DESCRIPTION
Instead of checking that the secrets are available on the `kaniko` pod we should check that the secret files are available in the Dockerfile itself.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>