### PR TITLE
Adding NotFound error to the GetMLD API

### DIFF
--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
+var ErrNoMatchingKernelMapping = errors.New("kernel mapping not found")
+
 //go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go KernelMapper,kernelMapperHelperAPI
 
 type KernelMapper interface {
@@ -32,7 +34,7 @@ func (k *kernelMapper) GetModuleLoaderDataForKernel(mod *kmmv1beta1.Module, kern
 	mappings := mod.Spec.ModuleLoader.Container.KernelMappings
 	foundMapping, err := k.helper.findKernelMapping(mappings, kernelVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find mapping for kernel %s: %v", kernelVersion, err)
+		return nil, fmt.Errorf("failed to find mapping for kernel %s: %w", kernelVersion, err)
 	}
 	mld, err := k.helper.prepareModuleLoaderData(foundMapping, mod, kernelVersion)
 	if err != nil {
@@ -81,7 +83,7 @@ func (kh *kernelMapperHelper) findKernelMapping(mappings []kmmv1beta1.KernelMapp
 		}
 	}
 
-	return nil, errors.New("no suitable mapping found")
+	return nil, ErrNoMatchingKernelMapping
 }
 
 func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {


### PR DESCRIPTION
In case kernel mapping for the kernel version is not found, GetModuleLoaderDataForKernel API returns an indistinguishable error, just like in case there was some internal error during processing.
This PR introducing a new propriaetory error: ErrNotFound. In case kernel mapping for a specific kernel does not exists, this error will be returned. As a consequence, the calling code will be able to act seperatly on internal error, or on KernelMapping not present, which may not be an error at all