### PR TITLE
Loading multiple independent kernel modules in one KMM Module

### DIFF
--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -87,6 +87,51 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
 	})
 
+	It("should add volume and volume mount if module ordering is set", func() {
+		mld := api.ModuleLoaderData{
+			Name:      moduleName,
+			Namespace: namespace,
+			Modprobe: kmmv1beta1.ModprobeSpec{
+				ModulesLoadingOrder: []string{"ModuleA", "ModuleB", "ModuleC"},
+			},
+			Owner:          &kmmv1beta1.Module{},
+			ContainerImage: "some image",
+			KernelVersion:  kernelVersion,
+			ModuleVersion:  "some version",
+		}
+
+		orderedVol := v1.Volume{
+			Name: "modules-order",
+			VolumeSource: v1.VolumeSource{
+				DownwardAPI: &v1.DownwardAPIVolumeSource{
+					Items: []v1.DownwardAPIVolumeFile{
+						{
+							Path:     "softdep.conf",
+							FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.annotations['modules-order']"},
+						},
+					},
+				},
+			},
+		}
+		orderedVolMount := v1.VolumeMount{
+			Name:      "modules-order",
+			ReadOnly:  true,
+			MountPath: "/etc/modprobe.d",
+		}
+
+		annotations := map[string]string{"modules-order": "softdep ModuleA pre: ModuleB\nsoftdep ModuleB pre: ModuleC\n"}
+
+		ds := appsv1.DaemonSet{}
+
+		err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(orderedVol))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[1]).To(Equal(orderedVolMount))
+		Expect(ds.Spec.Template.Annotations).To(Equal(annotations))
+	})
+
 	It("should add the volume and volume mount for firmware if FirmwarePath is set", func() {
 		hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 		vol := v1.Volume{
@@ -224,12 +269,12 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								Lifecycle: &v1.Lifecycle{
 									PostStart: &v1.LifecycleHandler{
 										Exec: &v1.ExecAction{
-											Command: MakeLoadCommand(mld.InTreeRemoval, mld.Modprobe, moduleName),
+											Command: makeLoadCommand(mld.InTreeRemoval, mld.Modprobe, moduleName),
 										},
 									},
 									PreStop: &v1.LifecycleHandler{
 										Exec: &v1.ExecAction{
-											Command: MakeUnloadCommand(mld.Modprobe, moduleName),
+											Command: makeUnloadCommand(mld.Modprobe, moduleName),
 										},
 									},
 								},
@@ -803,7 +848,7 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 	})
 })
 
-var _ = Describe("MakeLoadCommand", func() {
+var _ = Describe("makeLoadCommand", func() {
 	const (
 		kernelModuleName = "some-kmod"
 		moduleName       = "module-name"
@@ -818,7 +863,7 @@ var _ = Describe("MakeLoadCommand", func() {
 		}
 
 		Expect(
-			MakeLoadCommand(false, spec, moduleName),
+			makeLoadCommand(false, spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -842,7 +887,7 @@ var _ = Describe("MakeLoadCommand", func() {
 		}
 
 		Expect(
-			MakeLoadCommand(true, spec, moduleName),
+			makeLoadCommand(true, spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -861,7 +906,7 @@ var _ = Describe("MakeLoadCommand", func() {
 		}
 
 		Expect(
-			MakeLoadCommand(false, spec, moduleName),
+			makeLoadCommand(false, spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -878,7 +923,7 @@ var _ = Describe("MakeLoadCommand", func() {
 		}
 
 		Expect(
-			MakeLoadCommand(false, spec, moduleName),
+			makeLoadCommand(false, spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -889,7 +934,7 @@ var _ = Describe("MakeLoadCommand", func() {
 	})
 })
 
-var _ = Describe("MakeUnloadCommand", func() {
+var _ = Describe("makeUnloadCommand", func() {
 	const (
 		kernelModuleName = "some-kmod"
 		moduleName       = "module-name"
@@ -904,7 +949,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 		}
 
 		Expect(
-			MakeUnloadCommand(spec, moduleName),
+			makeUnloadCommand(spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -923,7 +968,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 		}
 
 		Expect(
-			MakeUnloadCommand(spec, moduleName),
+			makeUnloadCommand(spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -942,7 +987,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 		}
 
 		Expect(
-			MakeUnloadCommand(spec, moduleName),
+			makeUnloadCommand(spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",
@@ -959,7 +1004,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 		}
 
 		Expect(
-			MakeUnloadCommand(spec, moduleName),
+			makeUnloadCommand(spec, moduleName),
 		).To(
 			Equal([]string{
 				"/bin/sh",


### PR DESCRIPTION
This PR allows defining the load order of multiple independent kernel modules in one KMM Module. The order is defined as a list in the ModulesLoadingOrder field of the ModprobeSpec. The first module will be loaded last, the last one in the list will be loaded first. It is implement by using DownwardAPI: module loader pod template contains is added an annotation that contains the /etc/modprobe.d/softdep format, and then this annotation is added as a file to module loader's pod filesystem using Downward API