### PR TITLE
Configuring the build and sign job backoff and restart policies

### DIFF
--- a/internal/build/job/maker.go
+++ b/internal/build/job/maker.go
@@ -105,8 +105,9 @@ func (m *maker) MakeJobTemplate(
 			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
 		},
 		Spec: batchv1.JobSpec{
-			Completions: pointer.Int32(1),
-			Template:    specTemplate,
+			Completions:  pointer.Int32(1),
+			BackoffLimit: pointer.Int32(0),
+			Template:     specTemplate,
 		},
 	}
 
@@ -146,7 +147,7 @@ func (m *maker) specTemplate(
 				},
 			},
 			NodeSelector:  modSpec.Selector,
-			RestartPolicy: v1.RestartPolicyOnFailure,
+			RestartPolicy: v1.RestartPolicyNever,
 			Volumes:       volumes(modSpec, buildConfig),
 		},
 	}

--- a/internal/build/job/maker_test.go
+++ b/internal/build/job/maker_test.go
@@ -105,7 +105,8 @@ var _ = Describe("MakeJobTemplate", func() {
 				},
 			},
 			Spec: batchv1.JobSpec{
-				Completions: pointer.Int32(1),
+				Completions:  pointer.Int32(1),
+				BackoffLimit: pointer.Int32(0),
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
@@ -127,7 +128,7 @@ var _ = Describe("MakeJobTemplate", func() {
 							},
 						},
 						NodeSelector:  nodeSelector,
-						RestartPolicy: v1.RestartPolicyOnFailure,
+						RestartPolicy: v1.RestartPolicyNever,
 						Volumes: []v1.Volume{
 							{
 								Name: "dockerfile",

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -143,7 +143,7 @@ func (s *signer) MakeJobTemplate(
 					VolumeMounts: volumeMounts,
 				},
 			},
-			RestartPolicy: v1.RestartPolicyOnFailure,
+			RestartPolicy: v1.RestartPolicyNever,
 			Volumes:       volumes,
 			NodeSelector:  mod.Spec.Selector,
 		},
@@ -162,8 +162,9 @@ func (s *signer) MakeJobTemplate(
 			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
 		},
 		Spec: batchv1.JobSpec{
-			Completions: pointer.Int32(1),
-			Template:    specTemplate,
+			Completions:  pointer.Int32(1),
+			Template:     specTemplate,
+			BackoffLimit: pointer.Int32(0),
 		},
 	}
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -148,7 +148,8 @@ var _ = Describe("MakeJobTemplate", func() {
 				},
 			},
 			Spec: batchv1.JobSpec{
-				Completions: pointer.Int32(1),
+				Completions:  pointer.Int32(1),
+				BackoffLimit: pointer.Int32(0),
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
@@ -167,7 +168,7 @@ var _ = Describe("MakeJobTemplate", func() {
 							},
 						},
 						NodeSelector:  nodeSelector,
-						RestartPolicy: v1.RestartPolicyOnFailure,
+						RestartPolicy: v1.RestartPolicyNever,
 
 						Volumes: []v1.Volume{keysecret, certsecret},
 					},


### PR DESCRIPTION
In the default configuration, once the failed container of the pod is restarted 6 times, and after the final failure it is deleted. This PR changes the policy to never restart, and the backoff limit to 0, meaning that after first failure, the pod/container won't be restarted, but the failed pod itself will be kept in the cluster for future debugging