### PR TITLE
Fix concurrent map read and write in cache test

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -113,8 +113,6 @@ var _ = Describe("StartCollecting", func() {
 		ctx := context.Background()
 		c := New[string](1 * time.Nanosecond)
 
-		c.StartCollecting(ctx, 10*time.Millisecond)
-
 		c.items["not-expired"] = item{
 			Object:     1,
 			Expiration: time.Now().Add(1 * time.Minute),
@@ -123,6 +121,8 @@ var _ = Describe("StartCollecting", func() {
 			Object:     1,
 			Expiration: time.Now().Add(-1 * time.Minute),
 		}
+
+		c.StartCollecting(ctx, 10*time.Millisecond)
 
 		// make sure at least on run of DeleteItems() has run
 		time.Sleep(25 * time.Millisecond)


### PR DESCRIPTION
This flaky internal cache test's root cause was that the `StartCollecting` method was locking the map to delete the expired item, but the respective test code could be writing to the map at the same time without locking it. By running the `StartCollecting` after the initial writing of the items to the map, we get rid of the possibility of `concurrent map read and write` errors.

Fixes #528 