### PR TITLE
handling Version change in DevicePlugin and ModuleLoader DaemonSets

### DIFF
--- a/internal/api/moduleloaderdata.go
+++ b/internal/api/moduleloaderdata.go
@@ -36,6 +36,9 @@ type ModuleLoaderData struct {
 	// Sign provides default kmod signing settings
 	Sign *kmmv1beta1.Sign
 
+	// Module version
+	ModuleVersion string
+
 	// ContainerImage is a top-level field
 	ContainerImage string
 

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -40,18 +40,18 @@ func (m *MockDaemonSetCreator) EXPECT() *MockDaemonSetCreatorMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, existingDS, validKernels)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS, validKernels)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, existingDS, validKernels interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS, validKernels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, existingDS, validKernels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS, validKernels)
 }
 
 // GetModuleDaemonSets mocks base method.

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -120,6 +120,7 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 	mld.Selector = mod.Spec.Selector
 	mld.ServiceAccountName = mod.Spec.ModuleLoader.ServiceAccountName
 	mld.Modprobe = mod.Spec.ModuleLoader.Container.Modprobe
+	mld.ModuleVersion = mod.Spec.ModuleLoader.Container.Version
 	mld.Owner = mod
 
 	return mld, nil


### PR DESCRIPTION
This PR add handing of the Version of the module in the creation of DevicePlugin and ModuleLoader DaemonSets. The following was added: 
1) setting the Module's Version in the ModuleLoaderData
2) adding Version the hash of DevicePlugin/ModuleLoader daemonset's name
3) adding module version label to the labels of DevicePlugin/ModuleLoader daemonsets
4) changing DS garbage collection to remove DS that does not contain the current
   version label, and has no more available pods