### PR TITLE
Quote arguments in modprobe commands

### DIFF
--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -868,7 +868,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				"modprobe load arguments",
+				`modprobe "load" "arguments"`,
 			}),
 		)
 	})
@@ -892,7 +892,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -r -d %s %s && modprobe -v -d %s %s %s %s", dir, "in-tree-module", dir, kernelModuleName, arg1, arg2),
+				fmt.Sprintf(`modprobe -r %q && modprobe -v -d %q %q %q %q`, "in-tree-module", dir, kernelModuleName, arg1, arg2),
 			}),
 		)
 	})
@@ -911,7 +911,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -z -k %s", kernelModuleName),
+				fmt.Sprintf(`modprobe "-z" "-k" %q`, kernelModuleName),
 			}),
 		)
 	})
@@ -928,7 +928,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("cp -r /kmm/firmware/mymodule/* /var/lib/firmware && modprobe -v %s", kernelModuleName),
+				fmt.Sprintf(`cp -r "/kmm/firmware/mymodule/*" /var/lib/firmware && modprobe -v %q`, kernelModuleName),
 			}),
 		)
 	})
@@ -954,7 +954,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				"modprobe unload arguments",
+				`modprobe "unload" "arguments"`,
 			}),
 		)
 	})
@@ -973,7 +973,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -rv -d %s %s", dir, kernelModuleName),
+				fmt.Sprintf(`modprobe -rv -d %q %q`, dir, kernelModuleName),
 			}),
 		)
 	})
@@ -992,7 +992,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -z -k %s", kernelModuleName),
+				fmt.Sprintf(`modprobe "-z" "-k" %q`, kernelModuleName),
 			}),
 		)
 	})
@@ -1009,7 +1009,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/{}", kernelModuleName),
+				fmt.Sprintf(`modprobe -rv %q && cd "/kmm/firmware/mymodule" && find |sort -r |xargs -I{} rm -d "/var/lib/firmware/{}"`, kernelModuleName),
 			}),
 		)
 	})


### PR DESCRIPTION
Quote arguments to avoid shell injections.

/cc @yevgeny-shnaidman