### PR TITLE
Use operator namespace when hub fetches the image digest

### DIFF
--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	mcmr := hub.NewManagedClusterModuleReconciler(
 		client,
-		manifestwork.NewCreator(client, scheme, kernelAPI, registryAPI, cache),
+		manifestwork.NewCreator(client, scheme, kernelAPI, registryAPI, cache, operatorNamespace),
 		cluster.NewClusterAPI(client, kernelAPI, buildAPI, signAPI, operatorNamespace),
 		statusupdater.NewManagedClusterModuleStatusUpdater(client),
 		filterAPI,

--- a/internal/manifestwork/manifestwork.go
+++ b/internal/manifestwork/manifestwork.go
@@ -63,11 +63,12 @@ type ManifestWorkCreator interface {
 }
 
 type manifestWorkGenerator struct {
-	client      client.Client
-	scheme      *runtime.Scheme
-	kernelAPI   module.KernelMapper
-	registryAPI registry.Registry
-	cache       cache.Cache[string]
+	client            client.Client
+	scheme            *runtime.Scheme
+	kernelAPI         module.KernelMapper
+	registryAPI       registry.Registry
+	cache             cache.Cache[string]
+	operatorNamespace string
 }
 
 func NewCreator(
@@ -75,13 +76,15 @@ func NewCreator(
 	scheme *runtime.Scheme,
 	kernelAPI module.KernelMapper,
 	registryAPI registry.Registry,
-	cache cache.Cache[string]) ManifestWorkCreator {
+	cache cache.Cache[string],
+	operatorNamespace string) ManifestWorkCreator {
 	return &manifestWorkGenerator{
-		client:      client,
-		scheme:      scheme,
-		kernelAPI:   kernelAPI,
-		registryAPI: registryAPI,
-		cache:       cache,
+		client:            client,
+		scheme:            scheme,
+		kernelAPI:         kernelAPI,
+		registryAPI:       registryAPI,
+		cache:             cache,
+		operatorNamespace: operatorNamespace,
 	}
 }
 
@@ -286,7 +289,7 @@ func (mwg *manifestWorkGenerator) imageDigestForModuleLoaderData(ctx context.Con
 		return value.(string), nil
 	}
 
-	digest, err := module.ImageDigest(ctx, mwg.client, mwg.registryAPI, mld, mld.Namespace, ref.Name())
+	digest, err := module.ImageDigest(ctx, mwg.client, mwg.registryAPI, mld, mwg.operatorNamespace, ref.Name())
 	if err != nil {
 		return "", fmt.Errorf("could not get image digest: %v", err)
 	}

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -95,7 +95,7 @@ var _ = Describe("GarbageCollect", func() {
 			clnt.EXPECT().Delete(ctx, &mwToBeCollected),
 		)
 
-		mwc := NewCreator(clnt, scheme, nil, nil, nil)
+		mwc := NewCreator(clnt, scheme, nil, nil, nil, "")
 
 		err := mwc.GarbageCollect(context.Background(), clusterList, mcm)
 		Expect(err).NotTo(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("GetOwnedManifestWorks", func() {
 			),
 		)
 
-		mwc := NewCreator(clnt, scheme, nil, nil, nil)
+		mwc := NewCreator(clnt, scheme, nil, nil, nil, "")
 
 		ownedManifestWorks, err := mwc.GetOwnedManifestWorks(context.Background(), mcm)
 		Expect(err).NotTo(HaveOccurred())
@@ -219,7 +219,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 	})
 
 	It("should return an error if the ManifestWork is nil", func() {
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		Expect(
 			mwc.SetManifestWorkAsDesired(context.Background(), nil, hubv1beta1.ManagedClusterModule{}, nil),
@@ -233,7 +233,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			mockKM.EXPECT().GetModuleLoaderDataForKernel(gomock.Any(), kernelVersion).Return(nil, errors.New("no-mappings-found")),
 		)
 
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm, []string{kernelVersion})
 		Expect(err).NotTo(HaveOccurred())
@@ -257,7 +257,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			mockKM.EXPECT().GetModuleLoaderDataForKernel(gomock.Any(), kernelVersion).Return(&mld, nil),
 		)
 
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm, []string{kernelVersion})
 		Expect(err).NotTo(HaveOccurred())
@@ -282,7 +282,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			mockCache.EXPECT().Get(mld.ContainerImage).Return(digest, true),
 		)
 
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm, []string{kernelVersion})
 		Expect(err).NotTo(HaveOccurred())
@@ -305,7 +305,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			mockRegistry.EXPECT().GetDigest(ctx, mld.ContainerImage+":latest", gomock.Any(), nil).Return("", errors.New("generic-error")),
 		)
 
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm, []string{kernelVersion})
 		Expect(err).NotTo(HaveOccurred())
@@ -350,7 +350,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			mockCache.EXPECT().Set(mld.ContainerImage, digest),
 		)
 
-		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache)
+		mwc := NewCreator(clnt, scheme, mockKM, mockRegistry, mockCache, "")
 
 		err := mwc.SetManifestWorkAsDesired(context.Background(), mw, mcm, []string{kernelVersion})
 


### PR DESCRIPTION
This PR fixes an issue when KMM Hub fetches the container image digest with registry authentication creds and fails due to searching the registry creds secret in the spoke's namespace instead of the KMM Hub operator namespace.  