### PR TITLE
Expose module's name and namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ vet: ## Run go vet against code.
 
 TEST ?= ./...
 
-.PHONY: test
+.PHONY: unit-test
 unit-test: vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
 

--- a/ci/module-kmm-ci-build-sign.yaml
+++ b/ci/module-kmm-ci-build-sign.yaml
@@ -10,7 +10,7 @@ spec:
         moduleName: kmm_ci_a
       kernelMappings:
         - regexp: '^.+$'
-          containerImage: host.minikube.internal:5000/kmm-kmod:$KERNEL_FULL_VERSION
+          containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION
           registryTLS:
             insecure: true
           build:

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -127,6 +127,8 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 
 func (kh *kernelMapperHelper) replaceTemplates(mld *api.ModuleLoaderData) error {
 	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelVersion)
+	osConfigEnvVars = append(osConfigEnvVars, "MOD_NAME="+mld.Name, "MOD_NAMESPACE="+mld.Namespace)
+
 	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mld.ContainerImage)
 	if err != nil {
 		return fmt.Errorf("failed to substitute templates in the ContainerImage field: %v", err)


### PR DESCRIPTION
Expose module's name and namespace  through build args and use them in the `containerImage`

#103