### PR TITLE
Revert "Adding a `prow` script to test a basic deployment."

### DIFF
--- a/ci/prow/test-deploy
+++ b/ci/prow/test-deploy
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -euxo pipefail
-
-echo "Deploy KMMO..."
-make deploy


### PR DESCRIPTION
Reverts kubernetes-sigs/kernel-module-management#353

If someone breaks the deployment flow but inserting new dependencies and
decide that the "fix" is to install those dependencies manually in the
e2e test, then he will also probably install the dependency manually in
this test instead of adding the dependency installation to the
`kustomization` overlay, therefore, this test doesn't have any
additional value.
