### PR TITLE
Fixes edit-uri for documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 site_name: Kernel Module Management
 repo_url: https://github.com/kubernetes-sigs/kernel-module-management
-edit_uri: edit/main/docs/
+edit_uri: edit/main/docs/mkdocs
 
 docs_dir: mkdocs
 strict: true


### PR DESCRIPTION
Current [Edit on GitHub](https://github.com/kubernetes-sigs/kernel-module-management/edit/main/docs/index.md) link lands on a 404 because, I think, the docs are under `mkdocs` directory.
