### PR TITLE
Fixing termination timeout for module loader pods

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-openapi/swag"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
@@ -191,12 +192,13 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 				Finalizers: []string{constants.NodeLabelerFinalizer},
 			},
 			Spec: v1.PodSpec{
-				Containers:         []v1.Container{container},
-				ImagePullSecrets:   GetPodPullSecrets(mld.ImageRepoSecret),
-				NodeSelector:       nodeSelector,
-				PriorityClassName:  "system-node-critical",
-				ServiceAccountName: mld.ServiceAccountName,
-				Volumes:            volumes,
+				ShareProcessNamespace: swag.Bool(true),
+				Containers:            []v1.Container{container},
+				ImagePullSecrets:      GetPodPullSecrets(mld.ImageRepoSecret),
+				NodeSelector:          nodeSelector,
+				PriorityClassName:     "system-node-critical",
+				ServiceAccountName:    mld.ServiceAccountName,
+				Volumes:               volumes,
 			},
 		},
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -252,6 +253,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								},
 							},
 						},
+						ShareProcessNamespace: swag.Bool(true),
 						ImagePullSecrets: []v1.LocalObjectReference{
 							{Name: imageRepoSecretName},
 						},


### PR DESCRIPTION
Setting the SharedProcessNamespace to true, which will cause the PID 1 process of the pod container to be pause. Puase process is trapping SIGTERM, which will allow kubelet to destroy the container process immediately, without 30 seconds timeout