### PR TITLE
Adding the namespace to the `<module>.ready` label.

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -279,7 +279,7 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(
 				},
 				PriorityClassName:  "system-node-critical",
 				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
-				NodeSelector:       map[string]string{getDriverContainerNodeLabel(mod.Name): ""},
+				NodeSelector:       map[string]string{getDriverContainerNodeLabel(mod.Namespace, mod.Name): ""},
 				ServiceAccountName: mod.Spec.DevicePlugin.ServiceAccountName,
 				Volumes:            append([]v1.Volume{devicePluginVolume}, mod.Spec.DevicePlugin.Volumes...),
 			},
@@ -292,9 +292,9 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(
 func (dc *daemonSetGenerator) GetNodeLabelFromPod(pod *v1.Pod, moduleName string) string {
 	kernelVersion := pod.Labels[dc.kernelLabel]
 	if kernelVersion == devicePluginKernelVersion {
-		return getDevicePluginNodeLabel(moduleName)
+		return getDevicePluginNodeLabel(pod.Namespace, moduleName)
 	}
-	return getDriverContainerNodeLabel(moduleName)
+	return getDriverContainerNodeLabel(pod.Namespace, moduleName)
 }
 
 func (dc *daemonSetGenerator) moduleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
@@ -324,12 +324,12 @@ func CopyMapStringString(m map[string]string) map[string]string {
 	return n
 }
 
-func getDriverContainerNodeLabel(moduleName string) string {
-	return fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", moduleName)
+func getDriverContainerNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
 }
 
-func getDevicePluginNodeLabel(moduleName string) string {
-	return fmt.Sprintf("kmm.node.kubernetes.io/%s.device-plugin-ready", moduleName)
+func getDevicePluginNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }
 
 func IsDevicePluginKernelVersion(kernelVersion string) bool {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -496,7 +496,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 						},
 						ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
 						NodeSelector: map[string]string{
-							getDriverContainerNodeLabel(mod.Name): "",
+							getDriverContainerNodeLabel(mod.Namespace, mod.Name): "",
 						},
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
@@ -762,6 +762,8 @@ var _ = Describe("OverrideLabels", func() {
 })
 
 var _ = Describe("GetNodeLabelFromPod", func() {
+
+	const namespace = "some-namespace"
 	var dc DaemonSetCreator
 
 	BeforeEach(func() {
@@ -775,10 +777,11 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 					constants.ModuleNameLabel: moduleName,
 					kernelLabel:               "some kernel",
 				},
+				Namespace: namespace,
 			},
 		}
 		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDriverContainerNodeLabel("module-name")))
+		Expect(res).To(Equal(getDriverContainerNodeLabel(namespace, "module-name")))
 	})
 
 	It("should return a device plugin label", func() {
@@ -787,10 +790,11 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 				Labels: map[string]string{
 					constants.ModuleNameLabel: moduleName,
 				},
+				Namespace: namespace,
 			},
 		}
 		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDevicePluginNodeLabel("module-name")))
+		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name")))
 	})
 })
 


### PR DESCRIPTION
This is handy when there are multiple modules on each node and make it easier to determine where is each module.

---

This is how the new label looks like:
```
kmm.node.kubernetes.io/default.kmm-ci.ready: ""
```