### PR TITLE
Fix device-plugin/worker pod labels validationsduring ordered-upgrade

### DIFF
--- a/internal/controllers/mock_node_label_module_version_reconciler.go
+++ b/internal/controllers/mock_node_label_module_version_reconciler.go
@@ -14,6 +14,7 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MocknodeLabelModuleVersionHelperAPI is a mock of nodeLabelModuleVersionHelperAPI interface.
@@ -68,18 +69,32 @@ func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getLabelsPerModules(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getLabelsPerModules", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getLabelsPerModules), ctx, nodeLabels)
 }
 
-// reconcileLabels mocks base method.
-func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, devicePluginPods []v1.Pod) *reconcileLabelsResult {
+// getLoadedKernelModules mocks base method.
+func (m *MocknodeLabelModuleVersionHelperAPI) getLoadedKernelModules(labels map[string]string) []types.NamespacedName {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, devicePluginPods)
+	ret := m.ctrl.Call(m, "getLoadedKernelModules", labels)
+	ret0, _ := ret[0].([]types.NamespacedName)
+	return ret0
+}
+
+// getLoadedKernelModules indicates an expected call of getLoadedKernelModules.
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getLoadedKernelModules(labels any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getLoadedKernelModules", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getLoadedKernelModules), labels)
+}
+
+// reconcileLabels mocks base method.
+func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, devicePluginPods []v1.Pod, kernelModuleReadyLabels []types.NamespacedName) *reconcileLabelsResult {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, devicePluginPods, kernelModuleReadyLabels)
 	ret0, _ := ret[0].(*reconcileLabelsResult)
 	return ret0
 }
 
 // reconcileLabels indicates an expected call of reconcileLabels.
-func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, devicePluginPods any) *gomock.Call {
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, devicePluginPods, kernelModuleReadyLabels any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, devicePluginPods)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, devicePluginPods, kernelModuleReadyLabels)
 }
 
 // updateNodeLabels mocks base method.


### PR DESCRIPTION
This PR inforces the correct ordering of add/removing version labels for worker pods and device-plugin. The correct sequence should always be:
1. remove old version device-plugin label (if exists)
2. remove old version worker pod label (only in case no relevant device-plugin pod is present)
3. add new version worker pod label (only in case the kernel module is not loaded)
4. add new version device-plugin label ( if needed)

We are stalling for worker-pod labels in order to make sure that new device-label pod will not be scheduled prior to new version of kernel module being loaded. Otherwise, old version will never be able to be removed from the kernel