### PR TITLE
Use the `default` ServiceAccount when creating NMC

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -76,11 +76,47 @@ jobs:
           path: kmm-signimage_local.tar
           retention-days: 1
 
+  build-worker-image:
+    runs-on: ubuntu-20.04
+
+    name: Build the worker image
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build the image
+        run:  make workerimage-build WORKER_IMG=kmm-worker:local
+
+      - name: Export the image
+        run: docker save -o kmm-worker_local.tar kmm-worker:local
+
+      - name: Upload the image
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-images
+          if-no-files-found: error
+          path: kmm-worker_local.tar
+          retention-days: 1
+
   e2e:
+    strategy:
+      matrix:
+        include:
+          - name: e2e
+            env:
+              KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci
+            script: ./ci/prow/e2e-incluster-build
+          - name: e2e-hub
+            env:
+              KUSTOMIZE_CONFIG_HUB_DEFAULT: ci/install-ci-hub
+              KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci-spoke
+            import_hub_image: true
+            script: ./ci/prow/e2e-hub-spoke-incluster-build
 
     runs-on: ubuntu-20.04
-    name: e2e
-    needs: [build-operator-image, build-signing-image]
+    name: ${{ matrix.name }}
+    needs: [build-operator-image, build-operator-hub-image, build-signing-image, build-worker-image]
 
     services:
       registry:
@@ -104,76 +140,21 @@ jobs:
 
       - name: Import the KMM operator image into minikube
         run: minikube image load kmm_local.tar
-
-      - name: Copy the signing image to the registry
-        run: |
-          docker load -i kmm-signimage_local.tar
-          docker tag kmm-signimage:local localhost:5000/kmm/signimage:local
-          docker push localhost:5000/kmm/signimage:local
-
-      - name: Set some Ubuntu environment variables
-        run: |
-          grep 'ID=' /etc/os-release >> "$GITHUB_ENV"
-          grep 'VERSION_ID=' /etc/os-release >> "$GITHUB_ENV"
-
-      - name: Cache binaries needed by Makefile
-        id: cache-bin
-        uses: actions/cache@v3
-        with:
-          path: ./bin
-          key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-        if: steps.cache-bin.outputs.cache-hit != 'true'
-
-      - name: Run test
-        run: ./ci/prow/e2e-incluster-build
-        env:
-          KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci
-
-      - name: Collect troubleshooting data
-        uses: ./.github/actions/collect-troubleshooting
-        if: ${{ always() }}
-
-  e2e-hub:
-
-    runs-on: ubuntu-20.04
-    name: e2e-hub
-    needs: [build-operator-image, build-operator-hub-image, build-signing-image]
-
-    services:
-      registry:
-        image: registry:2
-        ports: ['5000:5000/tcp']
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Create the minikube cluster
-        uses: ./.github/actions/create-minikube-cluster
-        with:
-          start-args: --insecure-registry=host.minikube.internal:5000
-
-      - name: Download container images
-        uses: actions/download-artifact@v3
-        with:
-          name: ci-images
 
       - name: Import the KMM-hub operator image into minikube
         run: minikube image load kmm-hub_local.tar
+        if: ${{ matrix.import_hub_image }}
 
-      - name: Import the KMM operator image into minikube
-        run: minikube image load kmm_local.tar
-
-      - name: Copy the signing image to the registry
+      - name: Copy the signing and worker images to the registry
         run: |
           docker load -i kmm-signimage_local.tar
+          docker load -i kmm-worker_local.tar
+          
           docker tag kmm-signimage:local localhost:5000/kmm/signimage:local
+          docker tag kmm-worker:local localhost:5000/kmm/worker:local
+          
           docker push localhost:5000/kmm/signimage:local
+          docker push localhost:5000/kmm/worker:local
 
       - name: Set some Ubuntu environment variables
         run: |
@@ -193,10 +174,9 @@ jobs:
         if: steps.cache-bin.outputs.cache-hit != 'true'
 
       - name: Run test
-        run: ./ci/prow/e2e-hub-spoke-incluster-build
+        run: ${{ matrix.script }}
         env:
-          KUSTOMIZE_CONFIG_HUB_DEFAULT: ci/install-ci-hub
-          KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci-spoke
+          ${{ matrix.env }}
 
       - name: Collect troubleshooting data
         uses: ./.github/actions/collect-troubleshooting

--- a/ci/install-ci-spoke/kustomization.yaml
+++ b/ci/install-ci-spoke/kustomization.yaml
@@ -19,3 +19,5 @@ patches:
               env:
                 - name: KMM_MANAGED
                   value: "1"
+                - name: RELATED_IMAGES_WORKER
+                  value: host.minikube.internal:5000/kmm/worker:local

--- a/ci/install-ci/kustomization.yaml
+++ b/ci/install-ci/kustomization.yaml
@@ -25,3 +25,5 @@ patches:
               env:
                 - name: RELATED_IMAGES_SIGN
                   value: host.minikube.internal:5000/kmm/signimage:local
+                - name: RELATED_IMAGES_WORKER
+                  value: host.minikube.internal:5000/kmm/worker:local

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -4,3 +4,6 @@ webhookPort: 9443
 leaderElection:
   enabled: true
   resourceID: kmm.sigs.x-k8s.io
+worker:
+  runAsUser: 0
+  seLinuxType: spc_t

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -71,6 +71,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
   - modules

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -50,6 +50,7 @@ const (
 //+kubebuilder:rbac:groups="core",resources=pods,verbs=create;delete;get;list;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch
 
 type NMCReconciler struct {
 	client client.Client

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -53,18 +53,24 @@ func (h *helper) SetModuleConfig(
 	if foundEntry == nil {
 		nms := kmmv1beta1.NodeModuleSpec{
 			ModuleItem: kmmv1beta1.ModuleItem{
-				ImageRepoSecret:    mld.ImageRepoSecret,
-				Name:               mld.Name,
-				Namespace:          mld.Namespace,
-				ServiceAccountName: mld.ServiceAccountName,
+				Name:      mld.Name,
+				Namespace: mld.Namespace,
 			},
 		}
 
 		nmc.Spec.Modules = append(nmc.Spec.Modules, nms)
 		foundEntry = &nmc.Spec.Modules[len(nmc.Spec.Modules)-1]
 	}
+
+	saName := mld.ServiceAccountName
+	if saName == "" {
+		saName = "default"
+	}
+
 	setLabel(nmc, mld.Namespace, mld.Name)
 	foundEntry.Config = *moduleConfig
+	foundEntry.ImageRepoSecret = mld.ImageRepoSecret
+	foundEntry.ServiceAccountName = saName
 
 	return nil
 }

--- a/internal/nmc/helper_test.go
+++ b/internal/nmc/helper_test.go
@@ -78,8 +78,10 @@ var _ = Describe("SetModuleConfig", func() {
 		nmcHelper = NewHelper(nil)
 	})
 
-	namespace := "test_namespace"
-	name := "test_name"
+	const (
+		namespace = "test_namespace"
+		name      = "test_name"
+	)
 
 	nmc := kmmv1beta1.NodeModulesConfig{}
 
@@ -100,10 +102,13 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(3))
 		Expect(nmc.Spec.Modules[2].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
+		Expect(nmc.Spec.Modules[2].ServiceAccountName).To(Equal("default"))
 		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 
 	It("changing existing module config", func() {
+		const saName = "test-sa"
+
 		nmc.Spec.Modules = []kmmv1beta1.NodeModuleSpec{
 			{
 				ModuleItem: kmmv1beta1.ModuleItem{
@@ -121,12 +126,18 @@ var _ = Describe("SetModuleConfig", func() {
 		}
 
 		moduleConfig := kmmv1beta1.ModuleConfig{InTreeModuleToRemove: "in-tree-module"}
+		mld := api.ModuleLoaderData{
+			Name:               name,
+			Namespace:          namespace,
+			ServiceAccountName: saName,
+		}
 
-		err := nmcHelper.SetModuleConfig(&nmc, &api.ModuleLoaderData{Name: name, Namespace: namespace}, &moduleConfig)
+		err := nmcHelper.SetModuleConfig(&nmc, &mld, &moduleConfig)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
+		Expect(nmc.Spec.Modules[1].ServiceAccountName).To(Equal(saName))
 		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 })


### PR DESCRIPTION
Using `default` instead of an empty string allows us to attach all pull secrets configured for that account when setting up the mounts for the worker Pod.

/cc @yevgeny-shnaidman 