### PR TITLE
Adding module version labels definitions

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,6 +9,10 @@ const (
 	JobHashAnnotation    = "kmm.node.kubernetes.io/last-hash"
 	KernelLabel          = "kmm.node.kubernetes.io/kernel-version.full"
 
+	ModuleLoaderVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-module-loader"
+	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
+	ModuleVersionLabelPrefix       = "kmm.node.kubernetes.io/version-module"
+
 	ManagedClusterModuleNameLabel  = "kmm.node.kubernetes.io/managedclustermodule.name"
 	KernelVersionsClusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 	DockerfileCMKey                = "dockerfile"

--- a/internal/utils/moduleversionlabels.go
+++ b/internal/utils/moduleversionlabels.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+)
+
+func GetModuleVersionLabelName(namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
+}
+
+func GetModuleLoaderVersionLabelName(namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", constants.ModuleLoaderVersionLabelPrefix, namespace, name)
+}
+
+func GetDevicePluginVersionLabelName(namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", constants.DevicePluginVersionLabelPrefix, namespace, name)
+}
+
+func GetNamespaceNameFromVersionLabel(label string) (string, string, error) {
+	parts := strings.Split(label, ".")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("label %s is in incorrect format", label)
+	}
+	return parts[len(parts)-2], parts[len(parts)-1], nil
+}
+
+func IsModuleVersionLabel(label string) bool {
+	return strings.HasPrefix(label, constants.ModuleVersionLabelPrefix)
+}
+
+func IsModuleLoaderVersionLabel(label string) bool {
+	return strings.HasPrefix(label, constants.ModuleLoaderVersionLabelPrefix)
+}
+
+func IsDevicePluginVersionLabel(label string) bool {
+	return strings.HasPrefix(label, constants.DevicePluginVersionLabelPrefix)
+}

--- a/internal/utils/moduleversionlabels_test.go
+++ b/internal/utils/moduleversionlabels_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetModuleVersionLabelName", func() {
+	It("should work as expected", func() {
+		res := GetModuleVersionLabelName("some-namespace", "some-name")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/version-module.some-namespace.some-name"))
+	})
+})
+
+var _ = Describe("GetModuleLoaderVersionLabelName", func() {
+	It("should work as expected", func() {
+		res := GetModuleLoaderVersionLabelName("some-namespace", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-module-loader.some-namespace.some-name"))
+	})
+})
+
+var _ = Describe("GetDevicePluginVersionLabelName", func() {
+	It("should work as expected", func() {
+		res := GetDevicePluginVersionLabelName("some-namespace", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-device-plugin.some-namespace.some-name"))
+	})
+})
+
+var _ = Describe("GetNamespaceNameFromVersionLabel", func() {
+	DescribeTable("should return correct name and namespace",
+		func(versionLabel, expectedNamespace, expectedName string, expectsErr bool) {
+			namespace, name, err := GetNamespaceNameFromVersionLabel(versionLabel)
+
+			if expectsErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(namespace).To(Equal(expectedNamespace))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry("moduleLoader label", "beta.kmm.node.kubernetes.io/version-module-loader.some-namespace.some-name", "some-namespace", "some-name", false),
+		Entry("devicePlugin label", "beta.kmm.node.kubernetes.io/version-device-plugin.some-namespace.some-name", "some-namespace", "some-name", false),
+		Entry("module label", "kmm.node.kubernetes.io/version-module.some-namespace.some-name", "some-namespace", "some-name", false),
+		Entry("with error", "version-module-some-namespace-some-name", "some-namespace", "some-name", true),
+	)
+})


### PR DESCRIPTION
This PR add the following 3 labels, that will be used during ordered update process:
1) kmm.node.kubernetes.io/version-label-module_<namespace>_<name> 2) kmm.node.kubernetes.io/version-label-module-loader_<namespace>_<name> 3) kmm.node.kubernetes.io/version-label-device-plugin_<namespace>_<name>

The first label is set by the user and signifies on which node which version should be run. The second and the third labels are managed by KMMO and are used as node selectors for module loader and device plugin damoensets accordingly. This PR also include utils functions for generating the full labels' names and for extracting namespace and name data from labels

Part of [263](https://github.com/kubernetes-sigs/kernel-module-management/issues/263)