### PR TITLE
Do not require pods to have a `.spec.nodeName`

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -248,15 +248,6 @@ func DeletingPredicate() predicate.Predicate {
 	})
 }
 
-// PodHasSpecNodeName returns a predicate that returns true if the object is a *v1.Pod and its .spec.nodeName
-// property is set.
-func PodHasSpecNodeName() predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(o client.Object) bool {
-		pod, ok := o.(*v1.Pod)
-		return ok && pod.Spec.NodeName != ""
-	})
-}
-
 // PodReadinessChangedPredicate returns a predicate for Update events that only returns true if the Ready condition
 // changed.
 func PodReadinessChangedPredicate(logger logr.Logger) predicate.Predicate {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -556,24 +556,6 @@ var _ = Describe("DeletingPredicate", func() {
 	)
 })
 
-var _ = Describe("PodHasSpecNodeName", func() {
-	p := PodHasSpecNodeName()
-
-	DescribeTable(
-		"should return the expected value",
-		func(o client.Object, expected bool) {
-			Expect(
-				p.Create(event.CreateEvent{Object: o}),
-			).To(
-				Equal(expected),
-			)
-		},
-		Entry("ConfigMap: false", &v1.ConfigMap{}, false),
-		Entry("Pod with no nodeName: false", &v1.Pod{}, false),
-		Entry("Pod with a nodeName: true", &v1.Pod{Spec: v1.PodSpec{NodeName: "test"}}, true),
-	)
-})
-
 var _ = Describe("PodReadinessChangedPredicate", func() {
 	p := PodReadinessChangedPredicate(logr.Discard())
 


### PR DESCRIPTION
ModuleLoader pods that have an empty `.spec.nodeName` cannot terminate properly because we filter out events for those objects and never remove their finalizer.
Modify the PodNodeModule reconciler so it removes the finalizer for those objects, as it should.

/cc @yevgeny-shnaidman @mresvanis