### PR TITLE
Wrap assertions into Ginkgo `It` blocks

### DIFF
--- a/internal/utils/replaceStrings_test.go
+++ b/internal/utils/replaceStrings_test.go
@@ -6,34 +6,38 @@ import (
 )
 
 var _ = Describe("KernelComponentsAsEnvVars", func() {
-	const kernelVersion = "6.0.15-300.fc37.x86_64"
+	It("should work as expected", func() {
+		const kernelVersion = "6.0.15-300.fc37.x86_64"
 
-	expected := []string{
-		"KERNEL_FULL_VERSION=" + kernelVersion,
-		"KERNEL_VERSION=" + kernelVersion,
-		"KERNEL_XYZ=6.0.15",
-		"KERNEL_X=6",
-		"KERNEL_Y=0",
-		"KERNEL_Z=15",
-	}
+		expected := []string{
+			"KERNEL_FULL_VERSION=" + kernelVersion,
+			"KERNEL_VERSION=" + kernelVersion,
+			"KERNEL_XYZ=6.0.15",
+			"KERNEL_X=6",
+			"KERNEL_Y=0",
+			"KERNEL_Z=15",
+		}
 
-	Expect(KernelComponentsAsEnvVars(kernelVersion)).To(Equal(expected))
+		Expect(KernelComponentsAsEnvVars(kernelVersion)).To(Equal(expected))
+	})
 })
 
 var _ = Describe("ReplaceInTemplates", func() {
-	vars := []string{"A=AAA", "B=BBB", "C=CCC"}
+	It("should work as expected", func() {
+		vars := []string{"A=AAA", "B=BBB", "C=CCC"}
 
-	templates := []string{
-		"string with template $A",
-		"string with template ${B}",
-		"string without template",
-	}
+		templates := []string{
+			"string with template $A",
+			"string with template ${B}",
+			"string without template",
+		}
 
-	expected := []string{
-		"string with template AAA",
-		"string with template BBB",
-		"string without template",
-	}
+		expected := []string{
+			"string with template AAA",
+			"string with template BBB",
+			"string without template",
+		}
 
-	Expect(ReplaceInTemplates(vars, templates...)).To(Equal(expected))
+		Expect(ReplaceInTemplates(vars, templates...)).To(Equal(expected))
+	})
 })


### PR DESCRIPTION
Ginkgo / Gomega require assertions to be within `It` blocks.

/cc @yevgeny-shnaidman