### PR TITLE
Use ubuntu-20.04 explicitly in CI e2e tests instead of ubuntu-latest

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
 
   build-operator-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Build the KMMO container image
 
@@ -31,7 +31,7 @@ jobs:
           retention-days: 1
 
   build-operator-hub-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Build the KMMO-hub container image
 
@@ -54,7 +54,7 @@ jobs:
           retention-days: 1
 
   build-signing-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     name: Build the signing image
 
@@ -78,7 +78,7 @@ jobs:
 
   e2e:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: e2e
     needs: [build-operator-image, build-signing-image]
 
@@ -134,7 +134,7 @@ jobs:
 
   e2e-hub:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: e2e-hub
     needs: [build-operator-image, build-operator-hub-image, build-signing-image]
 

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kmm-kmod-dockerfile
 data:
   dockerfile: |
-    FROM ubuntu as builder
+    FROM ubuntu:20.04 as builder
 
     ARG KERNEL_VERSION
 
@@ -25,7 +25,7 @@ data:
 
     RUN KERNEL_SRC_DIR=/usr/src/linux-headers-${KERNEL_VERSION} make all
 
-    FROM ubuntu
+    FROM ubuntu:20.04
 
     ARG KERNEL_VERSION
 


### PR DESCRIPTION
This PR replaces [ubuntu-latest](https://github.com/actions/runner-images#available-images) with `ubuntu-20.04` explicitly in the CI e2e Github actions and Dockerfiles. 

When using `ubuntu-latest`, which is currently pointing to `ubuntu-22.04`, we have kernel version `5.15.0-1036-azure` on the VM, but there is no `linux-headers-5.15.0-1036-azure` package in the ubuntu-22.04 repos. So we we get an error when building the CI kmod using the `ubuntu:latest` (also pointing currently to `ubuntu:22.04`) container image, because the respective linux headers cannot be installed. With Ubuntu 20.04 LTS  this is not an issue.  

Example CI error:

```log
E: Unable to locate package linux-headers-5.15.0-1036-azure
E: Couldn't find any package by glob 'linux-headers-5.15.0-1036-azure'
E: Couldn't find any package by regex 'linux-headers-5.15.0-1036-azure'
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 100
``` 