### PR TITLE
Patch instead of update Module and ManagedClusterModule status

### DIFF
--- a/api-hub/v1beta1/managedclustermodule_types.go
+++ b/api-hub/v1beta1/managedclustermodule_types.go
@@ -36,13 +36,13 @@ type ManagedClusterModuleSpec struct {
 // ManagedClusterModuleStatus defines the observed state of ManagedClusterModule.
 type ManagedClusterModuleStatus struct {
 	// Number of ManifestWorks to be applied.
-	NumberDesired int32 `json:"numberDesired"`
+	NumberDesired int32 `json:"numberDesired,omitempty"`
 
 	// Number of ManifestWorks that have been successfully applied.
-	NumberApplied int32 `json:"numberApplied"`
+	NumberApplied int32 `json:"numberApplied,omitempty"`
 
 	// Number of ManifestWorks that could not be successfully applied.
-	NumberDegraded int32 `json:"numberDegraded"`
+	NumberDegraded int32 `json:"numberDegraded,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -288,11 +288,11 @@ type ModuleSpec struct {
 // reconciliation loop
 type DaemonSetStatus struct {
 	// number of nodes that are targeted by the module selector
-	NodesMatchingSelectorNumber int32 `json:"nodesMatchingSelectorNumber"`
+	NodesMatchingSelectorNumber int32 `json:"nodesMatchingSelectorNumber,omitempty"`
 	// number of the pods that should be deployed for daemonset
-	DesiredNumber int32 `json:"desiredNumber"`
+	DesiredNumber int32 `json:"desiredNumber,omitempty"`
 	// number of the actually deployed and running pods
-	AvailableNumber int32 `json:"availableNumber"`
+	AvailableNumber int32 `json:"availableNumber,omitempty"`
 }
 
 // ModuleStatus defines the observed state of Module.

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2493,10 +2493,6 @@ spec:
                 description: Number of ManifestWorks to be applied.
                 format: int32
                 type: integer
-            required:
-            - numberApplied
-            - numberDegraded
-            - numberDesired
             type: object
         type: object
     served: true

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2381,10 +2381,6 @@ spec:
                     description: number of nodes that are targeted by the module selector
                     format: int32
                     type: integer
-                required:
-                - availableNumber
-                - desiredNumber
-                - nodesMatchingSelectorNumber
                 type: object
               moduleLoader:
                 description: ModuleLoader contains the status of the ModuleLoader
@@ -2402,10 +2398,6 @@ spec:
                     description: number of nodes that are targeted by the module selector
                     format: int32
                     type: integer
-                required:
-                - availableNumber
-                - desiredNumber
-                - nodesMatchingSelectorNumber
                 type: object
             required:
             - moduleLoader

--- a/internal/statusupdater/statusupdater.go
+++ b/internal/statusupdater/statusupdater.go
@@ -89,6 +89,9 @@ func (m *moduleStatusUpdater) ModuleUpdateStatus(ctx context.Context,
 			numAvailableKernelModule += ds.Status.NumberAvailable
 		}
 	}
+
+	unmodifiedMod := mod.DeepCopy()
+
 	mod.Status.ModuleLoader.NodesMatchingSelectorNumber = nodesMatchingSelectorNumber
 	mod.Status.ModuleLoader.DesiredNumber = numDesired
 	mod.Status.ModuleLoader.AvailableNumber = numAvailableKernelModule
@@ -97,7 +100,7 @@ func (m *moduleStatusUpdater) ModuleUpdateStatus(ctx context.Context,
 		mod.Status.DevicePlugin.DesiredNumber = numDesired
 		mod.Status.DevicePlugin.AvailableNumber = numAvailableDevicePlugin
 	}
-	return m.client.Status().Update(ctx, mod)
+	return m.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
 }
 
 func (m *managedClusterModuleStatusUpdater) ManagedClusterModuleUpdateStatus(ctx context.Context,
@@ -120,11 +123,14 @@ func (m *managedClusterModuleStatusUpdater) ManagedClusterModuleUpdateStatus(ctx
 			}
 		}
 	}
+
+	unmodifiedMCM := mcm.DeepCopy()
+
 	mcm.Status.NumberDesired = int32(len(ownedManifestWorks))
 	mcm.Status.NumberApplied = numApplied
 	mcm.Status.NumberDegraded = numDegraded
 
-	return m.client.Status().Update(ctx, mcm)
+	return m.client.Status().Patch(ctx, mcm, client.MergeFrom(unmodifiedMCM))
 }
 
 func (p *preflightStatusUpdater) PreflightPresetStatuses(ctx context.Context,

--- a/internal/statusupdater/statusupdater_test.go
+++ b/internal/statusupdater/statusupdater_test.go
@@ -62,9 +62,10 @@ var _ = Describe("module status update", func() {
 					moduleLoaderAvailable += ds.Status.NumberAvailable
 				}
 			}
+
 			statusWrite := client.NewMockStatusWriter(ctrl)
 			clnt.EXPECT().Status().Return(statusWrite)
-			statusWrite.EXPECT().Update(context.Background(), mod).Return(nil)
+			statusWrite.EXPECT().Patch(context.Background(), mod, gomock.Any()).Return(nil)
 
 			res := su.ModuleUpdateStatus(context.Background(), mod, mappingsNodes, targetedNodes, dsMap)
 
@@ -131,7 +132,7 @@ var _ = Describe("ManagedClusterModule status update", func() {
 	It("", func() {
 		statusWrite := client.NewMockStatusWriter(ctrl)
 		clnt.EXPECT().Status().Return(statusWrite)
-		statusWrite.EXPECT().Update(context.Background(), mcm).Return(nil)
+		statusWrite.EXPECT().Patch(context.Background(), mcm, gomock.Any()).Return(nil)
 
 		mw := workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This change includes the following:
- mark the DaemonSetStatus fields are optional
- replace update with patch for the {Module,ManagedClusterModule} status subresource

It resolves the issue of the reconciliation returning an StatusConflict error when trying to update the status of a {Module,ManagedClusterModule} CR, which in turn leads to multiple reconciliation requests of a CR just to update its status subresource successfully.

Context
-------
When updating the {Module,ManagedClusterModule} status subresource, the following error usually comes up:

"the object has been modified; please apply your changes to the latest version and try again"

This error is caused by the controller-runtime cache being stale at the time of the status update, i.e. the resourceVersion of the {Module,ManagedClusterModule} in the cache is not the latest one found in the kubeapi server.

This reconcilation errors leads to additional reconciliation requests being queued, with nothing more to reconcile other than actually update the status subresource.

When using patch instead of update, the resourceVersion is not included in the payload and the above error is resolved. In order to be able to use patch instead of update, we need to mark the DaemonSetStatus fields as optional. Otherwise, when trying to patch with one or more of the DaemonSetStatus fields the validation of the patch call will fail with the error that one or more required fields are missing.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>