### PR TITLE
Documentation fix

### DIFF
--- a/docs/mkdocs/documentation/secure_boot.md
+++ b/docs/mkdocs/documentation/secure_boot.md
@@ -175,7 +175,7 @@ metadata:
   name: example-module-dockerfile
   namespace: default
 data:
-  Dockerfile: |
+  dockerfile: |
     ARG DTK_AUTO
     ARG KERNEL_VERSION
     FROM ${DTK_AUTO} as builder


### PR DESCRIPTION
Fixing the build Configmap example in the secture_boot.md The key for the Configmap's data should be 'dockerfile' and not 'Dockerfile'