### PR TITLE
Fix race condition for Node reboot issue

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -267,7 +267,7 @@ func (mrh *moduleReconcilerHelper) getNodesListBySelector(ctx context.Context, m
 	nodes := make([]v1.Node, 0, len(selectedNodes.Items))
 
 	for _, node := range selectedNodes.Items {
-		if isNodeSchedulable(&node) {
+		if utils.IsNodeSchedulable(&node) {
 			nodes = append(nodes, node)
 		}
 	}
@@ -486,15 +486,6 @@ func (r *ModuleReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string
 		).
 		Named(ModuleReconcilerName).
 		Complete(r)
-}
-
-func isNodeSchedulable(node *v1.Node) bool {
-	for _, taint := range node.Spec.Taints {
-		if taint.Effect == v1.TaintEffectNoSchedule {
-			return false
-		}
-	}
-	return true
 }
 
 func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {

--- a/internal/utils/nodeutils.go
+++ b/internal/utils/nodeutils.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+func IsNodeSchedulable(node *v1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == v1.TaintEffectNoSchedule {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Module controller needs to be scheduled in case node has been rebooted and becomes ready. Module controller get the target nodes for the modules based on the selector and the NonSchedulable taint of the node. Sometimes node's Ready condition is set while the taint is not being removed, which causes the reconcilation loop to skip DS generation, and we have not addition event  scheduled. This PR changes the condition for reconciliation kick-off: now we are waiting for node to become scheduled, instead of just ready