### PR TITLE
Explicitly checking PodPending when reporting Build/Sign status

### DIFF
--- a/internal/utils/podhelper.go
+++ b/internal/utils/podhelper.go
@@ -119,12 +119,12 @@ func (ph *podHelper) CreatePod(ctx context.Context, pod *v1.Pod) error {
 // GetPodStatus returns the status of a Pod, whether the latter is in progress or not and
 // whether there was an error or not
 func (ph *podHelper) GetPodStatus(pod *v1.Pod) (Status, error) {
-	switch {
-	case pod.Status.Phase == v1.PodSucceeded:
+	switch pod.Status.Phase {
+	case v1.PodSucceeded:
 		return StatusCompleted, nil
-	case pod.Status.Phase == v1.PodRunning:
+	case v1.PodRunning, v1.PodPending:
 		return StatusInProgress, nil
-	case pod.Status.Phase == v1.PodFailed:
+	case v1.PodFailed:
 		return StatusFailed, nil
 	default:
 		return "", fmt.Errorf("unknown status: %v", pod.Status)

--- a/internal/utils/podhelper_test.go
+++ b/internal/utils/podhelper_test.go
@@ -425,7 +425,9 @@ var _ = Describe("PodStatus", func() {
 		},
 		Entry("succeeded", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodSucceeded}}, StatusCompleted, false),
 		Entry("in progress", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodRunning}}, StatusInProgress, false),
+		Entry("pending", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodPending}}, StatusInProgress, false),
 		Entry("Failed", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}}, StatusFailed, false),
+		Entry("Unknown", &v1.Pod{Status: v1.PodStatus{Phase: v1.PodUnknown}}, "", true),
 	)
 })
 


### PR DESCRIPTION
Currently, PodPending phase of a running pod is not explicitly checked, which may cause an unnecessary errors reported. It does not affect the correctness of the flow, but does causes confusion in logs