### PR TITLE
Changing the metrics flow

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -141,7 +141,7 @@ func main() {
 		kernelAPI,
 		metricsAPI,
 		filterAPI,
-		statusupdater.NewModuleStatusUpdater(client, metricsAPI),
+		statusupdater.NewModuleStatusUpdater(client),
 		operatorNamespace,
 	)
 
@@ -162,7 +162,7 @@ func main() {
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
 	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, signAPI, registryAPI, preflightStatusUpdaterAPI, kernelAPI)
 
-	if err = controllers.NewPreflightValidationReconciler(client, filterAPI, preflightStatusUpdaterAPI, preflightAPI).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewPreflightValidationReconciler(client, filterAPI, metricsAPI, preflightStatusUpdaterAPI, preflightAPI).SetupWithManager(mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PreflightValidationReconcilerName)
 	}
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,12 +7,13 @@ import (
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-	existingKMMOModulesQuery = "kmmo_module_total"
-	completedKMMOStageQuery  = "kmmo_completed_stage"
-	BuildStage               = "build"
-	SignStage                = "sign"
-	ModuleLoaderStage        = "module-loader"
-	DevicePluginStage        = "device-plugin"
+	kmmModulesQuery         = "kmm_module_num"
+	kmmInClusterBuildQuery  = "kmm_in_cluster_build_num"
+	kmmInClusterSignQuery   = "kmm_in_cluster_sign_num"
+	kmmDevicePluginQuery    = "kmm_device_plugin_num"
+	kmmPreflightQuery       = "kmm_preflight_num"
+	kmmModprobeArgsQuery    = "kmm_modprobe_args"
+	kmmModprobeRawArgsQuery = "kmm_modprobe_raw_args"
 )
 
 //go:generate mockgen -source=metrics.go -package=metrics -destination=mock_metrics_api.go
@@ -20,52 +21,124 @@ const (
 // Metrics is an interface representing a prometheus client for the Kernel Module Management Operator
 type Metrics interface {
 	Register()
-	SetExistingKMMOModules(value int)
-	SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool)
+	SetKMMModulesNum(value int)
+	SetKMMInClusterBuildNum(value int)
+	SetKMMInClusterSignNum(value int)
+	SetKMMDevicePluginNum(value int)
+	SetKMMPreflightsNum(value int)
+	SetKMMModprobeArgs(modName, namespace, modprobeArgs string)
+	SetKMMModprobeRawArgs(modName, namespace, modprobeArgs string)
 }
 
 type metrics struct {
-	kmmoResourcesNum   prometheus.Gauge
-	kmmoCompletedStage *prometheus.GaugeVec
+	kmmModuleResourcesNum       prometheus.Gauge
+	kmmInClusterBuildNum        prometheus.Gauge
+	kmmInClusterSignNum         prometheus.Gauge
+	kmmDevicePluginResourcesNum prometheus.Gauge
+	kmmPreflightResourceNum     prometheus.Gauge
+	kmmModprobeArgs             *prometheus.GaugeVec
+	kmmModprobeRawArgs          *prometheus.GaugeVec
 }
 
 func New() Metrics {
 
-	kmmoResourcesNum := prometheus.NewGauge(
+	kmmModuleResourcesNum := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: existingKMMOModulesQuery,
+			Name: kmmModulesQuery,
 			Help: "Number of existing KMMO Modules",
 		},
 	)
-	completedStages := prometheus.NewGaugeVec(
+
+	kmmInClusterBuildNum := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: completedKMMOStageQuery,
-			Help: "For a given kmmo,namespace, kernel version, stage(device-plugin, module-loader, build), 1 if the stage is completed, 0 if it is not.",
+			Name: kmmInClusterBuildQuery,
+			Help: "Number of existing KMMO Modules with in-cluster Build defined",
 		},
-		[]string{"kmmo", "namespace", "kernel", "stage"},
+	)
+
+	kmmInClusterSignNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmInClusterSignQuery,
+			Help: "Number of existing KMMO Modules with in-cluster Sign defined",
+		},
+	)
+
+	kmmDevicePluginResourcesNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmDevicePluginQuery,
+			Help: "Number of existing KMMO Modules with DevicePlugin defined",
+		},
+	)
+
+	kmmPreflightResourceNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmPreflightQuery,
+			Help: "Number of existing KMMO Preflights",
+		},
+	)
+
+	kmmModprobeArgs := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: kmmModprobeArgsQuery,
+			Help: "for a given kernel version, describe which modprobe args used (if at all)",
+		},
+		[]string{"name", "namespace", "modprobeArgs"},
+	)
+
+	kmmModprobeRawArgs := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: kmmModprobeRawArgsQuery,
+			Help: "for a given kernel version, describe which modprobe raw args used (if at all)",
+		},
+		[]string{"name", "namespace", "modprobeRawArgs"},
 	)
 
 	return &metrics{
-		kmmoResourcesNum:   kmmoResourcesNum,
-		kmmoCompletedStage: completedStages,
+		kmmModuleResourcesNum:       kmmModuleResourcesNum,
+		kmmInClusterBuildNum:        kmmInClusterBuildNum,
+		kmmInClusterSignNum:         kmmInClusterSignNum,
+		kmmDevicePluginResourcesNum: kmmDevicePluginResourcesNum,
+		kmmPreflightResourceNum:     kmmPreflightResourceNum,
+		kmmModprobeArgs:             kmmModprobeArgs,
+		kmmModprobeRawArgs:          kmmModprobeRawArgs,
 	}
 }
 
 func (m *metrics) Register() {
 	runtimemetrics.Registry.MustRegister(
-		m.kmmoResourcesNum,
-		m.kmmoCompletedStage,
+		m.kmmModuleResourcesNum,
+		m.kmmInClusterBuildNum,
+		m.kmmInClusterSignNum,
+		m.kmmDevicePluginResourcesNum,
+		m.kmmPreflightResourceNum,
+		m.kmmModprobeArgs,
 	)
 }
 
-func (m *metrics) SetExistingKMMOModules(value int) {
-	m.kmmoResourcesNum.Set(float64(value))
+func (m *metrics) SetKMMModulesNum(value int) {
+	m.kmmModuleResourcesNum.Set(float64(value))
 }
 
-func (m *metrics) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool) {
-	var value float64
-	if completed {
-		value = 1
-	}
-	m.kmmoCompletedStage.WithLabelValues(kmmoName, kmmoNamespace, kernelVersion, stage).Set(value)
+func (m *metrics) SetKMMInClusterBuildNum(value int) {
+	m.kmmInClusterBuildNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMInClusterSignNum(value int) {
+	m.kmmInClusterSignNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMDevicePluginNum(value int) {
+	m.kmmDevicePluginResourcesNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMPreflightsNum(value int) {
+	m.kmmPreflightResourceNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMModprobeArgs(modName, namespace, modprobeArgs string) {
+	m.kmmModprobeArgs.WithLabelValues(modName, namespace, modprobeArgs).Set(float64(1))
+}
+
+func (m *metrics) SetKMMModprobeRawArgs(modName, namespace, modprobeRawArgs string) {
+	m.kmmModprobeRawArgs.WithLabelValues(modName, namespace, modprobeRawArgs).Set(float64(1))
 }

--- a/internal/metrics/mock_metrics_api.go
+++ b/internal/metrics/mock_metrics_api.go
@@ -45,26 +45,86 @@ func (mr *MockMetricsMockRecorder) Register() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockMetrics)(nil).Register))
 }
 
-// SetCompletedStage mocks base method.
-func (m *MockMetrics) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool) {
+// SetKMMDevicePluginNum mocks base method.
+func (m *MockMetrics) SetKMMDevicePluginNum(value int) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetCompletedStage", kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+	m.ctrl.Call(m, "SetKMMDevicePluginNum", value)
 }
 
-// SetCompletedStage indicates an expected call of SetCompletedStage.
-func (mr *MockMetricsMockRecorder) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage, completed interface{}) *gomock.Call {
+// SetKMMDevicePluginNum indicates an expected call of SetKMMDevicePluginNum.
+func (mr *MockMetricsMockRecorder) SetKMMDevicePluginNum(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCompletedStage", reflect.TypeOf((*MockMetrics)(nil).SetCompletedStage), kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMDevicePluginNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMDevicePluginNum), value)
 }
 
-// SetExistingKMMOModules mocks base method.
-func (m *MockMetrics) SetExistingKMMOModules(value int) {
+// SetKMMInClusterBuildNum mocks base method.
+func (m *MockMetrics) SetKMMInClusterBuildNum(value int) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetExistingKMMOModules", value)
+	m.ctrl.Call(m, "SetKMMInClusterBuildNum", value)
 }
 
-// SetExistingKMMOModules indicates an expected call of SetExistingKMMOModules.
-func (mr *MockMetricsMockRecorder) SetExistingKMMOModules(value interface{}) *gomock.Call {
+// SetKMMInClusterBuildNum indicates an expected call of SetKMMInClusterBuildNum.
+func (mr *MockMetricsMockRecorder) SetKMMInClusterBuildNum(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExistingKMMOModules", reflect.TypeOf((*MockMetrics)(nil).SetExistingKMMOModules), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMInClusterBuildNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMInClusterBuildNum), value)
+}
+
+// SetKMMInClusterSignNum mocks base method.
+func (m *MockMetrics) SetKMMInClusterSignNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMInClusterSignNum", value)
+}
+
+// SetKMMInClusterSignNum indicates an expected call of SetKMMInClusterSignNum.
+func (mr *MockMetricsMockRecorder) SetKMMInClusterSignNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMInClusterSignNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMInClusterSignNum), value)
+}
+
+// SetKMMModprobeArgs mocks base method.
+func (m *MockMetrics) SetKMMModprobeArgs(modName, namespace, modprobeArgs string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModprobeArgs", modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeArgs indicates an expected call of SetKMMModprobeArgs.
+func (mr *MockMetricsMockRecorder) SetKMMModprobeArgs(modName, namespace, modprobeArgs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModprobeArgs", reflect.TypeOf((*MockMetrics)(nil).SetKMMModprobeArgs), modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeRawArgs mocks base method.
+func (m *MockMetrics) SetKMMModprobeRawArgs(modName, namespace, modprobeArgs string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModprobeRawArgs", modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeRawArgs indicates an expected call of SetKMMModprobeRawArgs.
+func (mr *MockMetricsMockRecorder) SetKMMModprobeRawArgs(modName, namespace, modprobeArgs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModprobeRawArgs", reflect.TypeOf((*MockMetrics)(nil).SetKMMModprobeRawArgs), modName, namespace, modprobeArgs)
+}
+
+// SetKMMModulesNum mocks base method.
+func (m *MockMetrics) SetKMMModulesNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModulesNum", value)
+}
+
+// SetKMMModulesNum indicates an expected call of SetKMMModulesNum.
+func (mr *MockMetricsMockRecorder) SetKMMModulesNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModulesNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMModulesNum), value)
+}
+
+// SetKMMPreflightsNum mocks base method.
+func (m *MockMetrics) SetKMMPreflightsNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMPreflightsNum", value)
+}
+
+// SetKMMPreflightsNum indicates an expected call of SetKMMPreflightsNum.
+func (mr *MockMetricsMockRecorder) SetKMMPreflightsNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMPreflightsNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMPreflightsNum), value)
 }

--- a/internal/statusupdater/statusupdater_test.go
+++ b/internal/statusupdater/statusupdater_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/daemonset"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/metrics"
 )
 
 type daemonSetConfig struct {
@@ -35,19 +34,17 @@ var _ = Describe("module status update", func() {
 	)
 
 	var (
-		ctrl        *gomock.Controller
-		clnt        *client.MockClient
-		mockMetrics *metrics.MockMetrics
-		mod         *kmmv1beta1.Module
-		su          ModuleStatusUpdater
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mod  *kmmv1beta1.Module
+		su   ModuleStatusUpdater
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		mockMetrics = metrics.NewMockMetrics(ctrl)
 		mod = &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-		su = NewModuleStatusUpdater(clnt, mockMetrics)
+		su = NewModuleStatusUpdater(clnt)
 	})
 
 	DescribeTable("checking status updater based on module",
@@ -61,18 +58,8 @@ var _ = Describe("module status update", func() {
 			for kernelVersion, ds := range dsMap {
 				if daemonset.IsDevicePluginKernelVersion(kernelVersion) {
 					devicePluginAvailable = ds.Status.NumberAvailable
-					mockMetrics.EXPECT().SetCompletedStage(name,
-						namespace,
-						daemonset.GetDevicePluginKernelVersion(),
-						metrics.DevicePluginStage,
-						ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled)
 				} else {
 					moduleLoaderAvailable += ds.Status.NumberAvailable
-					mockMetrics.EXPECT().SetCompletedStage(name,
-						namespace,
-						kernelVersion,
-						metrics.ModuleLoaderStage,
-						ds.Status.NumberAvailable == ds.Status.DesiredNumberScheduled)
 				}
 			}
 			statusWrite := client.NewMockStatusWriter(ctrl)


### PR DESCRIPTION
Up to now, the metric were mainly refelcting the current progress of customer's Module, which was not very useful, since customers do not look at them. This PR changes the metrics so as to supply the info regarding KMMO usage by the customer. The following metrics are gathered: 1) number of Modules deployed on the cluster
2) number of modules with in-cluster build capabilty 3) number of module with in-cluster sign capability 4) number of modules deploying device plugin
5) if the preflight capability is used on the cluster 6) modules that are using Morprobe arg configuration ( raw and non-raw)
   and which configuration they are using