### PR TITLE
Adding the namespace to the `<module>.ready` label.

### DIFF
--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -433,7 +433,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 						},
 						ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
 						NodeSelector: map[string]string{
-							getDriverContainerNodeLabel(mod.Name): "",
+							getDriverContainerNodeLabel(mod.Namespace, mod.Name, true): "",
 						},
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
@@ -619,6 +619,8 @@ var _ = Describe("OverrideLabels", func() {
 })
 
 var _ = Describe("GetNodeLabelFromPod", func() {
+
+	const namespace = "some-namespace"
 	var dc DaemonSetCreator
 
 	BeforeEach(func() {
@@ -632,10 +634,13 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 					constants.ModuleNameLabel: moduleName,
 					constants.DaemonSetRole:   "module-loader",
 				},
+				Namespace: namespace,
 			},
 		}
-		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDriverContainerNodeLabel("module-name")))
+		res := dc.GetNodeLabelFromPod(&pod, "module-name", false)
+		Expect(res).To(Equal(getDriverContainerNodeLabel(namespace, "module-name", false)))
+		res = dc.GetNodeLabelFromPod(&pod, "module-name", true)
+		Expect(res).To(Equal(getDriverContainerNodeLabel(namespace, "module-name", true)))
 	})
 
 	It("should return a device plugin label", func() {
@@ -645,10 +650,13 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 					constants.ModuleNameLabel: moduleName,
 					constants.DaemonSetRole:   "device-plugin",
 				},
+				Namespace: namespace,
 			},
 		}
-		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDevicePluginNodeLabel("module-name")))
+		res := dc.GetNodeLabelFromPod(&pod, "module-name", false)
+		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", false)))
+		res = dc.GetNodeLabelFromPod(&pod, "module-name", true)
+		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", true)))
 	})
 })
 

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -70,17 +70,17 @@ func (mr *MockDaemonSetCreatorMockRecorder) GetModuleDaemonSets(ctx, name, names
 }
 
 // GetNodeLabelFromPod mocks base method.
-func (m *MockDaemonSetCreator) GetNodeLabelFromPod(pod *v10.Pod, moduleName string) string {
+func (m *MockDaemonSetCreator) GetNodeLabelFromPod(pod *v10.Pod, moduleName string, useDeprecatedLabel bool) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeLabelFromPod", pod, moduleName)
+	ret := m.ctrl.Call(m, "GetNodeLabelFromPod", pod, moduleName, useDeprecatedLabel)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // GetNodeLabelFromPod indicates an expected call of GetNodeLabelFromPod.
-func (mr *MockDaemonSetCreatorMockRecorder) GetNodeLabelFromPod(pod, moduleName interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GetNodeLabelFromPod(pod, moduleName, useDeprecatedLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeLabelFromPod", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetNodeLabelFromPod), pod, moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeLabelFromPod", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetNodeLabelFromPod), pod, moduleName, useDeprecatedLabel)
 }
 
 // SetDevicePluginAsDesired mocks base method.


### PR DESCRIPTION

Adding the namespace to the `<module>.ready` label.

This is handy when there are multiple modules on each node and make it
easier to determine where is each module.

Also, solving a race condition in a new pod was created while the old
pod of a `moduleLoader` is being terminated which resulted in the
`<module>.ready` label to be deleted.

---

Fixes https://github.com/kubernetes-sigs/kernel-module-management/issues/315