### PR TITLE
Fixing Module with device-plugin finalization deadlock

### DIFF
--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -119,17 +119,31 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleBuild(ctx, mld any) *
 }
 
 // handleDevicePlugin mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingModuleDS []v1.DaemonSet) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingDevicePluginDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingModuleDS)
+	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingDevicePluginDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDevicePlugin indicates an expected call of handleDevicePlugin.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingModuleDS any) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingDevicePluginDS any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingModuleDS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingDevicePluginDS)
+}
+
+// handleModuleDeletion mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) handleModuleDeletion(ctx context.Context, existingDevicePluginDS []v1.DaemonSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleModuleDeletion", ctx, existingDevicePluginDS)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleModuleDeletion indicates an expected call of handleModuleDeletion.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleModuleDeletion(ctx, existingDevicePluginDS any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleModuleDeletion", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleModuleDeletion), ctx, existingDevicePluginDS)
 }
 
 // handleSigning mocks base method.


### PR DESCRIPTION
Currently, when the module is deleted, the finalization function is called. This function basically waits till all the kernel modules has been unloaded, and only then removes the finalizer from Module. In case device-plugin is deployed, its Daemonset won't be deleted (since Module is not deleted due to finalizer), and the kernel modules cannot be unloaded due to device plugin running
Solution: in case of Module being deleted, handle device-plugin deletion in the module-reconciler specifically, and not wait for it to be deleted based on ownerReference