### PR TITLE
Creating ModuleLoaderData sturcture for Build/Sign/ModuleLoader workflow

### DIFF
--- a/internal/api/moduleloaderdata.go
+++ b/internal/api/moduleloaderdata.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ModuleLoaderData contains all the data needed for succesfull execution of
+// Build,Sign, ModuleLoader flow per specific kernel. It is constructed at the begining
+// of the Reconciliation loop flow.It contains all the data after merging/resolving all the
+// definitions (Build/Sign configuration from KM or from Container, ContainerImage etc').
+// From that point on , it is the only structure that is needed as input, no need for
+// Module or for KernelMapping
+type ModuleLoaderData struct {
+	// kernel version
+	KernelVersion string
+	// Repo secret for DS images
+	ImageRepoSecret *v1.LocalObjectReference
+
+	// Selector for DS
+	Selector map[string]string
+
+	// Name
+	Name string
+
+	// Namspace
+	Namespace string
+
+	// service account for DS
+	ServiceAccountName string
+
+	// Build contains build instructions.
+	Build *kmmv1beta1.Build
+
+	// Sign provides default kmod signing settings
+	Sign *kmmv1beta1.Sign
+
+	// ContainerImage is a top-level field
+	ContainerImage string
+
+	// Image pull policy.
+	ImagePullPolicy v1.PullPolicy
+
+	// Modprobe is a set of properties to customize which module modprobe loads and with which properties.
+	Modprobe kmmv1beta1.ModprobeSpec
+
+	// RegistryTLS set the TLS configs for accessing the registry of the module-loader's image.
+	RegistryTLS *kmmv1beta1.TLSOptions
+
+	// used for setting the owner field of jobs/buildconfigs
+	Owner metav1.Object
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/kubernetes"
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,11 +45,11 @@ func (rsag *registrySecretAuthGetter) GetKeyChain(ctx context.Context) (authn.Ke
 	return keychain, nil
 }
 
-func NewRegistryAuthGetterFrom(client client.Client, mod *kmmv1beta1.Module) RegistryAuthGetter {
-	if mod.Spec.ImageRepoSecret != nil {
+func NewRegistryAuthGetterFrom(client client.Client, mld *api.ModuleLoaderData) RegistryAuthGetter {
+	if mld.ImageRepoSecret != nil {
 		namespacedName := types.NamespacedName{
-			Name:      mod.Spec.ImageRepoSecret.Name,
-			Namespace: mod.Namespace,
+			Name:      mld.ImageRepoSecret.Name,
+			Namespace: mld.Namespace,
 		}
 		return NewRegistryAuthGetter(client, namespacedName)
 	}

--- a/internal/build/job/mock_maker.go
+++ b/internal/build/job/mock_maker.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	v1 "k8s.io/api/batch/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,16 +38,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockMaker) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, owner v10.Object, pushImage bool) (*v1.Job, error) {
+func (m *MockMaker) MakeJobTemplate(ctx context.Context, mld *api.ModuleLoaderData, owner v10.Object, pushImage bool) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, owner, pushImage)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mld, owner, pushImage)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockMakerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, owner, pushImage interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeJobTemplate(ctx, mld, owner, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, owner, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockMaker)(nil).MakeJobTemplate), ctx, mld, owner, pushImage)
 }

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
@@ -14,16 +14,11 @@ import (
 type Manager interface {
 	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
-	ShouldSync(
-		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping) (bool, error)
+	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 
 	Sync(
 		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping,
-		targetKernel string,
+		mld *api.ModuleLoaderData,
 		pushImage bool,
 		owner metav1.Object) (utils.Status, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	utils "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,31 +53,31 @@ func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner
 }
 
 // ShouldSync mocks base method.
-func (m_2 *MockManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+func (m *MockManager) ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSync", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ShouldSync indicates an expected call of ShouldSync.
-func (mr *MockManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) ShouldSync(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mod, m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mld)
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (utils.Status, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage, owner)
+func (m *MockManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner v1.Object) (utils.Status, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sync", ctx, mld, pushImage, owner)
 	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mld, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mld, pushImage, owner)
 }

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	. "github.com/onsi/ginkgo/v2"
@@ -43,7 +44,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), nil, "", kmmv1beta1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), nil, &api.ModuleLoaderData{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -51,7 +52,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the image is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}),
 		).To(
 			HaveOccurred(),
 		)
@@ -59,22 +60,23 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the kernel version is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, "", kmmv1beta1.Module{}, ""),
+			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}),
 		).To(
 			HaveOccurred(),
 		)
 	})
 
-	It("should not add a device-plugin container if it is not set in the spec", func() {
-		mod := kmmv1beta1.Module{
-			Spec: kmmv1beta1.ModuleSpec{
-				Selector: map[string]string{"has-feature-x": "true"},
-			},
+	It("should have one container in the pod", func() {
+		mld := api.ModuleLoaderData{
+			Selector:       map[string]string{"has-feature-x": "true"},
+			Owner:          &kmmv1beta1.Module{},
+			ContainerImage: "some images",
+			KernelVersion:  kernelVersion,
 		}
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
@@ -97,24 +99,19 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			MountPath: "/var/lib/firmware",
 		}
 
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: moduleName,
+		mld := api.ModuleLoaderData{
+			Name: moduleName,
+			Modprobe: kmmv1beta1.ModprobeSpec{
+				FirmwarePath: "/opt/lib/firmware/example",
 			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
-					Container: kmmv1beta1.ModuleLoaderContainerSpec{
-						Modprobe: kmmv1beta1.ModprobeSpec{
-							FirmwarePath: "/opt/lib/firmware/example",
-						},
-					},
-				},
-			},
+			Owner:          &kmmv1beta1.Module{},
+			ContainerImage: "some image",
+			KernelVersion:  kernelVersion,
 		}
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
@@ -139,16 +136,17 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				Name:      moduleName,
 				Namespace: namespace,
 			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
-					Container: kmmv1beta1.ModuleLoaderContainerSpec{
-						Modprobe: kmmv1beta1.ModprobeSpec{ModuleName: "some-kmod"},
-					},
-					ServiceAccountName: serviceAccountName,
-				},
-				ImageRepoSecret: &v1.LocalObjectReference{Name: imageRepoSecretName},
-				Selector:        map[string]string{"has-feature-x": "true"},
-			},
+		}
+		mld := api.ModuleLoaderData{
+			Name:               moduleName,
+			Namespace:          namespace,
+			ServiceAccountName: serviceAccountName,
+			ContainerImage:     moduleLoaderImage,
+			ImageRepoSecret:    &v1.LocalObjectReference{Name: imageRepoSecretName},
+			Selector:           map[string]string{"has-feature-x": "true"},
+			Modprobe:           kmmv1beta1.ModprobeSpec{ModuleName: "some-kmod"},
+			Owner:              &mod,
+			KernelVersion:      kernelVersion,
 		}
 
 		ds := appsv1.DaemonSet{
@@ -158,7 +156,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, moduleLoaderImage, mod, kernelVersion)
+		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld)
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -200,12 +198,12 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								Lifecycle: &v1.Lifecycle{
 									PostStart: &v1.LifecycleHandler{
 										Exec: &v1.ExecAction{
-											Command: MakeLoadCommand(mod.Spec.ModuleLoader.Container.Modprobe, moduleName),
+											Command: MakeLoadCommand(mld.Modprobe, moduleName),
 										},
 									},
 									PreStop: &v1.LifecycleHandler{
 										Exec: &v1.ExecAction{
-											Command: MakeUnloadCommand(mod.Spec.ModuleLoader.Container.Modprobe, moduleName),
+											Command: MakeUnloadCommand(mld.Modprobe, moduleName),
 										},
 									},
 								},
@@ -267,14 +265,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 			dc := NewCreator(clnt, kernelLabel, scheme)
 
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-			}
-
-			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
+			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).To(BeEmpty())
 		})
@@ -283,14 +274,8 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 			dc := NewCreator(clnt, kernelLabel, scheme)
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-			}
 
-			_, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
+			_, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -328,14 +313,8 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			)
 
 			dc := NewCreator(clnt, kernelLabel, scheme)
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-			}
 
-			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), mod.Name, mod.Namespace)
+			m, err := dc.ModuleDaemonSetsByKernelVersion(context.Background(), moduleName, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).To(HaveLen(2))
 			Expect(m).To(HaveKeyWithValue(kernelVersion, &ds1))

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
@@ -97,15 +98,15 @@ func (mr *MockDaemonSetCreatorMockRecorder) SetDevicePluginAsDesired(ctx, ds, mo
 }
 
 // SetDriverContainerAsDesired mocks base method.
-func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, image string, mod v1beta1.Module, kernelVersion string) error {
+func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, mld *api.ModuleLoaderData) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, image, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, mld)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetDriverContainerAsDesired indicates an expected call of SetDriverContainerAsDesired.
-func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, image, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, image, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, mld)
 }

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -14,7 +15,7 @@ import (
 //go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go KernelMapper,kernelMapperHelperAPI
 
 type KernelMapper interface {
-	GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
+	GetModuleLoaderDataForKernel(mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error)
 }
 
 type kernelMapper struct {
@@ -27,29 +28,28 @@ func NewKernelMapper(buildHelper build.Helper, signHelper sign.Helper) KernelMap
 	}
 }
 
-func (k *kernelMapper) GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
-	mappings := modSpec.ModuleLoader.Container.KernelMappings
+func (k *kernelMapper) GetModuleLoaderDataForKernel(mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
+	mappings := mod.Spec.ModuleLoader.Container.KernelMappings
 	foundMapping, err := k.helper.findKernelMapping(mappings, kernelVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find mapping for kernel %s: %v", kernelVersion, err)
 	}
-	mapping := foundMapping.DeepCopy()
-	err = k.helper.mergeMappingData(mapping, modSpec, kernelVersion)
+	mld, err := k.helper.prepareModuleLoaderData(foundMapping, mod, kernelVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare module loader data for kernel %s: %v", kernelVersion, err)
 	}
 
-	err = k.helper.replaceTemplates(mapping, kernelVersion)
+	err = k.helper.replaceTemplates(mld)
 	if err != nil {
 		return nil, fmt.Errorf("failed to replace templates in module loader data for kernel %s: %v", kernelVersion, err)
 	}
-	return mapping, nil
+	return mld, nil
 }
 
 type kernelMapperHelperAPI interface {
 	findKernelMapping(mappings []kmmv1beta1.KernelMapping, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
-	mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error
-	replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error
+	prepareModuleLoaderData(mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error)
+	replaceTemplates(mld *api.ModuleLoaderData) error
 }
 
 type kernelMapperHelper struct {
@@ -84,42 +84,54 @@ func (kh *kernelMapperHelper) findKernelMapping(mappings []kmmv1beta1.KernelMapp
 	return nil, errors.New("no suitable mapping found")
 }
 
-func (kh *kernelMapperHelper) mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error {
+func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	var err error
 
+	mld := &api.ModuleLoaderData{}
 	// prepare the build
-	if mapping.Build != nil || modSpec.ModuleLoader.Container.Build != nil {
-		mapping.Build = kh.buildHelper.GetRelevantBuild(modSpec.ModuleLoader.Container.Build, mapping.Build)
+	if mapping.Build != nil || mod.Spec.ModuleLoader.Container.Build != nil {
+		mld.Build = kh.buildHelper.GetRelevantBuild(mod.Spec.ModuleLoader.Container.Build, mapping.Build)
 	}
 
 	// prepare the sign
-	if mapping.Sign != nil || modSpec.ModuleLoader.Container.Sign != nil {
-		mapping.Sign, err = kh.signHelper.GetRelevantSign(modSpec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
+	if mapping.Sign != nil || mod.Spec.ModuleLoader.Container.Sign != nil {
+		mld.Sign, err = kh.signHelper.GetRelevantSign(mod.Spec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
 		if err != nil {
-			return fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
+			return nil, fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
 		}
 	}
 
 	// prepare TLS options
+	mld.RegistryTLS = mapping.RegistryTLS
 	if mapping.RegistryTLS == nil {
-		mapping.RegistryTLS = &modSpec.ModuleLoader.Container.RegistryTLS
+		mld.RegistryTLS = &mod.Spec.ModuleLoader.Container.RegistryTLS
 	}
 
 	//prepare container image
+	mld.ContainerImage = mapping.ContainerImage
 	if mapping.ContainerImage == "" {
-		mapping.ContainerImage = modSpec.ModuleLoader.Container.ContainerImage
+		mld.ContainerImage = mod.Spec.ModuleLoader.Container.ContainerImage
 	}
 
-	return nil
+	mld.KernelVersion = kernelVersion
+	mld.Name = mod.Name
+	mld.Namespace = mod.Namespace
+	mld.ImageRepoSecret = mod.Spec.ImageRepoSecret
+	mld.Selector = mod.Spec.Selector
+	mld.ServiceAccountName = mod.Spec.ModuleLoader.ServiceAccountName
+	mld.Modprobe = mod.Spec.ModuleLoader.Container.Modprobe
+	mld.Owner = mod
+
+	return mld, nil
 }
 
-func (kh *kernelMapperHelper) replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error {
-	osConfigEnvVars := utils.KernelComponentsAsEnvVars(kernelVersion)
-	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mapping.ContainerImage)
+func (kh *kernelMapperHelper) replaceTemplates(mld *api.ModuleLoaderData) error {
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelVersion)
+	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mld.ContainerImage)
 	if err != nil {
 		return fmt.Errorf("failed to substitute templates in the ContainerImage field: %v", err)
 	}
-	mapping.ContainerImage = replacedContainerImage[0]
+	mld.ContainerImage = replacedContainerImage[0]
 
 	return nil
 }

--- a/internal/module/mock_kernelmapper.go
+++ b/internal/module/mock_kernelmapper.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 )
 
 // MockKernelMapper is a mock of KernelMapper interface.
@@ -34,19 +35,19 @@ func (m *MockKernelMapper) EXPECT() *MockKernelMapperMockRecorder {
 	return m.recorder
 }
 
-// GetMergedMappingForKernel mocks base method.
-func (m *MockKernelMapper) GetMergedMappingForKernel(modSpec *v1beta1.ModuleSpec, kernelVersion string) (*v1beta1.KernelMapping, error) {
+// GetModuleLoaderDataForKernel mocks base method.
+func (m *MockKernelMapper) GetModuleLoaderDataForKernel(mod *v1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMergedMappingForKernel", modSpec, kernelVersion)
-	ret0, _ := ret[0].(*v1beta1.KernelMapping)
+	ret := m.ctrl.Call(m, "GetModuleLoaderDataForKernel", mod, kernelVersion)
+	ret0, _ := ret[0].(*api.ModuleLoaderData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMergedMappingForKernel indicates an expected call of GetMergedMappingForKernel.
-func (mr *MockKernelMapperMockRecorder) GetMergedMappingForKernel(modSpec, kernelVersion interface{}) *gomock.Call {
+// GetModuleLoaderDataForKernel indicates an expected call of GetModuleLoaderDataForKernel.
+func (mr *MockKernelMapperMockRecorder) GetModuleLoaderDataForKernel(mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedMappingForKernel", reflect.TypeOf((*MockKernelMapper)(nil).GetMergedMappingForKernel), modSpec, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleLoaderDataForKernel", reflect.TypeOf((*MockKernelMapper)(nil).GetModuleLoaderDataForKernel), mod, kernelVersion)
 }
 
 // MockkernelMapperHelperAPI is a mock of kernelMapperHelperAPI interface.
@@ -87,30 +88,31 @@ func (mr *MockkernelMapperHelperAPIMockRecorder) findKernelMapping(mappings, ker
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "findKernelMapping", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).findKernelMapping), mappings, kernelVersion)
 }
 
-// mergeMappingData mocks base method.
-func (m *MockkernelMapperHelperAPI) mergeMappingData(mapping *v1beta1.KernelMapping, modSpec *v1beta1.ModuleSpec, kernelVersion string) error {
+// prepareModuleLoaderData mocks base method.
+func (m *MockkernelMapperHelperAPI) prepareModuleLoaderData(mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "mergeMappingData", mapping, modSpec, kernelVersion)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "prepareModuleLoaderData", mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(*api.ModuleLoaderData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// mergeMappingData indicates an expected call of mergeMappingData.
-func (mr *MockkernelMapperHelperAPIMockRecorder) mergeMappingData(mapping, modSpec, kernelVersion interface{}) *gomock.Call {
+// prepareModuleLoaderData indicates an expected call of prepareModuleLoaderData.
+func (mr *MockkernelMapperHelperAPIMockRecorder) prepareModuleLoaderData(mapping, mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeMappingData", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).mergeMappingData), mapping, modSpec, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareModuleLoaderData", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).prepareModuleLoaderData), mapping, mod, kernelVersion)
 }
 
 // replaceTemplates mocks base method.
-func (m *MockkernelMapperHelperAPI) replaceTemplates(mapping *v1beta1.KernelMapping, kernelVersion string) error {
+func (m *MockkernelMapperHelperAPI) replaceTemplates(mld *api.ModuleLoaderData) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "replaceTemplates", mapping, kernelVersion)
+	ret := m.ctrl.Call(m, "replaceTemplates", mld)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // replaceTemplates indicates an expected call of replaceTemplates.
-func (mr *MockkernelMapperHelperAPIMockRecorder) replaceTemplates(mapping, kernelVersion interface{}) *gomock.Call {
+func (mr *MockkernelMapperHelperAPIMockRecorder) replaceTemplates(mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "replaceTemplates", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).replaceTemplates), mapping, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "replaceTemplates", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).replaceTemplates), mld)
 }

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 )
 
 // MockPreflightAPI is a mock of PreflightAPI interface.
@@ -74,46 +75,46 @@ func (m *MockpreflightHelperAPI) EXPECT() *MockpreflightHelperAPIMockRecorder {
 }
 
 // verifyBuild mocks base method.
-func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, pv *v1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifyBuild", ctx, pv, mapping, mod)
+	ret := m.ctrl.Call(m, "verifyBuild", ctx, pv, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifyBuild indicates an expected call of verifyBuild.
-func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, pv, mapping, mod interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, pv, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, pv, mapping, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, pv, mld)
 }
 
 // verifyImage mocks base method.
-func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifyImage", ctx, mapping, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "verifyImage", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifyImage indicates an expected call of verifyImage.
-func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mld)
 }
 
 // verifySign mocks base method.
-func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mapping, mod)
+	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifySign indicates an expected call of verifySign.
-func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mapping, mod interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mapping, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mld)
 }

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/registry"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -54,19 +54,16 @@ func (jbm *signJobManager) GarbageCollect(ctx context.Context, modName, namespac
 	return deleteNames, nil
 }
 
-func (jbm *signJobManager) ShouldSync(
-	ctx context.Context,
-	mod kmmv1beta1.Module,
-	m kmmv1beta1.KernelMapping) (bool, error) {
+func (jbm *signJobManager) ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
 
 	// if there is no sign specified skip
-	if !module.ShouldBeSigned(m) {
+	if !module.ShouldBeSigned(mld) {
 		return false, nil
 	}
 
-	exists, err := module.ImageExists(ctx, jbm.client, jbm.registry, mod.Spec, mod.Namespace, m, m.ContainerImage)
+	exists, err := module.ImageExists(ctx, jbm.client, jbm.registry, mld, mld.Namespace, mld.ContainerImage)
 	if err != nil {
-		return false, fmt.Errorf("failed to check existence of image %s: %w", m.ContainerImage, err)
+		return false, fmt.Errorf("failed to check existence of image %s: %w", mld.ContainerImage, err)
 	}
 
 	return !exists, nil
@@ -74,9 +71,7 @@ func (jbm *signJobManager) ShouldSync(
 
 func (jbm *signJobManager) Sync(
 	ctx context.Context,
-	mod kmmv1beta1.Module,
-	m kmmv1beta1.KernelMapping,
-	targetKernel string,
+	mld *api.ModuleLoaderData,
 	imageToSign string,
 	pushImage bool,
 	owner metav1.Object) (utils.Status, error) {
@@ -85,14 +80,14 @@ func (jbm *signJobManager) Sync(
 
 	logger.Info("Signing in-cluster")
 
-	labels := jbm.jobHelper.JobLabels(mod.Name, targetKernel, "sign")
+	labels := jbm.jobHelper.JobLabels(mld.Name, mld.KernelVersion, "sign")
 
-	jobTemplate, err := jbm.signer.MakeJobTemplate(ctx, mod, m, targetKernel, labels, imageToSign, pushImage, owner)
+	jobTemplate, err := jbm.signer.MakeJobTemplate(ctx, mld, labels, imageToSign, pushImage, owner)
 	if err != nil {
 		return "", fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign, owner)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, mld.KernelVersion, utils.JobTypeSign, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return "", fmt.Errorf("error getting the signing job: %v", err)

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	v1 "k8s.io/api/batch/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,16 +38,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(ctx context.Context, mld *api.ModuleLoaderData, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mld, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mld, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mld, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
@@ -14,16 +14,11 @@ import (
 type SignManager interface {
 	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
-	ShouldSync(
-		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping) (bool, error)
+	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 
 	Sync(
 		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping,
-		targetKernel string,
+		mld *api.ModuleLoaderData,
 		imageToSign string,
 		pushImage bool,
 		owner metav1.Object) (utils.Status, error)

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	utils "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,31 +53,31 @@ func (mr *MockSignManagerMockRecorder) GarbageCollect(ctx, modName, namespace, o
 }
 
 // ShouldSync mocks base method.
-func (m_2 *MockSignManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+func (m *MockSignManager) ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSync", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ShouldSync indicates an expected call of ShouldSync.
-func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mod, m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mld)
 }
 
 // Sync mocks base method.
-func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Status, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+func (m *MockSignManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, imageToSign string, pushImage bool, owner v1.Object) (utils.Status, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sync", ctx, mld, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) Sync(ctx, mld, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mld, imageToSign, pushImage, owner)
 }


### PR DESCRIPTION
This PR add the creation of the ModuleLoaderData structure. This struct contains all the data needed for processing the wholw flow of Build/Sign/Module loader per specific Module/KernelMapping.
The flow ass following:
1) when starting processing the Reconcile request( either in Module controller
   or in ManagedCluster controller) all the needed data from Module and KernelMapping
   is merged into a newly created ModuleLoaderData struct
2) all the following layers are working only with this structure, no need to look
   at Module or KernelMapping again.
3) This does not affect the flow of DevicePlugin