### PR TITLE
Finalize Module resources

### DIFF
--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -29,7 +29,10 @@ echo "Check that the module gets loaded on the node..."
 timeout 10m bash -c 'until minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
 
 echo "Remove the Module..."
-kubectl delete -f ci/module-kmm-ci-build-sign.yaml
+kubectl delete -f ci/module-kmm-ci-build-sign.yaml --wait=false
 
 echo "Check that the module gets unloaded from the node..."
 timeout 1m bash -c 'until ! minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Wait for the Module to be deleted..."
+kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -18,31 +18,45 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockworkerHelper is a mock of workerHelper interface.
-type MockworkerHelper struct {
+// MocknmcReconcilerHelper is a mock of nmcReconcilerHelper interface.
+type MocknmcReconcilerHelper struct {
 	ctrl     *gomock.Controller
-	recorder *MockworkerHelperMockRecorder
+	recorder *MocknmcReconcilerHelperMockRecorder
 }
 
-// MockworkerHelperMockRecorder is the mock recorder for MockworkerHelper.
-type MockworkerHelperMockRecorder struct {
-	mock *MockworkerHelper
+// MocknmcReconcilerHelperMockRecorder is the mock recorder for MocknmcReconcilerHelper.
+type MocknmcReconcilerHelperMockRecorder struct {
+	mock *MocknmcReconcilerHelper
 }
 
-// NewMockworkerHelper creates a new mock instance.
-func NewMockworkerHelper(ctrl *gomock.Controller) *MockworkerHelper {
-	mock := &MockworkerHelper{ctrl: ctrl}
-	mock.recorder = &MockworkerHelperMockRecorder{mock}
+// NewMocknmcReconcilerHelper creates a new mock instance.
+func NewMocknmcReconcilerHelper(ctrl *gomock.Controller) *MocknmcReconcilerHelper {
+	mock := &MocknmcReconcilerHelper{ctrl: ctrl}
+	mock.recorder = &MocknmcReconcilerHelperMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockworkerHelper) EXPECT() *MockworkerHelperMockRecorder {
+func (m *MocknmcReconcilerHelper) EXPECT() *MocknmcReconcilerHelperMockRecorder {
 	return m.recorder
 }
 
+// GarbageCollectInUseLabels mocks base method.
+func (m *MocknmcReconcilerHelper) GarbageCollectInUseLabels(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollectInUseLabels", ctx, nmc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GarbageCollectInUseLabels indicates an expected call of GarbageCollectInUseLabels.
+func (mr *MocknmcReconcilerHelperMockRecorder) GarbageCollectInUseLabels(ctx, nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectInUseLabels", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).GarbageCollectInUseLabels), ctx, nmc)
+}
+
 // ProcessModuleSpec mocks base method.
-func (m *MockworkerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus) error {
+func (m *MocknmcReconcilerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessModuleSpec", ctx, nmc, spec, status)
 	ret0, _ := ret[0].(error)
@@ -50,27 +64,27 @@ func (m *MockworkerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.N
 }
 
 // ProcessModuleSpec indicates an expected call of ProcessModuleSpec.
-func (mr *MockworkerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MockworkerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status)
 }
 
-// ProcessOrphanModuleStatus mocks base method.
-func (m *MockworkerHelper) ProcessOrphanModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus) error {
+// ProcessUnconfiguredModuleStatus mocks base method.
+func (m *MocknmcReconcilerHelper) ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessOrphanModuleStatus", ctx, nmc, status)
+	ret := m.ctrl.Call(m, "ProcessUnconfiguredModuleStatus", ctx, nmc, status)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ProcessOrphanModuleStatus indicates an expected call of ProcessOrphanModuleStatus.
-func (mr *MockworkerHelperMockRecorder) ProcessOrphanModuleStatus(ctx, nmc, status any) *gomock.Call {
+// ProcessUnconfiguredModuleStatus indicates an expected call of ProcessUnconfiguredModuleStatus.
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessUnconfiguredModuleStatus(ctx, nmc, status any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessOrphanModuleStatus", reflect.TypeOf((*MockworkerHelper)(nil).ProcessOrphanModuleStatus), ctx, nmc, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessUnconfiguredModuleStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessUnconfiguredModuleStatus), ctx, nmc, status)
 }
 
 // RemoveOrphanFinalizers mocks base method.
-func (m *MockworkerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
+func (m *MocknmcReconcilerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveOrphanFinalizers", ctx, nodeName)
 	ret0, _ := ret[0].(error)
@@ -78,13 +92,13 @@ func (m *MockworkerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName 
 }
 
 // RemoveOrphanFinalizers indicates an expected call of RemoveOrphanFinalizers.
-func (mr *MockworkerHelperMockRecorder) RemoveOrphanFinalizers(ctx, nodeName any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) RemoveOrphanFinalizers(ctx, nodeName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanFinalizers", reflect.TypeOf((*MockworkerHelper)(nil).RemoveOrphanFinalizers), ctx, nodeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanFinalizers", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).RemoveOrphanFinalizers), ctx, nodeName)
 }
 
 // SyncStatus mocks base method.
-func (m *MockworkerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc)
 	ret0, _ := ret[0].(error)
@@ -92,9 +106,9 @@ func (m *MockworkerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModu
 }
 
 // SyncStatus indicates an expected call of SyncStatus.
-func (mr *MockworkerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MockworkerHelper)(nil).SyncStatus), ctx, nmc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
 }
 
 // MockpodManager is a mock of podManager interface.

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/config"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/labels"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/nmc"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/worker"
 	v1 "k8s.io/api/core/v1"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/cmd/util/podcmd"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -55,7 +57,7 @@ const (
 
 type NMCReconciler struct {
 	client client.Client
-	helper workerHelper
+	helper nmcReconcilerHelper
 }
 
 func NewNMCReconciler(
@@ -118,6 +120,8 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 				errs,
 				fmt.Errorf("error processing Module %s: %v", moduleNameKey, err),
 			)
+
+			continue
 		}
 
 		delete(statusMap, moduleNameKey)
@@ -129,7 +133,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	for statusNameKey, status := range statusMap {
 		logger := logger.WithValues("status", statusNameKey)
 
-		if err := r.helper.ProcessOrphanModuleStatus(ctrl.LoggerInto(ctx, logger), &nmcObj, status); err != nil {
+		if err := r.helper.ProcessUnconfiguredModuleStatus(ctrl.LoggerInto(ctx, logger), &nmcObj, status); err != nil {
 			errs = append(
 				errs,
 				fmt.Errorf("erorr processing orphan status for Module %s: %v", statusNameKey, err),
@@ -137,7 +141,15 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		}
 	}
 
-	return ctrl.Result{}, errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not process orphan statuses: %v", err)
+	}
+
+	if err := r.helper.GarbageCollectInUseLabels(ctx, &nmcObj); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not garbage collect in-use labels for NMC %s: %v", req.NamespacedName, err)
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *NMCReconciler) SetupWithManager(ctx context.Context, mgr manager.Manager) error {
@@ -198,23 +210,63 @@ func FindNodeCondition(cond []v1.NodeCondition, conditionType v1.NodeConditionTy
 
 //go:generate mockgen -source=nmc_reconciler.go -package=controllers -destination=mock_nmc_reconciler.go workerHelper
 
-type workerHelper interface {
+type nmcReconcilerHelper interface {
+	GarbageCollectInUseLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
 	ProcessModuleSpec(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, spec *kmmv1beta1.NodeModuleSpec, status *kmmv1beta1.NodeModuleStatus) error
-	ProcessOrphanModuleStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, status *kmmv1beta1.NodeModuleStatus) error
-	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
+	ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, status *kmmv1beta1.NodeModuleStatus) error
 	RemoveOrphanFinalizers(ctx context.Context, nodeName string) error
+	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
 }
 
-type workerHelperImpl struct {
+type nmcReconcilerHelperImpl struct {
 	client client.Client
 	pm     podManager
 }
 
-func newWorkerHelper(client client.Client, pm podManager) workerHelper {
-	return &workerHelperImpl{
+func newWorkerHelper(client client.Client, pm podManager) nmcReconcilerHelper {
+	return &nmcReconcilerHelperImpl{
 		client: client,
 		pm:     pm,
 	}
+}
+
+// GarbageCollectInUseLabels removes all module-in-use labels for which there is no corresponding entry either in
+// spec.modules or in status.modules.
+func (h *nmcReconcilerHelperImpl) GarbageCollectInUseLabels(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig) error {
+	labelSet := sets.New[string]()
+	desiredSet := sets.New[string]()
+
+	for k := range nmcObj.Labels {
+		if ok, _, _ := nmc.IsModuleInUseLabel(k); ok {
+			labelSet.Insert(k)
+		}
+	}
+
+	for _, s := range nmcObj.Spec.Modules {
+		desiredSet.Insert(
+			nmc.ModuleInUseLabel(s.Namespace, s.Name),
+		)
+	}
+
+	for _, s := range nmcObj.Status.Modules {
+		desiredSet.Insert(
+			nmc.ModuleInUseLabel(s.Namespace, s.Name),
+		)
+	}
+
+	diff := labelSet.Difference(desiredSet)
+
+	if diff.Len() != 0 {
+		patchFrom := client.MergeFrom(nmcObj.DeepCopy())
+
+		for k := range diff {
+			delete(nmcObj.Labels, k)
+		}
+
+		return h.client.Patch(ctx, nmcObj, patchFrom)
+	}
+
+	return nil
 }
 
 // ProcessModuleSpec determines if a worker Pod should be created for a Module entry in a
@@ -227,9 +279,9 @@ func newWorkerHelper(client client.Client, pm podManager) workerHelper {
 //
 // An unloading worker Pod is created when the entry in .spec.modules has a different config compared to the entry in
 // .status.modules.
-func (w *workerHelperImpl) ProcessModuleSpec(
+func (h *nmcReconcilerHelperImpl) ProcessModuleSpec(
 	ctx context.Context,
-	nmc *kmmv1beta1.NodeModulesConfig,
+	nmcObj *kmmv1beta1.NodeModulesConfig,
 	spec *kmmv1beta1.NodeModuleSpec,
 	status *kmmv1beta1.NodeModuleStatus,
 ) error {
@@ -237,7 +289,7 @@ func (w *workerHelperImpl) ProcessModuleSpec(
 
 	if status == nil {
 		logger.Info("Missing status; creating loader Pod")
-		return w.pm.CreateLoaderPod(ctx, nmc, spec)
+		return h.pm.CreateLoaderPod(ctx, nmcObj, spec)
 	}
 
 	if status.InProgress {
@@ -247,30 +299,30 @@ func (w *workerHelperImpl) ProcessModuleSpec(
 
 	if status.Config == nil {
 		logger.Info("Missing status config and pod is not running: previously failed pod, creating loader Pod")
-		return w.pm.CreateLoaderPod(ctx, nmc, spec)
+		return h.pm.CreateLoaderPod(ctx, nmcObj, spec)
 	}
 
 	if !reflect.DeepEqual(spec.Config, *status.Config) {
 		logger.Info("Outdated config in status; creating unloader Pod")
 
-		return w.pm.CreateUnloaderPod(ctx, nmc, status)
+		return h.pm.CreateUnloaderPod(ctx, nmcObj, status)
 	}
 
 	node := v1.Node{}
 
-	if err := w.client.Get(ctx, types.NamespacedName{Name: nmc.Name}, &node); err != nil {
-		return fmt.Errorf("could not get node %s: %v", nmc.Name, err)
+	if err := h.client.Get(ctx, types.NamespacedName{Name: nmcObj.Name}, &node); err != nil {
+		return fmt.Errorf("could not get node %s: %v", nmcObj.Name, err)
 	}
 
 	readyCondition := FindNodeCondition(node.Status.Conditions, v1.NodeReady)
 	if readyCondition == nil {
-		return fmt.Errorf("node %s has no Ready condition", nmc.Name)
+		return fmt.Errorf("node %s has no Ready condition", nmcObj.Name)
 	}
 
 	if readyCondition.Status == v1.ConditionTrue && status.LastTransitionTime.Before(&readyCondition.LastTransitionTime) {
 		logger.Info("Outdated last transition time status; creating loader Pod")
 
-		return w.pm.CreateLoaderPod(ctx, nmc, spec)
+		return h.pm.CreateLoaderPod(ctx, nmcObj, spec)
 	}
 
 	logger.Info("Spec and status in sync; nothing to do")
@@ -278,7 +330,14 @@ func (w *workerHelperImpl) ProcessModuleSpec(
 	return nil
 }
 
-func (w *workerHelperImpl) ProcessOrphanModuleStatus(
+// ProcessUnconfiguredModuleStatus cleans up a NodeModuleStatus.
+// It should be called for each status entry for which the NodeModulesConfigs does not have a spec entry; this means
+// that KMM wants the module unloaded from the node.
+// If status.Config field is nil, then it represents a module that could not be loaded by a worker Pod.
+// ProcessUnconfiguredModuleStatus will then remove status from nmcObj's Status.Modules.
+// If status.Config is not nil, it means that the module was successfully loaded.
+// ProcessUnconfiguredModuleStatus will then create a worker pod to unload the module.
+func (h *nmcReconcilerHelperImpl) ProcessUnconfiguredModuleStatus(
 	ctx context.Context,
 	nmcObj *kmmv1beta1.NodeModulesConfig,
 	status *kmmv1beta1.NodeModuleStatus,
@@ -294,16 +353,16 @@ func (w *workerHelperImpl) ProcessOrphanModuleStatus(
 		logger.Info("Missing status config and pod is not running: previously failed pod, no need to unload")
 		patchFrom := client.MergeFrom(nmcObj.DeepCopy())
 		nmc.RemoveModuleStatus(&nmcObj.Status.Modules, status.Namespace, status.Name)
-		return w.client.Status().Patch(ctx, nmcObj, patchFrom)
+		return h.client.Status().Patch(ctx, nmcObj, patchFrom)
 	}
 
 	logger.Info("Creating unloader Pod")
 
-	return w.pm.CreateUnloaderPod(ctx, nmcObj, status)
+	return h.pm.CreateUnloaderPod(ctx, nmcObj, status)
 }
 
-func (w *workerHelperImpl) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
-	pods, err := w.pm.ListWorkerPodsOnNode(ctx, nodeName)
+func (h *nmcReconcilerHelperImpl) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
+	pods, err := h.pm.ListWorkerPodsOnNode(ctx, nodeName)
 	if err != nil {
 		return fmt.Errorf("could not delete orphan worker Pods on node %s: %v", nodeName, err)
 	}
@@ -316,7 +375,7 @@ func (w *workerHelperImpl) RemoveOrphanFinalizers(ctx context.Context, nodeName 
 		mergeFrom := client.MergeFrom(pod.DeepCopy())
 
 		if controllerutil.RemoveFinalizer(pod, nodeModulesConfigFinalizer) {
-			if err = w.client.Patch(ctx, pod, mergeFrom); err != nil {
+			if err = h.client.Patch(ctx, pod, mergeFrom); err != nil {
 				errs = append(
 					errs,
 					fmt.Errorf("could not patch Pod %s/%s: %v", pod.Namespace, pod.Name, err),
@@ -330,12 +389,12 @@ func (w *workerHelperImpl) RemoveOrphanFinalizers(ctx context.Context, nodeName 
 	return errors.Join(errs...)
 }
 
-func (w *workerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig) error {
+func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	logger.Info("Syncing status")
 
-	pods, err := w.pm.ListWorkerPodsOnNode(ctx, nmcObj.Name)
+	pods, err := h.pm.ListWorkerPodsOnNode(ctx, nmcObj.Name)
 	if err != nil {
 		return fmt.Errorf("could not list worker pods for NodeModulesConfig %s: %v", nmcObj.Name, err)
 	}
@@ -380,7 +439,6 @@ func (w *workerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.No
 			status.InProgress = false
 			updateModuleStatus = true
 			podsToDelete = append(podsToDelete, p)
-
 		case v1.PodSucceeded:
 			if p.Labels[actionLabelKey] == WorkerActionUnload {
 				podsToDelete = append(podsToDelete, p)
@@ -411,7 +469,6 @@ func (w *workerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.No
 
 			status.LastTransitionTime = &podLTT
 			podsToDelete = append(podsToDelete, p)
-
 		case v1.PodPending, v1.PodRunning:
 			status.InProgress = true
 			updateModuleStatus = true
@@ -428,7 +485,7 @@ func (w *workerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.No
 		}
 	}
 
-	err = w.client.Status().Patch(ctx, nmcObj, patchFrom)
+	err = h.client.Status().Patch(ctx, nmcObj, patchFrom)
 	errs = append(errs, err)
 	if err = errors.Join(errs...); err != nil {
 		return fmt.Errorf("encountered errors while reconciling NMC %s status: %v", nmcObj.Name, err)
@@ -440,7 +497,7 @@ func (w *workerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.No
 	// in the reconcile loop, and in that case we can always try to delete the pod manually, and after that the flow will be able to continue
 	errs = errs[:0]
 	for _, pod := range podsToDelete {
-		err = w.pm.DeletePod(ctx, &pod)
+		err = h.pm.DeletePod(ctx, &pod)
 		errs = append(errs, err)
 	}
 
@@ -502,7 +559,7 @@ func (p *podManagerImpl) CreateLoaderPod(ctx context.Context, nmc client.Object,
 		}
 	}
 
-	setWorkerActionLabel(pod, WorkerActionLoad)
+	labels.SetLabel(pod, actionLabelKey, WorkerActionLoad)
 	pod.Spec.RestartPolicy = v1.RestartPolicyNever
 
 	return p.client.Create(ctx, pod)
@@ -528,7 +585,7 @@ func (p *podManagerImpl) CreateUnloaderPod(ctx context.Context, nmc client.Objec
 		}
 	}
 
-	setWorkerActionLabel(pod, WorkerActionUnload)
+	labels.SetLabel(pod, actionLabelKey, WorkerActionUnload)
 
 	return p.client.Create(ctx, pod)
 }
@@ -717,18 +774,6 @@ func (p *podManagerImpl) baseWorkerPod(
 	controllerutil.AddFinalizer(&pod, nodeModulesConfigFinalizer)
 
 	return &pod, nil
-}
-
-func setWorkerActionLabel(pod *v1.Pod, action WorkerAction) {
-	labels := pod.GetLabels()
-
-	if labels == nil {
-		labels = make(map[string]string)
-	}
-
-	labels[actionLabelKey] = string(action)
-
-	pod.SetLabels(labels)
 }
 
 func setWorkerConfigAnnotation(pod *v1.Pod, cfg kmmv1beta1.ModuleConfig) error {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -172,6 +172,41 @@ var _ = Describe("kmmClusterClaimChanged", func() {
 	)
 })
 
+var _ = Describe("ListModulesForNMC", func() {
+	const (
+		namespace0 = "namespace0"
+		name0      = "name0"
+		namespace1 = "namespace1"
+		name1      = "name1"
+		namespace2 = "namespace2"
+		name2      = "name2"
+	)
+
+	It("should work as expected", func() {
+		nmcObj := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"abc": "def",
+					nmc.ModuleConfiguredLabel(namespace0, name0): "",
+					nmc.ModuleInUseLabel(namespace0, name0):      "",
+					nmc.ModuleConfiguredLabel(namespace1, name1): "",
+					nmc.ModuleInUseLabel(namespace2, name2):      "",
+				},
+			},
+		}
+
+		Expect(
+			ListModulesForNMC(context.TODO(), nmcObj),
+		).To(
+			ConsistOf(
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace0, Name: name0}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace1, Name: name1}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace2, Name: name2}},
+			),
+		)
+	})
+})
+
 var _ = Describe("ModuleReconcilerNodePredicate", func() {
 	const kernelLabel = "kernel-label"
 	var p predicate.Predicate

--- a/internal/filter/suite_test.go
+++ b/internal/filter/suite_test.go
@@ -3,20 +3,11 @@ package filter
 import (
 	"testing"
 
-	"github.com/kubernetes-sigs/kernel-module-management/internal/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
 )
-
-var scheme *runtime.Scheme
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	var err error
-	scheme, err = test.TestScheme()
-	Expect(err).NotTo(HaveOccurred())
-
 	RunSpecs(t, "Filter Suite")
 }

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,27 @@
+package labels
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+func RemoveLabel(obj client.Object, key string) {
+	labels := obj.GetLabels()
+
+	if labels == nil {
+		return
+	}
+
+	delete(labels, key)
+
+	obj.SetLabels(labels)
+}
+
+func SetLabel(obj client.Object, key, value string) {
+	labels := obj.GetLabels()
+
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+
+	labels[key] = value
+
+	obj.SetLabels(labels)
+}

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -1,0 +1,55 @@
+package labels
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("SetLabel", func() {
+	const key = "test-key"
+
+	DescribeTable(
+		"should work as expected",
+		func(labels map[string]string, key, value string) {
+			obj := &unstructured.Unstructured{}
+
+			obj.SetLabels(labels)
+
+			SetLabel(obj, key, value)
+
+			Expect(
+				obj.GetLabels(),
+			).To(
+				HaveKeyWithValue(key, value),
+			)
+		},
+		Entry("nil labels", nil, key, "test value"),
+		Entry("empty labels", make(map[string]string), key, "test value"),
+		Entry("existing label", map[string]string{key: "some-other-value"}, key, "test value"),
+	)
+})
+
+var _ = Describe("RemoveLabel", func() {
+	const key = "test-key"
+
+	DescribeTable(
+		"should work as expected",
+		func(labels map[string]string, key string) {
+			obj := &unstructured.Unstructured{}
+
+			obj.SetLabels(labels)
+
+			RemoveLabel(obj, key)
+
+			Expect(
+				obj.GetLabels(),
+			).NotTo(
+				HaveKey(key),
+			)
+		},
+		Entry("nil labels", nil, key),
+		Entry("empty labels", make(map[string]string), key),
+		Entry("existing label", map[string]string{key: "some-other-value"}, key),
+	)
+})

--- a/internal/labels/suite_test.go
+++ b/internal/labels/suite_test.go
@@ -1,4 +1,4 @@
-package nmc
+package labels
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NMC Suite")
+	RunSpecs(t, "Labels Suite")
 }

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
 //go:generate mockgen -source=helper.go -package=nmc -destination=mock_helper.go
@@ -67,7 +65,6 @@ func (h *helper) SetModuleConfig(
 		saName = "default"
 	}
 
-	setLabel(nmc, mld.Namespace, mld.Name)
 	foundEntry.Config = *moduleConfig
 	foundEntry.ImageRepoSecret = mld.ImageRepoSecret
 	foundEntry.ServiceAccountName = saName
@@ -80,7 +77,6 @@ func (h *helper) RemoveModuleConfig(nmc *kmmv1beta1.NodeModulesConfig, namespace
 	if foundEntry != nil {
 		nmc.Spec.Modules = append(nmc.Spec.Modules[:index], nmc.Spec.Modules[index+1:]...)
 	}
-	removeLabel(nmc, namespace, name)
 	return nil
 }
 
@@ -132,24 +128,5 @@ func SetModuleStatus(statuses *[]kmmv1beta1.NodeModuleStatus, status kmmv1beta1.
 		*s = status
 	} else {
 		*statuses = append(*statuses, status)
-	}
-}
-
-func setLabel(nmc *kmmv1beta1.NodeModulesConfig, namespace, name string) {
-	moduleNMCLabel := utils.GetModuleNMCLabel(namespace, name)
-	nmcLabels := nmc.GetLabels()
-	if nmcLabels == nil {
-		nmcLabels = map[string]string{}
-	}
-	nmcLabels[moduleNMCLabel] = ""
-	nmc.SetLabels(nmcLabels)
-}
-
-func removeLabel(nmc *kmmv1beta1.NodeModulesConfig, namespace, name string) {
-	moduleNMCLabel := utils.GetModuleNMCLabel(namespace, name)
-	nmcLabels := nmc.GetLabels()
-	if nmcLabels != nil {
-		delete(nmcLabels, moduleNMCLabel)
-		nmc.SetLabels(nmcLabels)
 	}
 }

--- a/internal/nmc/helper_test.go
+++ b/internal/nmc/helper_test.go
@@ -6,16 +6,14 @@ import (
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
-	"go.uber.org/mock/gomock"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -103,7 +101,6 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(len(nmc.Spec.Modules)).To(Equal(3))
 		Expect(nmc.Spec.Modules[2].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
 		Expect(nmc.Spec.Modules[2].ServiceAccountName).To(Equal("default"))
-		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 
 	It("changing existing module config", func() {
@@ -138,7 +135,6 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
 		Expect(nmc.Spec.Modules[1].ServiceAccountName).To(Equal(saName))
-		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 })
 
@@ -178,11 +174,10 @@ var _ = Describe("RemoveModuleConfig", func() {
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[0].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-1"))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-2"))
-		Expect(nmc.GetLabels()).NotTo(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 
 	It("deleting existing module", func() {
-		nmc.SetLabels(map[string]string{utils.GetModuleNMCLabel(namespace, name): ""})
+		nmc.SetLabels(map[string]string{ModuleConfiguredLabel(namespace, name): ""})
 		nmc.Spec.Modules = []kmmv1beta1.NodeModuleSpec{
 			{
 				ModuleItem: kmmv1beta1.ModuleItem{
@@ -205,7 +200,6 @@ var _ = Describe("RemoveModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(1))
 		Expect(nmc.Spec.Modules[0].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-1"))
-		Expect(nmc.GetLabels()).NotTo(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 })
 

--- a/internal/nmc/labels.go
+++ b/internal/nmc/labels.go
@@ -1,0 +1,39 @@
+package nmc
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	reConfiguredLabel = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-configured$`)
+	reInUseLabel      = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-in-use$`)
+)
+
+func IsModuleConfiguredLabel(s string) (bool, string, string) {
+	res := reConfiguredLabel.FindStringSubmatch(s)
+
+	if len(res) != 3 {
+		return false, "", ""
+	}
+
+	return true, res[1], res[2]
+}
+
+func IsModuleInUseLabel(s string) (bool, string, string) {
+	res := reInUseLabel.FindStringSubmatch(s)
+
+	if len(res) != 3 {
+		return false, "", ""
+	}
+
+	return true, res[1], res[2]
+}
+
+func ModuleConfiguredLabel(namespace, name string) string {
+	return fmt.Sprintf("beta.kmm.node.kubernetes.io/%s.%s.module-configured", namespace, name)
+}
+
+func ModuleInUseLabel(namespace, name string) string {
+	return fmt.Sprintf("beta.kmm.node.kubernetes.io/%s.%s.module-in-use", namespace, name)
+}

--- a/internal/nmc/labels_test.go
+++ b/internal/nmc/labels_test.go
@@ -1,0 +1,74 @@
+package nmc
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ModuleConfiguredLabel", func() {
+	It("should work as expected", func() {
+
+		Expect(
+			ModuleConfiguredLabel("a", "b"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.module-configured"),
+		)
+	})
+})
+
+var _ = Describe("ModuleInUseLabel", func() {
+	It("should work as expected", func() {
+
+		Expect(
+			ModuleInUseLabel("a", "b"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.module-in-use"),
+		)
+	})
+})
+
+var _ = Describe("IsModuleConfiguredLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expectedOK bool, expectedNS, expectedName string) {
+			ok, ns, name := IsModuleConfiguredLabel(input)
+
+			if !expectedOK {
+				Expect(ok).To(BeFalse())
+				return
+			}
+
+			Expect(ok).To(BeTrue())
+			Expect(ns).To(Equal(expectedNS))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry(nil, "a.b.module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a.b.module-configured", true, "a", "b"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/..module-configured", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-configured", true, "a123", "b456"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-configured", true, "with-hypen", "withouthypen"),
+	)
+})
+
+var _ = Describe("IsModuleInUseLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expectedOK bool, expectedNS, expectedName string) {
+			ok, ns, name := IsModuleInUseLabel(input)
+
+			if !expectedOK {
+				Expect(ok).To(BeFalse())
+				return
+			}
+
+			Expect(ok).To(BeTrue())
+			Expect(ns).To(Equal(expectedNS))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry(nil, "a.b.module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a.b.module-in-use", true, "a", "b"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/..module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-in-use", true, "a123", "b456"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-in-use", true, "with-hypen", "withouthypen"),
+	)
+})

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -65,7 +65,3 @@ func GetNodeWorkerPodVersionLabel(nodeLabels map[string]string, namespace, name 
 	}
 	return labelValue, true
 }
-
-func GetModuleNMCLabel(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.ModuleNMCLabelPrefix, namespace, name)
-}


### PR DESCRIPTION
Wait for kmods to be unloaded on all nodes to delete a `Module`.
This is implemented through 2 labels:
- `beta.kmm.node.kubernetes.io/<ns>.<name>.module-configured`
- `beta.kmm.node.kubernetes.io/<ns>.<name>.module-in-use`

Both labels are set by the Module-NMC reconciler when an entry is added to the NMC spec.
The first label is removed by the Module-NMC reconciler when, for any reason, the NMC is not targeted by the Module anymore.
The second label is removed by the NMC reconciler when the unloading worker pod is successful and the kmod is not present in the spec list anymore.
For the Module finalizer to be removed, no NMC must carry neither of these 2 labels.

/cc @yevgeny-shnaidman @mresvanis