### PR TITLE
Implementing ordered upgrade feature for V2

### DIFF
--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -55,6 +55,17 @@ func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {
 	return versionLabels
 }
 
+func GetNodesModuleLoaderVersionLabel(nodeLabels map[string]string, namespace, name string) (string, bool) {
+	if nodeLabels == nil {
+		return "", false
+	}
+	labelValue, ok := nodeLabels[GetModuleLoaderVersionLabelName(namespace, name)]
+	if !ok {
+		return "", false
+	}
+	return labelValue, true
+}
+
 func GetModuleNMCLabel(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleNMCLabelPrefix, namespace, name)
 }


### PR DESCRIPTION
Current implementation involves creating a daemonset per module version, and setting ModuleLoader/DevicePlugin labels for the version value into the Daemosets selector fields. NodeLabelModuleVersion controller adds/removes appropriate labels from nodes based on customer input.

In V2, device plugin ordered upgrade implmentation will remain the same. For kernel modules, module-nmc reconciler will decide how to change NMCs based on the labels' changes of the nodes (provided by NodeLabelModuleVersion controler).

Module-NMC will use the following decicion-making table to update NCM: 
1) if module is targeting the node, but kernel is not suitable - delete
   from NMC
2) if module is targeting the node, but the version is missing from
   Module (not an ordered upgrade) - add to NMC
3) if module is targeting the node, module loader version label is
   present on the node and its value equal to Module's version - add to
   NMC
4) if module is targeting the node, module loader version label is
   present on the node and its value is not equal to Module's version
   (meaning that the old version should be running) - no update to NMC.
5) if module is targeting the node, module loader version label is not
   present on the node, and Module's version is defined (meaning that
   currently no version should be running on the node) - delete from NMC