### PR TITLE
Handling of kmm  module ready label (kernel module is loaded)

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -7,7 +7,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 RUN ["apk", "add", "bash", "make", "docker", "curl", "shadow", "git"]
-RUN go install go.uber.org/mock/mockgen@v0.2.0
+RUN go install go.uber.org/mock/mockgen@v0.3.0
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -111,6 +111,20 @@ func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
 }
 
+// UpdateNodeLabels mocks base method.
+func (m *MocknmcReconcilerHelper) UpdateNodeLabels(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNodeLabels", ctx, nmc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateNodeLabels indicates an expected call of UpdateNodeLabels.
+func (mr *MocknmcReconcilerHelperMockRecorder) UpdateNodeLabels(ctx, nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodeLabels", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).UpdateNodeLabels), ctx, nmc)
+}
+
 // MockpodManager is a mock of podManager interface.
 type MockpodManager struct {
 	ctrl     *gomock.Controller

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -2,10 +2,13 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 )
+
+var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.ready$`)
 
 func GetModuleVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
@@ -64,4 +67,12 @@ func GetNodeWorkerPodVersionLabel(nodeLabels map[string]string, namespace, name 
 		return "", false
 	}
 	return labelValue, true
+}
+
+func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
+}
+
+func IsKernelModuleReadyNodeLabel(label string) bool {
+	return reKernelModuleReadyLabel.MatchString(label)
 }


### PR DESCRIPTION
This PR adds the ability to add/remove
kmm.node.kubernetes.io/%s.%s.ready label to the node. This is done based on the current labels on the node, and the comparison between NMC module's spec and status. State machine for adding/removing:
1. if spec config and status config are not equal - node's label should stay as is (either present or missing)
2. if both spec and status are missing - node's label should be removed
3. if spec config and status config are equal - node's label should be set