### PR TITLE
Adding Version field to Module CRD

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -165,6 +165,11 @@ type ModuleLoaderContainerSpec struct {
 	// Sign provides default kmod signing settings
 	Sign *Sign `json:"sign,omitempty"`
 
+	// Version defines the current version of the kernel module being used
+	// Used for upgrading the currently loaded kernel module to a new version
+	// +optional
+	Version string `json:"version,omitempty"`
+
 	// ContainerImage is a top-level field
 	// +optional
 	ContainerImage string `json:"containerImage,omitempty"`

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2442,6 +2442,11 @@ spec:
                             - certSecret
                             - keySecret
                             type: object
+                          version:
+                            description: Version defines the current version of the
+                              kernel module being used Used for upgrading the currently
+                              loaded kernel module to a new version
+                            type: string
                         required:
                         - kernelMappings
                         - modprobe

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2341,6 +2341,11 @@ spec:
                         - certSecret
                         - keySecret
                         type: object
+                      version:
+                        description: Version defines the current version of the kernel
+                          module being used Used for upgrading the currently loaded
+                          kernel module to a new version
+                        type: string
                     required:
                     - kernelMappings
                     - modprobe


### PR DESCRIPTION
Version field will be used in the ordered upgrade scenario. It signifies the current version of the kernel module.
It should be updated together with the new image in the appropriate kernel mapping. Its update will start the process of the ordered upgrade