### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/actions/create-minikube-cluster/action.yml
+++ b/.github/actions/create-minikube-cluster/action.yml
@@ -16,7 +16,7 @@ runs:
       run: |
         wget https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
         sudo dpkg -i ./minikube_latest_amd64.deb
-        echo "::set-output name=version::$(minikube version --short)"
+        echo "version=$(minikube version --short)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Cache Minikube artifacts


### PR DESCRIPTION
## Description

Resolve  #450 

Update `.github/actions/create-minikube-cluster/action.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=version::$(minikube version --short)"
```

**TO-BE**

```yaml
echo "version=$(minikube version --short)" >> $GITHUB_OUTPUT
```