### PR TITLE
Adding sign jobs garbage collection to hub flow

### DIFF
--- a/controllers/hub/managedclustermodule_reconciler.go
+++ b/controllers/hub/managedclustermodule_reconciler.go
@@ -136,9 +136,9 @@ func (r *ManagedClusterModuleReconciler) Reconcile(ctx context.Context, req ctrl
 		return res, fmt.Errorf("failed to garbage collect ManifestWorks with no matching cluster selector: %v", err)
 	}
 
-	deleted, err := r.clusterAPI.GarbageCollectBuilds(ctx, *mcm)
+	deleted, err := r.clusterAPI.GarbageCollectBuildsAndSigns(ctx, *mcm)
 	if err != nil {
-		return res, fmt.Errorf("failed to garbage collect build objects: %v", err)
+		return res, fmt.Errorf("failed to garbage collect build and sign objects: %v", err)
 	}
 	if len(deleted) > 0 {
 		logger.Info("Garbage-collected Build objects", "names", deleted)

--- a/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/controllers/hub/managedclustermodule_reconciler_test.go
@@ -140,7 +140,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -195,7 +195,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm).Return(nil, errors.New("test")),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm).Return(nil, errors.New("test")),
 		)
 
 		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil, nil)
@@ -222,7 +222,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(nil, errors.New("generic-error")),
 		)
 
@@ -251,7 +251,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(errors.New("generic-error")),
 		)
@@ -298,7 +298,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(false, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -348,7 +348,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockMW.EXPECT().SetManifestWorkAsDesired(context.Background(), &mw, gomock.AssignableToTypeOf(mcm)),
 			clnt.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -402,7 +402,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 				}),
 			clnt.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)

--- a/internal/cluster/mock_cluster.go
+++ b/internal/cluster/mock_cluster.go
@@ -52,19 +52,19 @@ func (mr *MockClusterAPIMockRecorder) BuildAndSign(ctx, mcm, cluster interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndSign", reflect.TypeOf((*MockClusterAPI)(nil).BuildAndSign), ctx, mcm, cluster)
 }
 
-// GarbageCollectBuilds mocks base method.
-func (m *MockClusterAPI) GarbageCollectBuilds(ctx context.Context, mcm v1beta1.ManagedClusterModule) ([]string, error) {
+// GarbageCollectBuildsAndSigns mocks base method.
+func (m *MockClusterAPI) GarbageCollectBuildsAndSigns(ctx context.Context, mcm v1beta1.ManagedClusterModule) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollectBuilds", ctx, mcm)
+	ret := m.ctrl.Call(m, "GarbageCollectBuildsAndSigns", ctx, mcm)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GarbageCollectBuilds indicates an expected call of GarbageCollectBuilds.
-func (mr *MockClusterAPIMockRecorder) GarbageCollectBuilds(ctx, mcm interface{}) *gomock.Call {
+// GarbageCollectBuildsAndSigns indicates an expected call of GarbageCollectBuildsAndSigns.
+func (mr *MockClusterAPIMockRecorder) GarbageCollectBuildsAndSigns(ctx, mcm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectBuilds", reflect.TypeOf((*MockClusterAPI)(nil).GarbageCollectBuilds), ctx, mcm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectBuildsAndSigns", reflect.TypeOf((*MockClusterAPI)(nil).GarbageCollectBuildsAndSigns), ctx, mcm)
 }
 
 // RequestedManagedClusterModule mocks base method.

--- a/internal/cluster/suite_test.go
+++ b/internal/cluster/suite_test.go
@@ -19,22 +19,41 @@ package cluster
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	//+kubebuilder:scaffold:imports
 )
 
-var scheme *runtime.Scheme
+var (
+	scheme *runtime.Scheme
+	ctrl   *gomock.Controller
+	clnt   *client.MockClient
+	mockKM *module.MockKernelMapper
+	mockBM *build.MockManager
+	mockSM *sign.MockSignManager
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	var err error
-
-	scheme, err = test.TestScheme()
-	Expect(err).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockKM = module.NewMockKernelMapper(ctrl)
+		mockBM = build.NewMockManager(ctrl)
+		mockSM = sign.NewMockSignManager(ctrl)
+		var err error
+		scheme, err = test.TestScheme()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	RunSpecs(t, "Cluster Suite")
 }


### PR DESCRIPTION
Currently only build jobs are garbage collected during hub flow. This PR also adds sign jobs garbage collection, at the same time as build jobs