### PR TITLE
Fixing worker pod failure in case no pullsecrets are defined

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -35,6 +35,6 @@ RUN ["apk", "add", "ca-certificates", "kmod"]
 WORKDIR /
 
 COPY --from=builder /workspace/worker /worker
-RUN mkdir -p /mnt/img
+RUN ["mkdir", "-p", "/mnt/img", "/var/run/kmm/pull-secrets"]
 
 ENTRYPOINT ["/worker"]


### PR DESCRIPTION
On initiliazation, worker pod goes over /var/run/kmm/pull-secrets directory in roder to read all pull secret and create authentication keychain. Currently, in case no pullsecrets are define, this function fails, since the directory itself does not exists. This PR defines the directory in the Dockerfile, and during pod creation, pull secrets will be mapping via volumes