### PR TITLE
Simplifying KernelAPI interface

### DIFF
--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -284,8 +284,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			},
 		}
 
-		osConfig := module.NodeOSConfig{}
-
 		mod := kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      moduleName,
@@ -347,9 +345,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 					return nil
 				},
 			),
-			mockKM.EXPECT().GetNodeOSConfig(&nodeList.Items[0]).Return(&osConfig),
-			mockKM.EXPECT().FindMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
-			mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+			mockKM.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 			mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, &mod),
@@ -376,8 +372,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			kernelVersion      = "1.2.3"
 			serviceAccountName = "module-loader-service-account"
 		)
-
-		osConfig := module.NodeOSConfig{}
 
 		mappings := []kmmv1beta1.KernelMapping{
 			{
@@ -460,9 +454,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		dsByKernelVersion := map[string]*appsv1.DaemonSet{kernelVersion: &ds}
 
 		gomock.InOrder(
-			mockKM.EXPECT().GetNodeOSConfig(&nodeList.Items[0]).Return(&osConfig),
-			mockKM.EXPECT().FindMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
-			mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+			mockKM.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 			mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, &mod),

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -145,7 +145,6 @@ func (c *clusterAPI) kernelMappingsByKernelVersion(
 	logger := log.FromContext(ctx)
 
 	for _, kernelVersion := range kernelVersions {
-		osConfig := c.kernelAPI.GetNodeOSConfigFromKernelVersion(kernelVersion)
 		kernelVersion := strings.TrimSuffix(kernelVersion, "+")
 
 		kernelVersionLogger := logger.WithValues(
@@ -157,15 +156,9 @@ func (c *clusterAPI) kernelMappingsByKernelVersion(
 			continue
 		}
 
-		m, err := c.kernelAPI.FindMappingForKernel(modSpec, kernelVersion)
+		m, err := c.kernelAPI.GetMergedMappingForKernel(modSpec, kernelVersion)
 		if err != nil {
 			kernelVersionLogger.Info("no suitable container image found; skipping kernel version")
-			continue
-		}
-
-		m, err = c.kernelAPI.PrepareKernelMapping(m, osConfig)
-		if err != nil {
-			kernelVersionLogger.Info("failed to substitute the template variables in the mapping", "error", err)
 			continue
 		}
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -173,8 +173,6 @@ var _ = Describe("ClusterAPI", func() {
 		)
 
 		var (
-			osConfig = module.NodeOSConfig{}
-
 			mappings = []kmmv1beta1.KernelMapping{
 				{
 					ContainerImage: imageName,
@@ -231,8 +229,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should do nothing when no kernel mappings are found", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(nil, errors.New("generic-error")),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(nil, errors.New("generic-error")),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -263,9 +260,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should do nothing when Build and Sign are not needed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
 				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
 			)
@@ -279,9 +274,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should run build sync if needed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm),
 				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
@@ -296,9 +289,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should return an error when build sync errors", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(build.Result{}, errors.New("test-error")),
 			)
@@ -315,9 +306,7 @@ var _ = Describe("ClusterAPI", func() {
 			signResult := utils.Result{Requeue: true}
 
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
 				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, mcm).Return(signResult, nil),
@@ -332,9 +321,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should return an error when sign sync errors", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
 				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, mcm).Return(utils.Result{}, errors.New("test-error")),
@@ -349,9 +336,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should not run sign sync when build sync requires a requeue", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(build.Result{Requeue: true}, nil),
 			)
@@ -365,9 +350,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should run both build sync and sign sync when build does not require a requeue", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetNodeOSConfigFromKernelVersion(kernelVersion).Return(&osConfig),
-				mockKM.EXPECT().FindMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockKM.EXPECT().PrepareKernelMapping(&mappings[0], &osConfig).Return(&mappings[0], nil),
+				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
 				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
 				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(build.Result{Requeue: false}, nil),
 				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -3,88 +3,68 @@ package module
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
-	"strings"
 
-	"github.com/a8m/envsubst/parse"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
-	v1 "k8s.io/api/core/v1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
-const (
-	kernelVersionMajorIdx = 0
-	kernelVersionMinorIdx = 1
-	kernelVersionPatchIdx = 2
-)
-
-type NodeOSConfig struct {
-	KernelFullVersion  string `subst:"KERNEL_FULL_VERSION"`
-	KernelVersionMMP   string `subst:"KERNEL_XYZ"`
-	KernelVersionMajor string `subst:"KERNEL_X"`
-	KernelVersionMinor string `subst:"KERNEL_Y"`
-	KernelVersionPatch string `subst:"KERNEL_Z"`
-}
-
-//go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go
+//go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go KernelMapper,kernelMapperHelperAPI
 
 type KernelMapper interface {
-	FindMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
-	GetNodeOSConfig(node *v1.Node) *NodeOSConfig
-	GetNodeOSConfigFromKernelVersion(kernelVersion string) *NodeOSConfig
-	PrepareKernelMapping(mapping *kmmv1beta1.KernelMapping, osConfig *NodeOSConfig) (*kmmv1beta1.KernelMapping, error)
+	GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
 }
 
 type kernelMapper struct {
-	buildHelper build.Helper
-	signHelper  sign.Helper
+	helper kernelMapperHelperAPI
 }
 
 func NewKernelMapper(buildHelper build.Helper, signHelper sign.Helper) KernelMapper {
 	return &kernelMapper{
+		helper: newKernelMapperHelper(buildHelper, signHelper),
+	}
+}
+
+func (k *kernelMapper) GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
+	mappings := modSpec.ModuleLoader.Container.KernelMappings
+	foundMapping, err := k.helper.findKernelMapping(mappings, kernelVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find mapping for kernel %s: %v", kernelVersion, err)
+	}
+	mapping := foundMapping.DeepCopy()
+	err = k.helper.mergeMappingData(mapping, modSpec, kernelVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare module loader data for kernel %s: %v", kernelVersion, err)
+	}
+
+	err = k.helper.replaceTemplates(mapping, kernelVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to replace templates in module loader data for kernel %s: %v", kernelVersion, err)
+	}
+	return mapping, nil
+}
+
+type kernelMapperHelperAPI interface {
+	findKernelMapping(mappings []kmmv1beta1.KernelMapping, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
+	mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error
+	replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error
+}
+
+type kernelMapperHelper struct {
+	buildHelper build.Helper
+	signHelper  sign.Helper
+}
+
+func newKernelMapperHelper(buildHelper build.Helper, signHelper sign.Helper) kernelMapperHelperAPI {
+	return &kernelMapperHelper{
 		buildHelper: buildHelper,
 		signHelper:  signHelper,
 	}
 }
 
-// FindMappingForKernel tries to match kernelVersion against mappings. It returns the first mapping that has a Literal
-// field equal to kernelVersion or a Regexp field that matches kernelVersion.
-func (k *kernelMapper) FindMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
-	mappings := modSpec.ModuleLoader.Container.KernelMappings
-	foundMapping, err := k.findKernelMapping(mappings, kernelVersion)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find mapping for kernel %s: %v", kernelVersion, err)
-	}
-	mapping := foundMapping.DeepCopy()
-
-	// prepare the build for the mapping
-	if mapping.Build != nil || modSpec.ModuleLoader.Container.Build != nil {
-		mapping.Build = k.buildHelper.GetRelevantBuild(modSpec.ModuleLoader.Container.Build, mapping.Build)
-	}
-
-	// prepare the sign for the mapping
-	if mapping.Sign != nil || modSpec.ModuleLoader.Container.Sign != nil {
-		mapping.Sign, err = k.signHelper.GetRelevantSign(modSpec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
-		}
-	}
-
-	// prepare TLS options
-	if mapping.RegistryTLS == nil {
-		mapping.RegistryTLS = &modSpec.ModuleLoader.Container.RegistryTLS
-	}
-
-	//prepare container image
-	if mapping.ContainerImage == "" {
-		mapping.ContainerImage = modSpec.ModuleLoader.Container.ContainerImage
-	}
-	return mapping, nil
-}
-
-func (k *kernelMapper) findKernelMapping(mappings []kmmv1beta1.KernelMapping, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
+func (kh *kernelMapperHelper) findKernelMapping(mappings []kmmv1beta1.KernelMapping, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
 	for _, m := range mappings {
 		if m.Literal != "" && m.Literal == kernelVersion {
 			return &m, nil
@@ -104,47 +84,42 @@ func (k *kernelMapper) findKernelMapping(mappings []kmmv1beta1.KernelMapping, ke
 	return nil, errors.New("no suitable mapping found")
 }
 
-func (k *kernelMapper) GetNodeOSConfig(node *v1.Node) *NodeOSConfig {
-	return k.GetNodeOSConfigFromKernelVersion(node.Status.NodeInfo.KernelVersion)
+func (kh *kernelMapperHelper) mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error {
+	var err error
+
+	// prepare the build
+	if mapping.Build != nil || modSpec.ModuleLoader.Container.Build != nil {
+		mapping.Build = kh.buildHelper.GetRelevantBuild(modSpec.ModuleLoader.Container.Build, mapping.Build)
+	}
+
+	// prepare the sign
+	if mapping.Sign != nil || modSpec.ModuleLoader.Container.Sign != nil {
+		mapping.Sign, err = kh.signHelper.GetRelevantSign(modSpec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
+		if err != nil {
+			return fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
+		}
+	}
+
+	// prepare TLS options
+	if mapping.RegistryTLS == nil {
+		mapping.RegistryTLS = &modSpec.ModuleLoader.Container.RegistryTLS
+	}
+
+	//prepare container image
+	if mapping.ContainerImage == "" {
+		mapping.ContainerImage = modSpec.ModuleLoader.Container.ContainerImage
+	}
+
+	return nil
 }
 
-func (k *kernelMapper) GetNodeOSConfigFromKernelVersion(kernelVersion string) *NodeOSConfig {
-	osConfig := NodeOSConfig{}
-
-	osConfigFieldsList := regexp.MustCompile("[.,-]").Split(kernelVersion, -1)
-
-	osConfig.KernelFullVersion = kernelVersion
-	osConfig.KernelVersionMMP = strings.Join(osConfigFieldsList[:kernelVersionPatchIdx+1], ".")
-	osConfig.KernelVersionMajor = osConfigFieldsList[kernelVersionMajorIdx]
-	osConfig.KernelVersionMinor = osConfigFieldsList[kernelVersionMinorIdx]
-	osConfig.KernelVersionPatch = osConfigFieldsList[kernelVersionPatchIdx]
-
-	return &osConfig
-}
-
-func (k *kernelMapper) PrepareKernelMapping(mapping *kmmv1beta1.KernelMapping, osConfig *NodeOSConfig) (*kmmv1beta1.KernelMapping, error) {
-	osConfigStrings := k.prepareOSConfigList(*osConfig)
-
-	parser := parse.New("mapping", osConfigStrings, &parse.Restrictions{})
-
-	substContainerImage, err := parser.Parse(mapping.ContainerImage)
+func (kh *kernelMapperHelper) replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error {
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(kernelVersion)
+	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mapping.ContainerImage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to substitute the os config into ContainerImage field: %w", err)
+		return fmt.Errorf("failed to substitute templates in the ContainerImage field: %v", err)
 	}
+	mapping.ContainerImage = replacedContainerImage[0]
 
-	substMapping := mapping.DeepCopy()
-	substMapping.ContainerImage = substContainerImage
-
-	return substMapping, nil
-}
-
-func (k *kernelMapper) prepareOSConfigList(osConfig NodeOSConfig) []string {
-	t := reflect.TypeOf(osConfig)
-	v := reflect.ValueOf(osConfig)
-
-	varList := make([]string, t.NumField())
-	for i := 0; i < t.NumField(); i++ {
-		varList[i] = t.Field(i).Tag.Get("subst") + "=" + v.Field(i).String()
-	}
-	return varList
+	return nil
 }

--- a/internal/module/mock_kernelmapper.go
+++ b/internal/module/mock_kernelmapper.go
@@ -9,7 +9,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	v1 "k8s.io/api/core/v1"
 )
 
 // MockKernelMapper is a mock of KernelMapper interface.
@@ -35,60 +34,83 @@ func (m *MockKernelMapper) EXPECT() *MockKernelMapperMockRecorder {
 	return m.recorder
 }
 
-// FindMappingForKernel mocks base method.
-func (m *MockKernelMapper) FindMappingForKernel(modSpec *v1beta1.ModuleSpec, kernelVersion string) (*v1beta1.KernelMapping, error) {
+// GetMergedMappingForKernel mocks base method.
+func (m *MockKernelMapper) GetMergedMappingForKernel(modSpec *v1beta1.ModuleSpec, kernelVersion string) (*v1beta1.KernelMapping, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindMappingForKernel", modSpec, kernelVersion)
+	ret := m.ctrl.Call(m, "GetMergedMappingForKernel", modSpec, kernelVersion)
 	ret0, _ := ret[0].(*v1beta1.KernelMapping)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindMappingForKernel indicates an expected call of FindMappingForKernel.
-func (mr *MockKernelMapperMockRecorder) FindMappingForKernel(modSpec, kernelVersion interface{}) *gomock.Call {
+// GetMergedMappingForKernel indicates an expected call of GetMergedMappingForKernel.
+func (mr *MockKernelMapperMockRecorder) GetMergedMappingForKernel(modSpec, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMappingForKernel", reflect.TypeOf((*MockKernelMapper)(nil).FindMappingForKernel), modSpec, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedMappingForKernel", reflect.TypeOf((*MockKernelMapper)(nil).GetMergedMappingForKernel), modSpec, kernelVersion)
 }
 
-// GetNodeOSConfig mocks base method.
-func (m *MockKernelMapper) GetNodeOSConfig(node *v1.Node) *NodeOSConfig {
+// MockkernelMapperHelperAPI is a mock of kernelMapperHelperAPI interface.
+type MockkernelMapperHelperAPI struct {
+	ctrl     *gomock.Controller
+	recorder *MockkernelMapperHelperAPIMockRecorder
+}
+
+// MockkernelMapperHelperAPIMockRecorder is the mock recorder for MockkernelMapperHelperAPI.
+type MockkernelMapperHelperAPIMockRecorder struct {
+	mock *MockkernelMapperHelperAPI
+}
+
+// NewMockkernelMapperHelperAPI creates a new mock instance.
+func NewMockkernelMapperHelperAPI(ctrl *gomock.Controller) *MockkernelMapperHelperAPI {
+	mock := &MockkernelMapperHelperAPI{ctrl: ctrl}
+	mock.recorder = &MockkernelMapperHelperAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockkernelMapperHelperAPI) EXPECT() *MockkernelMapperHelperAPIMockRecorder {
+	return m.recorder
+}
+
+// findKernelMapping mocks base method.
+func (m *MockkernelMapperHelperAPI) findKernelMapping(mappings []v1beta1.KernelMapping, kernelVersion string) (*v1beta1.KernelMapping, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeOSConfig", node)
-	ret0, _ := ret[0].(*NodeOSConfig)
-	return ret0
-}
-
-// GetNodeOSConfig indicates an expected call of GetNodeOSConfig.
-func (mr *MockKernelMapperMockRecorder) GetNodeOSConfig(node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeOSConfig", reflect.TypeOf((*MockKernelMapper)(nil).GetNodeOSConfig), node)
-}
-
-// GetNodeOSConfigFromKernelVersion mocks base method.
-func (m *MockKernelMapper) GetNodeOSConfigFromKernelVersion(kernelVersion string) *NodeOSConfig {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeOSConfigFromKernelVersion", kernelVersion)
-	ret0, _ := ret[0].(*NodeOSConfig)
-	return ret0
-}
-
-// GetNodeOSConfigFromKernelVersion indicates an expected call of GetNodeOSConfigFromKernelVersion.
-func (mr *MockKernelMapperMockRecorder) GetNodeOSConfigFromKernelVersion(kernelVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeOSConfigFromKernelVersion", reflect.TypeOf((*MockKernelMapper)(nil).GetNodeOSConfigFromKernelVersion), kernelVersion)
-}
-
-// PrepareKernelMapping mocks base method.
-func (m *MockKernelMapper) PrepareKernelMapping(mapping *v1beta1.KernelMapping, osConfig *NodeOSConfig) (*v1beta1.KernelMapping, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareKernelMapping", mapping, osConfig)
+	ret := m.ctrl.Call(m, "findKernelMapping", mappings, kernelVersion)
 	ret0, _ := ret[0].(*v1beta1.KernelMapping)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PrepareKernelMapping indicates an expected call of PrepareKernelMapping.
-func (mr *MockKernelMapperMockRecorder) PrepareKernelMapping(mapping, osConfig interface{}) *gomock.Call {
+// findKernelMapping indicates an expected call of findKernelMapping.
+func (mr *MockkernelMapperHelperAPIMockRecorder) findKernelMapping(mappings, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareKernelMapping", reflect.TypeOf((*MockKernelMapper)(nil).PrepareKernelMapping), mapping, osConfig)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "findKernelMapping", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).findKernelMapping), mappings, kernelVersion)
+}
+
+// mergeMappingData mocks base method.
+func (m *MockkernelMapperHelperAPI) mergeMappingData(mapping *v1beta1.KernelMapping, modSpec *v1beta1.ModuleSpec, kernelVersion string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "mergeMappingData", mapping, modSpec, kernelVersion)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// mergeMappingData indicates an expected call of mergeMappingData.
+func (mr *MockkernelMapperHelperAPIMockRecorder) mergeMappingData(mapping, modSpec, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeMappingData", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).mergeMappingData), mapping, modSpec, kernelVersion)
+}
+
+// replaceTemplates mocks base method.
+func (m *MockkernelMapperHelperAPI) replaceTemplates(mapping *v1beta1.KernelMapping, kernelVersion string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "replaceTemplates", mapping, kernelVersion)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// replaceTemplates indicates an expected call of replaceTemplates.
+func (mr *MockkernelMapperHelperAPIMockRecorder) replaceTemplates(mapping, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "replaceTemplates", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).replaceTemplates), mapping, kernelVersion)
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -54,15 +54,9 @@ type preflight struct {
 func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 	kernelVersion := pv.Spec.KernelVersion
-	mapping, err := p.kernelAPI.FindMappingForKernel(&mod.Spec, kernelVersion)
+	mapping, err := p.kernelAPI.GetMergedMappingForKernel(&mod.Spec, kernelVersion)
 	if err != nil {
-		return false, fmt.Sprintf("Failed to find kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
-	}
-
-	osConfig := module.NodeOSConfig{KernelFullVersion: kernelVersion}
-	mapping, err = p.kernelAPI.PrepareKernelMapping(mapping, &osConfig)
-	if err != nil {
-		return false, fmt.Sprintf("Failed to substitute template in kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
+		return false, fmt.Sprintf("failed to process kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
 	}
 
 	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageImage)


### PR DESCRIPTION
Currently KernelAPI consists of 4 functions, which are always used together in a sequence. This redifines the KernelAPI interface to contain only one functions that does everything the previous 4 functions were doing. In addtion a private helper interface is defined, and its function are used by the KernelAPI interface