### PR TITLE
Changing daemonsets GarbageCollector for v2

### DIFF
--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -37,7 +37,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -362,9 +361,7 @@ func (mrh *moduleReconcilerHelper) garbageCollect(ctx context.Context,
 	existingDS []appsv1.DaemonSet) error {
 	logger := log.FromContext(ctx)
 	// Garbage collect old DaemonSets for which there are no nodes.
-	validKernels := sets.KeySet[string](mldMappings)
-
-	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, mod, existingDS, validKernels)
+	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, mod, existingDS)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect DaemonSets: %v", err)
 	}

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -646,9 +645,8 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 			"kernelVersion1": &api.ModuleLoaderData{}, "kernelVersion2": &api.ModuleLoaderData{},
 		}
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
-		kernelSet := sets.New[string]("kernelVersion1", "kernelVersion2")
 		gomock.InOrder(
-			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil),
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, nil),
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 			mockSM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 		)
@@ -664,12 +662,11 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 			"kernelVersion1": &api.ModuleLoaderData{}, "kernelVersion2": &api.ModuleLoaderData{},
 		}
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
-		kernelSet := sets.New[string]("kernelVersion1", "kernelVersion2")
 		if dcError {
-			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, returnedError)
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil)
+		mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, nil)
 		if buildError {
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, returnedError)
 			goto executeTestFunction

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -12,7 +12,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
-	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockDaemonSetCreator is a mock of DaemonSetCreator interface.
@@ -39,18 +38,18 @@ func (m *MockDaemonSetCreator) EXPECT() *MockDaemonSetCreatorMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS, validKernels)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS, validKernels interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS, validKernels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS)
 }
 
 // GetModuleDaemonSets mocks base method.


### PR DESCRIPTION
KMM V2 does not contain Daemonset for ModuleLoader anymore, only for DevicePlugin. This PR changes implementatio n of GarbageCollector function in daemonset package and the appropriate unit-tests. The changes for the GC function include:
1) no need to handle Module Loader daemonsets, including Module Version
   use case
2) no need verifying kernel versions of the nodes, which means changes
   to the GC function input parameters