### PR TITLE
log error if sign-file fails

### DIFF
--- a/cmd/signimage/signimage.go
+++ b/cmd/signimage/signimage.go
@@ -210,7 +210,7 @@ func processFile(filename string, header *tar.Header, tarreader io.Reader, data 
 		//sign it
 		err = signFile(kmodsToSign[canonfilename], pubKeyFile, privKeyFile)
 		if err != nil {
-			return fmt.Errorf("error signing file %s", canonfilename)
+			return fmt.Errorf("error signing file %s: %v", canonfilename, err)
 		}
 		logger.Info("Signed successfully", "kmod", canonfilename)
 		return nil

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -176,8 +176,6 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 		if imagePullSecret != nil {
 			mod.Spec.ImageRepoSecret = imagePullSecret
-			//expected.Spec.Template.Spec.Containers[0].Args = append(expected.Spec.Template.Spec.Containers[0].Args, "-secretdir")
-			//expected.Spec.Template.Spec.Containers[0].Args = append(expected.Spec.Template.Spec.Containers[0].Args, "/docker_config/")
 			expected.Spec.Template.Spec.Containers[0].VolumeMounts =
 				append(expected.Spec.Template.Spec.Containers[0].VolumeMounts,
 					v1.VolumeMount{


### PR DESCRIPTION
the error from the sign-file binary was getting lost because it wasn't returned through the stack call correctly. This commit fixes that by passing the message up.

Also remove a couple of commented out code lines. (these were picked up by downstream code review)

