### PR TITLE
Remove unnecessary ServiceAccounts used in the operator namespace

### DIFF
--- a/config/rbac/device_plugin_service_account.yaml
+++ b/config/rbac/device_plugin_service_account.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: device-plugin
-  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,5 +1,3 @@
 resources:
   - ../rbac-base
-  - module_loader_service_account.yaml
-  - device_plugin_service_account.yaml
   - role.yaml

--- a/config/rbac/module_loader_service_account.yaml
+++ b/config/rbac/module_loader_service_account.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: module-loader
-  namespace: system

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -334,7 +334,7 @@ func (r *ModuleReconciler) handleDriverContainer(ctx context.Context,
 	}
 
 	opRes, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, func() error {
-		return r.daemonAPI.SetDriverContainerAsDesired(ctx, ds, km.ContainerImage, *mod, kernelVersion, mod.Namespace == r.operatorNamespace)
+		return r.daemonAPI.SetDriverContainerAsDesired(ctx, ds, km.ContainerImage, *mod, kernelVersion)
 	})
 
 	if err == nil {
@@ -364,7 +364,7 @@ func (r *ModuleReconciler) handleDevicePlugin(ctx context.Context, mod *kmmv1bet
 	}
 
 	opRes, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, func() error {
-		return r.daemonAPI.SetDevicePluginAsDesired(ctx, ds, mod, mod.Namespace == r.operatorNamespace)
+		return r.daemonAPI.SetDevicePluginAsDesired(ctx, ds, mod)
 	})
 
 	if err == nil {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -126,7 +126,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			mockDC.EXPECT().SetDevicePluginAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&mod), true),
+			mockDC.EXPECT().SetDevicePluginAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&mod)),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 		)
@@ -356,7 +356,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 			mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, &mod),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion, true),
+			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.New[string](kernelVersion)),
@@ -468,8 +468,8 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, &mod),
 			mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 			mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, &mod),
-			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion, true).Do(
-				func(ctx context.Context, d *appsv1.DaemonSet, _ string, _ kmmv1beta1.Module, _ string, _ bool) {
+			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion).Do(
+				func(ctx context.Context, d *appsv1.DaemonSet, _ string, _ kmmv1beta1.Module, _ string) {
 					d.SetLabels(map[string]string{"test": "test"})
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.New[string](kernelVersion)),
@@ -550,7 +550,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(nil, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			mockDC.EXPECT().SetDevicePluginAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&mod), true),
+			mockDC.EXPECT().SetDevicePluginAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&mod)),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, nil, sets.New[string]()),

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), nil, "", kmmv1beta1.Module{}, "", false),
+			dg.SetDriverContainerAsDesired(context.Background(), nil, "", kmmv1beta1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -51,7 +51,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the image is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, "", false),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -59,7 +59,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the kernel version is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, "", false),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, ""),
 		).To(
 			HaveOccurred(),
 		)
@@ -74,7 +74,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion, false)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
@@ -114,29 +114,13 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion, false)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
 		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[1]).To(Equal(volm))
 	})
-
-	DescribeTable("should add the default ServiceAccount to the module loader",
-		func(useDefaultSA bool, expectedSA string) {
-			mod := kmmv1beta1.Module{
-				Spec: kmmv1beta1.ModuleSpec{},
-			}
-
-			ds := appsv1.DaemonSet{}
-
-			err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion, useDefaultSA)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(expectedSA))
-		},
-		Entry(nil, false, ""),
-		Entry(nil, true, "kmm-operator-module-loader"),
-	)
 
 	It("should work as expected", func() {
 		const (
@@ -174,7 +158,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, moduleLoaderImage, mod, kernelVersion, false)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, moduleLoaderImage, mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -365,7 +349,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDevicePluginAsDesired(context.Background(), nil, &kmmv1beta1.Module{}, false),
+			dg.SetDevicePluginAsDesired(context.Background(), nil, &kmmv1beta1.Module{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -374,7 +358,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 	It("should return an error if DevicePlugin not set in the Spec", func() {
 		ds := appsv1.DaemonSet{}
 		Expect(
-			dg.SetDevicePluginAsDesired(context.Background(), &ds, &kmmv1beta1.Module{}, false),
+			dg.SetDevicePluginAsDesired(context.Background(), &ds, &kmmv1beta1.Module{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -394,29 +378,11 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
 	})
-
-	DescribeTable("should add the default ServiceAccount to the device plugin",
-		func(useDefaultSA bool, expectedSA string) {
-			mod := kmmv1beta1.Module{
-				Spec: kmmv1beta1.ModuleSpec{
-					DevicePlugin: &kmmv1beta1.DevicePluginSpec{},
-				},
-			}
-
-			ds := appsv1.DaemonSet{}
-
-			err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, useDefaultSA)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(expectedSA))
-		},
-		Entry(nil, false, ""),
-		Entry(nil, true, "kmm-operator-device-plugin"),
-	)
 
 	It("should work as expected", func() {
 		const (
@@ -494,7 +460,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod)
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -83,29 +83,29 @@ func (mr *MockDaemonSetCreatorMockRecorder) ModuleDaemonSetsByKernelVersion(ctx,
 }
 
 // SetDevicePluginAsDesired mocks base method.
-func (m *MockDaemonSetCreator) SetDevicePluginAsDesired(ctx context.Context, ds *v1.DaemonSet, mod *v1beta1.Module, useDefaultSA bool) error {
+func (m *MockDaemonSetCreator) SetDevicePluginAsDesired(ctx context.Context, ds *v1.DaemonSet, mod *v1beta1.Module) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDevicePluginAsDesired", ctx, ds, mod, useDefaultSA)
+	ret := m.ctrl.Call(m, "SetDevicePluginAsDesired", ctx, ds, mod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetDevicePluginAsDesired indicates an expected call of SetDevicePluginAsDesired.
-func (mr *MockDaemonSetCreatorMockRecorder) SetDevicePluginAsDesired(ctx, ds, mod, useDefaultSA interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) SetDevicePluginAsDesired(ctx, ds, mod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicePluginAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDevicePluginAsDesired), ctx, ds, mod, useDefaultSA)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevicePluginAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDevicePluginAsDesired), ctx, ds, mod)
 }
 
 // SetDriverContainerAsDesired mocks base method.
-func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, image string, mod v1beta1.Module, kernelVersion string, useDefaultSA bool) error {
+func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, image string, mod v1beta1.Module, kernelVersion string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, image, mod, kernelVersion, useDefaultSA)
+	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, image, mod, kernelVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetDriverContainerAsDesired indicates an expected call of SetDriverContainerAsDesired.
-func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, image, mod, kernelVersion, useDefaultSA interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, image, mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, image, mod, kernelVersion, useDefaultSA)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, image, mod, kernelVersion)
 }


### PR DESCRIPTION
The ModuleLoader and DevicePlugin ServiceAccounts created in the operator's namespace via the OLM bundle and used as default ServiceAccounts in the respective workloads are unnecessary. Users are free to use the default namespace ServiceAccount or any ServiceAccounts they dim necessary.

If Pod Security Admission is enabled in the cluster, an administrator needs to configure the level for the namespace where the `Module` is deployed for the ModuleLoader and device plugin pods to work.

- https://kubernetes.io/docs/concepts/security/pod-security-admission/

Signed-off-by: Michail Resvanis <mresvani@redhat.com>