### PR TITLE
Fixing documentation

### DIFF
--- a/docs/mkdocs/developer/index.md
+++ b/docs/mkdocs/developer/index.md
@@ -17,7 +17,7 @@ Variables available at build time still reflect the actual kernel version.
 ## `Module` CRD
 
 ```yaml
-apiVersion: ooto.sigs.k8s.io/v1alpha1
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
   name: module-sample
@@ -85,10 +85,6 @@ KMM supports in-cluster builds of DriverContainer images when those are not made
 **On OCP**, the build mechanism would be BuildConfig (maybe Shipwright in the future) and we can leverage the
 integrated in-cluster registry.
 
-## Unloading modules
-
-Users must provide a [preStop lifecycle hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) to their DriverContainer pod template to make sure that their module is unloaded when the DriverContainer pod exits.
-
 ## Security
 
 ### DriverContainer privileges
@@ -103,5 +99,6 @@ The KMM Operator would only be granted a limited set of Kubernetes API privilege
 - Read, modify (for kernel version labeling) and watch `Nodes`;
 - Read and watch `Modules`, update their status;
 - Read, create, modify and watch `DaemonSets`;
-- Read, create, modify and watch `Build` objects (from whatever system we agree on);
+- Read, create, modify and watch `Job` objects (used for building and signing);
 - Read `Secrets` for pull and build secrets.
+- Read `Configmaps` for build jobs

--- a/docs/mkdocs/developer/use_cases.md
+++ b/docs/mkdocs/developer/use_cases.md
@@ -17,8 +17,8 @@ For each `DaemonSet` belonging to `Module`, we set the following labels:
 
 | key                                          | value         |
 | -------------------------------------------- | ------------- |
-| `ooto.sigs.k8s.io/module-name`               | `$moduleName` |
-| `oot.node.kubernetes.io/kernel-version.full` | `$kernel`     |
+| `kmm.node.kubernetes.io/module-name`               | `$moduleName` |
+| `kmm.node.kubernetes.io/kernel-version.full` | `$kernel`     |
 
 We either create those `DaemonSets` (if they do not already exist) or update them (if a `DaemonSet` already exists with
 the same labels).


### PR DESCRIPTION
Removing section regarding pre-stop lifecycle that needs to be supplied by user and updatting the correct prefixes for labels and apiVersion