### PR TITLE
In module version label, default namespace should be explicit

### DIFF
--- a/internal/utils/moduleversionlabels.go
+++ b/internal/utils/moduleversionlabels.go
@@ -8,15 +8,22 @@ import (
 )
 
 func GetModuleVersionLabelName(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
+	return getVersionLabelName(constants.ModuleVersionLabelPrefix, namespace, name)
 }
 
 func GetModuleLoaderVersionLabelName(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.ModuleLoaderVersionLabelPrefix, namespace, name)
+	return getVersionLabelName(constants.ModuleLoaderVersionLabelPrefix, namespace, name)
 }
 
 func GetDevicePluginVersionLabelName(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.DevicePluginVersionLabelPrefix, namespace, name)
+	return getVersionLabelName(constants.DevicePluginVersionLabelPrefix, namespace, name)
+}
+
+func getVersionLabelName(labelPrefix, namespace, name string) string {
+	if namespace == "" {
+		namespace = "default"
+	}
+	return fmt.Sprintf("%s.%s.%s", labelPrefix, namespace, name)
 }
 
 func GetNamespaceNameFromVersionLabel(label string) (string, string, error) {

--- a/internal/utils/moduleversionlabels_test.go
+++ b/internal/utils/moduleversionlabels_test.go
@@ -10,6 +10,10 @@ var _ = Describe("GetModuleVersionLabelName", func() {
 		res := GetModuleVersionLabelName("some-namespace", "some-name")
 		Expect(res).To(Equal("kmm.node.kubernetes.io/version-module.some-namespace.some-name"))
 	})
+	It("default namespace", func() {
+		res := GetModuleVersionLabelName("", "some-name")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/version-module.default.some-name"))
+	})
 })
 
 var _ = Describe("GetModuleLoaderVersionLabelName", func() {
@@ -17,12 +21,20 @@ var _ = Describe("GetModuleLoaderVersionLabelName", func() {
 		res := GetModuleLoaderVersionLabelName("some-namespace", "some-name")
 		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-module-loader.some-namespace.some-name"))
 	})
+	It("default namespace", func() {
+		res := GetModuleLoaderVersionLabelName("", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-module-loader.default.some-name"))
+	})
 })
 
 var _ = Describe("GetDevicePluginVersionLabelName", func() {
 	It("should work as expected", func() {
 		res := GetDevicePluginVersionLabelName("some-namespace", "some-name")
 		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-device-plugin.some-namespace.some-name"))
+	})
+	It("default namespace", func() {
+		res := GetDevicePluginVersionLabelName("", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-device-plugin.default.some-name"))
 	})
 })
 


### PR DESCRIPTION
In case use does not define a namespace in its module, the Module and all its DaemonSets are created in the default namespace. When using module versioning labels, this namespace must be explictily stated with "default"