### PR TITLE
Fixing InTreeRemoval modprobe search path

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -405,11 +405,7 @@ func makeLoadCommand(inTreeModuleToRemove string, spec kmmv1beta1.ModprobeSpec, 
 	var loadCommand strings.Builder
 
 	if inTreeModuleToRemove != "" {
-		loadCommand.WriteString("modprobe -r")
-		if spec.DirName != "" {
-			loadCommand.WriteString(" -d " + spec.DirName)
-		}
-		loadCommand.WriteString(" " + inTreeModuleToRemove + " && ")
+		loadCommand.WriteString("modprobe -r " + inTreeModuleToRemove + " && ")
 	}
 
 	if fw := spec.FirmwarePath; fw != "" {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -892,7 +892,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -r -d %s %s && modprobe -v -d %s %s %s %s", dir, "in-tree-module", dir, kernelModuleName, arg1, arg2),
+				fmt.Sprintf("modprobe -r %s && modprobe -v -d %s %s %s %s", "in-tree-module", dir, kernelModuleName, arg1, arg2),
 			}),
 		)
 	})


### PR DESCRIPTION
When InTreeRemoval option is specified, it means that user wants to remove the in-tree module, which also means that it's module file is under /lib/modules/<kernel> directories, which is a default search path for modprobe and is also mounted by ModuleLoader There for no -d optin needs to be specified