### PR TITLE
Set the tag of all images when building bundles

### DIFF
--- a/ci/prow/check-api-changes
+++ b/ci/prow/check-api-changes
@@ -2,11 +2,10 @@
 
 set -euxo pipefail
 
-make generate bundle
-
+make generate manifests
 
 if [[ $(git diff) ]]; then
-   echo 'Please run `make generate bundle` and repush'
+   echo 'Please run `make generate manifests` and repush'
    echo 'The following differences were found:'
    echo $(git diff)
    exit 1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,6 @@ steps:
     - --build-arg
     - TARGET=manager
     - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator:$_GIT_TAG
-    - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator:latest
     - .
     waitFor: ['-']
   - id: push-manager-image
@@ -23,7 +22,6 @@ steps:
     - --build-arg
     - TARGET=manager-hub
     - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub:$_GIT_TAG
-    - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub:latest
     - .
     waitFor: ['-']
   - id: push-manager-hub-image
@@ -38,7 +36,6 @@ steps:
     args:
       - build
       - --tag=gcr.io/$PROJECT_ID/kernel-module-management-signimage:$_GIT_TAG
-      - --tag=gcr.io/$PROJECT_ID/kernel-module-management-signimage:latest
       - --file=Dockerfile.signimage
       - .
     waitFor: ['-']
@@ -53,7 +50,6 @@ steps:
     name: golang:1.20-alpine3.17
     env:
       - '_GIT_TAG=$_GIT_TAG'
-      - 'PROJECT_ID=$PROJECT_ID'
     entrypoint: sh
     args:
       - -eEuo
@@ -71,11 +67,11 @@ steps:
         export PATH=$$(go env GOPATH)/bin:$${PATH}
 
         # KMM
-        make bundle IMG=gcr.io/$PROJECT_ID/kernel-module-management-operator:$_GIT_TAG USE_IMAGE_DIGESTS=true
+        make bundle IMAGE_TAG=$_GIT_TAG USE_IMAGE_DIGESTS=true
         mv bundle bundle.Dockerfile /bundle-kmm
 
         # KMM Hub
-        make bundle-hub HUB_IMG=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub:$_GIT_TAG USE_IMAGE_DIGESTS=true
+        make bundle-hub IMAGE_TAG:$_GIT_TAG USE_IMAGE_DIGESTS=true
         mv bundle bundle.Dockerfile /bundle-hub
     volumes:
       - name: bundle-kmm
@@ -90,7 +86,6 @@ steps:
       - --file=bundle.Dockerfile
       - --cache-from=gcr.io/$PROJECT_ID/kernel-module-management-operator-bundle:latest
       - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-bundle:$_GIT_TAG
-      - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-bundle:latest
       - .
     dir: /bundle-kmm
     volumes:
@@ -104,7 +99,6 @@ steps:
       - --file=bundle.Dockerfile
       - --cache-from=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub-bundle:latest
       - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub-bundle:$_GIT_TAG
-      - --tag=gcr.io/$PROJECT_ID/kernel-module-management-operator-hub-bundle:latest
       - .
     dir: /bundle-hub
     volumes:
@@ -119,6 +113,4 @@ images:
   # Binary images pushed manually in steps so that they are available in build-bundles,
   # which looks for their SHA on their registry.
   - gcr.io/$PROJECT_ID/kernel-module-management-operator-bundle:$_GIT_TAG
-  - gcr.io/$PROJECT_ID/kernel-module-management-operator-bundle:latest
   - gcr.io/$PROJECT_ID/kernel-module-management-operator-hub-bundle:$_GIT_TAG
-  - gcr.io/$PROJECT_ID/kernel-module-management-operator-hub-bundle:latest

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Kustomization
 resources:
 - manager.yaml
 
+images:
+- name: signer
+  newName: gcr.io/k8s-staging-kmm/kernel-module-management-signimage
+  newTag: latest
+
 patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
@@ -14,3 +19,5 @@ patches:
 # through a ComponentConfig type
 - path: manager_config_patch.yaml
 
+configurations:
+- kustomizeconfig.yaml

--- a/config/manager-base/kustomizeconfig.yaml
+++ b/config/manager-base/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -49,7 +49,7 @@ spec:
           - name: RELATED_IMAGES_BUILD
             value: gcr.io/kaniko-project/executor:latest
           - name: RELATED_IMAGES_SIGN
-            value: gcr.io/k8s-staging-kmm/kernel-module-management-signimage:latest
+            value: signer
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Do not run make bundle in `ci/prow/check-api-changes` since we do not version bundles.
Do not push to the `latest` tag.

Cherry-pick of 25eb240526db4b0e7da234d6348beebc365bc56d

/cc @mresvanis