### PR TITLE
Make all binaries run as regular users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY go.sum go.sum
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN ["go", "mod", "download"]
 
 # Copy the go source
 COPY api api
@@ -36,7 +36,6 @@ WORKDIR /
 
 ARG TARGET
 
-COPY --from=builder /workspace/${TARGET} /manager
-USER 65532:65532
+COPY --from=builder /workspace/${TARGET} /usr/local/bin/manager
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/local/bin/manager"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -26,7 +26,7 @@ COPY docs.mk docs.mk
 COPY .git .git
 
 # Build
-RUN make worker
+RUN ["make", "worker"]
 
 FROM alpine:3.18
 
@@ -34,7 +34,13 @@ RUN ["apk", "add", "ca-certificates", "kmod"]
 
 WORKDIR /
 
-COPY --from=builder /workspace/worker /worker
-RUN ["mkdir", "-p", "/var/run/kmm/images", "/var/run/kmm/pull-secrets"]
+COPY --from=builder /workspace/worker /usr/local/bin/worker
 
-ENTRYPOINT ["/worker"]
+RUN ["addgroup", "-Sg", "201", "kmm"]
+RUN ["adduser", "-DSs", "/sbin/nologin", "-u", "201", "-G", "kmm", "kmm"]
+RUN ["mkdir", "-p", "/var/run/kmm/images", "/var/run/kmm/pull-secrets"]
+RUN ["chown", "-R", "201:201", "/var/run/kmm/images", "/var/run/kmm/pull-secrets"]
+
+USER 201:201
+
+ENTRYPOINT ["/usr/local/bin/worker"]

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -167,7 +167,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	if err = controllers.NewNMCReconciler(client, scheme, workerImage).SetupWithManager(ctx, mgr); err != nil {
+	if err = controllers.NewNMCReconciler(client, scheme, workerImage, &cfg.Worker).SetupWithManager(ctx, mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.NodeModulesConfigReconcilerName)
 	}
 

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -37,9 +37,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - command:
-        - /manager
-        image: controller:latest
+      - image: controller:latest
         name: manager
         env:
           - name: OPERATOR_NAMESPACE

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+type Worker struct {
+	RunAsUser   *int64 `yaml:"runAsUser"`
+	SELinuxType string `yaml:"seLinuxType"`
+}
+
 type LeaderElection struct {
 	Enabled    bool   `yaml:"enabled"`
 	ResourceID string `yaml:"resourceID"`
@@ -19,6 +24,7 @@ type Config struct {
 	MetricsBindAddress     string         `yaml:"metricsBindAddress"`
 	LeaderElection         LeaderElection `yaml:"leaderElection"`
 	WebhookPort            int            `yaml:"webhookPort"`
+	Worker                 Worker         `yaml:"worker"`
 }
 
 func ParseFile(path string) (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("ParseFile", func() {
@@ -20,6 +21,10 @@ var _ = Describe("ParseFile", func() {
 				ResourceID: "some-resource-id",
 			},
 			WebhookPort: 9443,
+			Worker: Worker{
+				RunAsUser:   pointer.Int64(1234),
+				SELinuxType: "mySELinuxType",
+			},
 		}
 
 		Expect(

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -4,4 +4,7 @@ webhookPort: 9443
 leaderElection:
   enabled: true
   resourceID: some-resource-id
+worker:
+  runAsUser: 1234
+  seLinuxType: mySELinuxType
 


### PR DESCRIPTION
Create UID & GID 201 for the worker image, and use it by default.
Move the `manager` and `worker` binaries under `/usr/local/bin`.
Remove redundant `USER 65532:65532` from the manager Dockerfile.

/cc @yevgeny-shnaidman 