### PR TITLE
Upgrade support between v1.02 and v1.1

### DIFF
--- a/controllers/mock_module_reconciler.go
+++ b/controllers/mock_module_reconciler.go
@@ -115,31 +115,31 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleBuild(ctx, mld interf
 }
 
 // handleDevicePlugin mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingModuleDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod)
+	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingModuleDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDevicePlugin indicates an expected call of handleDevicePlugin.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod interface{}) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingModuleDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingModuleDS)
 }
 
 // handleDriverContainer mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData, existingModuleDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDriverContainer", ctx, mld)
+	ret := m.ctrl.Call(m, "handleDriverContainer", ctx, mld, existingModuleDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDriverContainer indicates an expected call of handleDriverContainer.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDriverContainer(ctx, mld interface{}) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDriverContainer(ctx, mld, existingModuleDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDriverContainer", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDriverContainer), ctx, mld)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDriverContainer", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDriverContainer), ctx, mld, existingModuleDS)
 }
 
 // handleSigning mocks base method.

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-openapi/swag"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
@@ -214,13 +213,12 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 				Annotations: modulesOrderAnnotations,
 			},
 			Spec: v1.PodSpec{
-				ShareProcessNamespace: swag.Bool(true),
-				Containers:            []v1.Container{container},
-				ImagePullSecrets:      GetPodPullSecrets(mld.ImageRepoSecret),
-				NodeSelector:          nodeSelector,
-				PriorityClassName:     "system-node-critical",
-				ServiceAccountName:    mld.ServiceAccountName,
-				Volumes:               volumes,
+				Containers:         []v1.Container{container},
+				ImagePullSecrets:   GetPodPullSecrets(mld.ImageRepoSecret),
+				NodeSelector:       nodeSelector,
+				PriorityClassName:  "system-node-critical",
+				ServiceAccountName: mld.ServiceAccountName,
+				Volumes:            volumes,
 			},
 		},
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -298,7 +297,6 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								},
 							},
 						},
-						ShareProcessNamespace: swag.Bool(true),
 						ImagePullSecrets: []v1.LocalObjectReference{
 							{Name: imageRepoSecretName},
 						},


### PR DESCRIPTION
Currently in v1.1 the naming scheme for ModuleLoader and DevicePlugin daemonsets is different the what we had in v1.0.2. We are using hashings and the names are deterministic. This causes issues during upgrade, since the upgraded controller will try to create new daemonsets (new names). The old daemonsets can not be deleted, since it will cause the unloading of kernel modules. Since there is no way to change/delete lifecycle hooks of the running pod, we need to support the naming scheme of v1.0.2
The changes in PR:
1. get the runnings Daemonsets of the module in the earlier stage of the reconciliation loop
2. during ModuleLoader or DevicePlugin handling, check if the appropriate daemonset already exists based on the kernel-version and version label of daemonset
3. if now daemnonset is found, then create a new one using GenerateName option
4. removing the fix for pods being stuck in Terminating state for ~30 seconds, since it changes the Container spec of the Daemonset, which means that during upgrade the DaemonSet will delete the pod and then restart it, which may cause unloading of kernel module
5. unit test fixes