### PR TITLE
Workaround for SF.net plantuml URL missing

### DIFF
--- a/docs.mk
+++ b/docs.mk
@@ -5,4 +5,5 @@ docs: bin/plantuml.jar
 
 bin/plantuml.jar:
 	mkdir -p bin
-	curl -Lo $@ https://sourceforge.net/projects/plantuml/files/1.2022.2/plantuml.1.2022.2.jar/download
+	# TODO: Seems that SF is showing updated one, but no download of the previous one we were using: curl -Lo $@ https://sourceforge.net/projects/plantuml/files/1.2022.2/plantuml.1.2022.2.jar/download
+	curl -Lo $@ https://sourceforge.net/projects/plantuml/files/1.2021.9/plantuml-nodot.1.2021.9.jar/download


### PR DESCRIPTION
In my test of the docs pr, plantuml was failing to download and netlify complained of corrupt JAR file

In the website the version we were using has disappeared, and the reported 2023 one is not listed, using 2021 in the interim until it's fixed