### PR TITLE
Set the tag of related images when building bundles

### DIFF
--- a/ci/prow/check-api-changes
+++ b/ci/prow/check-api-changes
@@ -2,11 +2,10 @@
 
 set -euxo pipefail
 
-make generate bundle
-
+make generate manifests
 
 if [[ $(git diff) ]]; then
-   echo 'Please run `make generate bundle` and repush'
+   echo 'Please run `make generate manifests` and repush'
    echo 'The following differences were found:'
    echo $(git diff)
    exit 1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,6 @@ steps:
     name: golang:1.20-alpine3.17
     env:
       - '_GIT_TAG=$_GIT_TAG'
-      - 'PROJECT_ID=$PROJECT_ID'
     entrypoint: sh
     args:
       - -eEuo
@@ -71,11 +70,11 @@ steps:
         export PATH=$$(go env GOPATH)/bin:$${PATH}
 
         # KMM
-        make bundle IMG=gcr.io/$PROJECT_ID/kernel-module-management-operator:$_GIT_TAG USE_IMAGE_DIGESTS=true
+        make bundle IMAGE_TAG=$_GIT_TAG USE_IMAGE_DIGESTS=true
         mv bundle bundle.Dockerfile /bundle-kmm
 
         # KMM Hub
-        make bundle-hub HUB_IMG=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub:$_GIT_TAG USE_IMAGE_DIGESTS=true
+        make bundle-hub IMAGE_TAG:$_GIT_TAG USE_IMAGE_DIGESTS=true
         mv bundle bundle.Dockerfile /bundle-hub
     volumes:
       - name: bundle-kmm

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Kustomization
 resources:
 - manager.yaml
 
+images:
+- name: signer
+  newName: gcr.io/k8s-staging-kmm/kernel-module-management-signimage
+  newTag: latest
+
 patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
@@ -14,3 +19,5 @@ patches:
 # through a ComponentConfig type
 - path: manager_config_patch.yaml
 
+configurations:
+- kustomizeconfig.yaml

--- a/config/manager-base/kustomizeconfig.yaml
+++ b/config/manager-base/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -49,7 +49,7 @@ spec:
           - name: RELATED_IMAGES_BUILD
             value: gcr.io/kaniko-project/executor:latest
           - name: RELATED_IMAGES_SIGN
-            value: gcr.io/k8s-staging-kmm/kernel-module-management-signimage:latest
+            value: signer
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Add the `IMAGE_TAG` variable to `Makefile`.
Use that variable in `cloudbuild.yaml` to reference the correct images when creating the bundle.

/cc @mresvanis @ybettan 