### PR TITLE
Update CI e2e-hub test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -145,9 +145,6 @@ jobs:
 
     steps:
 
-      - name: Install curl on the machine
-        run: sudo apt update -y && sudo apt upgrade -y && sudo apt install -y curl
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/ci/prow/e2e-hub-spoke-incluster-build
+++ b/ci/prow/e2e-hub-spoke-incluster-build
@@ -24,11 +24,16 @@ hub_api_server=$(kubectl config view -o yaml | yq '.clusters[] | select(.. | .na
 clusteradm join \
   --hub-token ${token} \
   --hub-apiserver ${hub_api_server} \
-  --wait \
   --cluster-name ${MINIKUBE}
-kubectl wait --for=condition=Available deployment/klusterlet-registration-agent -n open-cluster-management-agent
-clusteradm accept --clusters ${MINIKUBE}
 
+# Wait for the join command to succeed
+kubectl wait --for=condition=Established crd managedclusters.cluster.open-cluster-management.io
+timeout 60 sh -c "until kubectl get managedcluster ${MINIKUBE}; do sleep 2; done"
+timeout 30 sh -c "until kubectl get csr -l open-cluster-management.io/cluster-name=${MINIKUBE} | grep Pending; do sleep 2; done"
+timeout 1m bash -c "until kubectl get csr -l open-cluster-management.io/cluster-name=${MINIKUBE} -o json | jq -er \".items[].metadata.name\"; do sleep 2; done"
+kubectl wait --for=condition=Available deployment/klusterlet-registration-agent -n open-cluster-management-agent
+
+clusteradm accept --clusters ${MINIKUBE}
 
 # Installing required addons to the hub/spoke clusters
 clusteradm install hub-addon --names application-manager


### PR DESCRIPTION
This change updates the CI e2e-hub test to wait for the `clusteradm join` command to succeed asynchronously. Waiting for it synchronously sometimes leads to errors like the following:
```log
+ clusteradm join --hub-token *** --hub-apiserver https://192.168.49.2:8443 --wait --cluster-name minikube
  Error: no matches for kind "Klusterlet" in version "operator.open-cluster-management.io/v1"
```
This errors comes from [clusteradm](https://github.com/open-cluster-management-io/clusteradm/blob/95f9d75af1b20d6c1f04298a8e01b5941cd7a867/pkg/cmd/join/exec.go#L261-L265) itself and the only workaround we can do is run the `clusteradm join` command and wait/watch asynchronously for the relevant Kubernetes resources, that indicate a successful join, to be available.

This PR also removes the unneeded `curl` installation in the same CI workflow. It also removes the `apt-get upgrade` command that could lead to more reliability issues on the CI e2e steps. 