### PR TITLE
Make cert-manager an OLM dependency of KMM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image signer=$(SIGNER_IMG)
 	kubectl kustomize config/manifests | ${OPERATOR_SDK} generate bundle $(BUNDLE_GEN_FLAGS)
+	cp -r config/manifests/bundle-metadata/* bundle/metadata/
 	${OPERATOR_SDK} bundle validate ./bundle
 
 .PHONY: bundle-hub
@@ -286,6 +287,7 @@ bundle-hub: operator-sdk manifests kustomize ## Generate bundle manifests and me
 	cd config/manager-hub && $(KUSTOMIZE) edit set image controller=$(HUB_IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image signer=$(SIGNER_IMG)
 	kubectl kustomize config/manifests-hub | ${OPERATOR_SDK} generate bundle --package kernel-module-management-hub $(BUNDLE_GEN_FLAGS)
+	cp -r config/manifests-hub/bundle-metadata/* bundle/metadata/
 	${OPERATOR_SDK} bundle validate ./bundle
 
 .PHONY: bundle-build

--- a/config/manifests-hub/bundle-metadata/dependencies.yaml
+++ b/config/manifests-hub/bundle-metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+dependencies:
+  - type: olm.gvk
+    value:
+      group: cert-manager.io
+      kind: Certificate
+      version: v1
+  - type: olm.gvk
+    value:
+      group: cert-manager.io
+      kind: Issuer
+      version: v1

--- a/config/manifests/bundle-metadata/dependencies.yaml
+++ b/config/manifests/bundle-metadata/dependencies.yaml
@@ -1,0 +1,11 @@
+dependencies:
+  - type: olm.gvk
+    value:
+      group: cert-manager.io
+      kind: Certificate
+      version: v1
+  - type: olm.gvk
+    value:
+      group: cert-manager.io
+      kind: Issuer
+      version: v1


### PR DESCRIPTION
Installing KMM and KMM-Hub will now pull cert-manager as a dependency.

/cc @ybettan @yevgeny-shnaidman 