### PR TITLE
Fixing panic for pull secret implementation

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -56,16 +56,11 @@ type NMCReconciler struct {
 }
 
 func NewNMCReconciler(client client.Client, scheme *runtime.Scheme, workerImage string) *NMCReconciler {
+	pm := newPodManager(client, workerImage, scheme)
+	helper := newWorkerHelper(client, pm)
 	return &NMCReconciler{
 		client: client,
-		helper: &workerHelperImpl{
-			client: client,
-			pm: &podManagerImpl{
-				client:      client,
-				scheme:      scheme,
-				workerImage: workerImage,
-			},
-		},
+		helper: helper,
 	}
 }
 
@@ -207,7 +202,7 @@ type workerHelperImpl struct {
 	pm     podManager
 }
 
-func NewWorkerHelper(client client.Client, pm podManager) workerHelper {
+func newWorkerHelper(client client.Client, pm podManager) workerHelper {
 	return &workerHelperImpl{
 		client: client,
 		pm:     pm,
@@ -470,7 +465,7 @@ type podManagerImpl struct {
 	workerImage string
 }
 
-func NewPodManager(client client.Client, workerImage string, scheme *runtime.Scheme) podManager {
+func newPodManager(client client.Client, workerImage string, scheme *runtime.Scheme) podManager {
 	return &podManagerImpl{
 		client:      client,
 		psh:         &pullSecretHelperImpl{client: client},

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -190,7 +190,7 @@ var _ = Describe("workerHelper_ProcessModuleSpec", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		client = testclient.NewMockClient(ctrl)
 		pm = NewMockpodManager(ctrl)
-		wh = NewWorkerHelper(client, pm)
+		wh = newWorkerHelper(client, pm)
 	})
 
 	It("should create a loader Pod if the corresponding status is missing", func() {
@@ -384,7 +384,7 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		status := &kmmv1beta1.NodeModuleStatus{InProgress: true}
 
 		Expect(
-			NewWorkerHelper(nil, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
+			newWorkerHelper(nil, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -400,7 +400,7 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		client.EXPECT().Status().Return(sw)
 		sw.EXPECT().Patch(ctx, nmc, gomock.Any())
 		Expect(
-			NewWorkerHelper(client, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
+			newWorkerHelper(client, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -411,7 +411,7 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		client := testclient.NewMockClient(ctrl)
 
 		pm := NewMockpodManager(ctrl)
-		wh := NewWorkerHelper(client, pm)
+		wh := newWorkerHelper(client, pm)
 
 		nmc := &kmmv1beta1.NodeModulesConfig{}
 		status := &kmmv1beta1.NodeModuleStatus{
@@ -443,7 +443,7 @@ var _ = Describe("workerHelper_SyncStatus", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kubeClient = testclient.NewMockClient(ctrl)
 		pm = NewMockpodManager(ctrl)
-		wh = NewWorkerHelper(kubeClient, pm)
+		wh = newWorkerHelper(kubeClient, pm)
 		sw = testclient.NewMockStatusWriter(ctrl)
 	})
 
@@ -722,7 +722,7 @@ var _ = Describe("workerHelper_RemoveOrphanFinalizers", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		kubeClient = testclient.NewMockClient(ctrl)
 		pm = NewMockpodManager(ctrl)
-		wh = NewWorkerHelper(kubeClient, pm)
+		wh = newWorkerHelper(kubeClient, pm)
 	})
 
 	It("should do nothing if no pods are present", func() {
@@ -854,7 +854,7 @@ var _ = Describe("podManagerImpl_CreateUnloaderPod", func() {
 			client.EXPECT().Create(ctx, cmpmock.DiffEq(expected)),
 		)
 
-		pm := NewPodManager(client, workerImage, scheme)
+		pm := newPodManager(client, workerImage, scheme)
 		pm.(*podManagerImpl).psh = psh
 
 		Expect(
@@ -892,7 +892,7 @@ var _ = Describe("podManagerImpl_DeletePod", func() {
 			}
 
 			Expect(
-				NewPodManager(kubeclient, workerImage, scheme).DeletePod(ctx, patchedPod),
+				newPodManager(kubeclient, workerImage, scheme).DeletePod(ctx, patchedPod),
 			).NotTo(
 				HaveOccurred(),
 			)
@@ -915,7 +915,7 @@ var _ = Describe("podManagerImpl_ListWorkerPodsOnNode", func() {
 	BeforeEach(func() {
 		ctrl := gomock.NewController(GinkgoT())
 		kubeClient = testclient.NewMockClient(ctrl)
-		pm = NewPodManager(kubeClient, workerImage, scheme)
+		pm = newPodManager(kubeClient, workerImage, scheme)
 	})
 
 	opts := []interface{}{


### PR DESCRIPTION
We need to call newPodManager function in roder to correctly initialize pullSecrets implementator, instead fo initializing workerHelperImpl explicitly