### PR TITLE
Adding support for firmware loading

### DIFF
--- a/cmd/worker/funcs_kmod.go
+++ b/cmd/worker/funcs_kmod.go
@@ -25,5 +25,7 @@ func kmodLoadFunc(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return w.LoadKmod(cmd.Context(), cfg)
+	mountPathFlag := cmd.Flags().Lookup(worker.FlagFirmwareMountPath)
+
+	return w.LoadKmod(cmd.Context(), cfg, mountPathFlag.Value.String())
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -58,7 +58,9 @@ var kmodUnloadCmd = &cobra.Command{
 			return fmt.Errorf("could not read config file %s: %v", cfgPath, err)
 		}
 
-		return w.UnloadKmod(cmd.Context(), cfg)
+		mountPathFlag := cmd.Flags().Lookup(worker.FlagFirmwareMountPath)
+
+		return w.UnloadKmod(cmd.Context(), cfg, mountPathFlag.Value.String())
 	},
 }
 
@@ -80,6 +82,16 @@ func main() {
 		"",
 		"if set, this value will be written to "+worker.FirmwareClassPathLocation,
 	)
+
+	kmodLoadCmd.Flags().String(
+		worker.FlagFirmwareMountPath,
+		"",
+		"if set, this the value that firmware host path is mounted to")
+
+	kmodUnloadCmd.Flags().String(
+		worker.FlagFirmwareMountPath,
+		"",
+		"if set, this the value that firmware host path is mounted to")
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		logger = klogr.New().WithName("kmm-worker")

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
+	github.com/otiai10/copy v1.14.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16 // indirect
 	github.com/prometheus/common v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc3 h1:fzg1mXZFj8YdPeNkRXMg+zb88BFV0Ys52cJydRwBkb8=
 github.com/opencontainers/image-spec v1.1.0-rc3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/budougumi0617/cmpmock"
@@ -174,7 +175,6 @@ var moduleConfig = kmmv1beta1.ModuleConfig{
 		DirName:             "/dir",
 		Args:                nil,
 		RawArgs:             nil,
-		FirmwarePath:        "/firmware-path",
 		ModulesLoadingOrder: []string{"a", "b", "c"},
 	},
 }
@@ -1155,7 +1155,7 @@ var workerCfg = &config.Worker{
 var _ = Describe("podManagerImpl_CreateLoaderPod", func() {
 	DescribeTable(
 		"should work as expected",
-		func(firmwareClassPath *string) {
+		func(firmwareClassPath *string, withFirmwareLoading bool) {
 			ctrl := gomock.NewController(GinkgoT())
 			client := testclient.NewMockClient(ctrl)
 			psh := NewMockpullSecretHelper(ctrl)
@@ -1173,12 +1173,17 @@ var _ = Describe("podManagerImpl_CreateLoaderPod", func() {
 				ServiceAccountName: serviceAccountName,
 			}
 
-			nms := &kmmv1beta1.NodeModuleSpec{
-				ModuleItem: mi,
-				Config:     moduleConfig,
+			moduleConfigToUse := moduleConfig
+			if withFirmwareLoading {
+				moduleConfigToUse.Modprobe.FirmwarePath = "/firmware-path"
 			}
 
-			expected := getBaseWorkerPod("load", WorkerActionLoad, nmc)
+			nms := &kmmv1beta1.NodeModuleSpec{
+				ModuleItem: mi,
+				Config:     moduleConfigToUse,
+			}
+
+			expected := getBaseWorkerPod("load", WorkerActionLoad, nmc, firmwareClassPath, withFirmwareLoading)
 
 			Expect(
 				controllerutil.SetControllerReference(nmc, expected, scheme),
@@ -1195,8 +1200,6 @@ var _ = Describe("podManagerImpl_CreateLoaderPod", func() {
 				container.SecurityContext = &v1.SecurityContext{
 					Privileged: pointer.Bool(true),
 				}
-
-				container.Args = append(container.Args, "--set-firmware-class-path", *firmwareClassPath)
 			} else {
 				container.SecurityContext = &v1.SecurityContext{
 					Capabilities: &v1.Capabilities{
@@ -1231,9 +1234,11 @@ var _ = Describe("podManagerImpl_CreateLoaderPod", func() {
 				HaveOccurred(),
 			)
 		},
-		Entry(nil, nil),
-		Entry(nil, pointer.String("")),
-		Entry(nil, pointer.String("some-path")),
+		Entry("pod without firmwareClassPath, without firmware loading", nil, false),
+		Entry("pod with empty firmwareClassPath, without firmware loading", pointer.String(""), false),
+		Entry("pod with firmwareClassPath, without firmware loading", pointer.String("some-path"), false),
+		Entry("pod with firmwareClassPath, with firmware loading", pointer.String("some-path"), true),
+		Entry("pod without firmwareClassPath, with firmware loading", nil, true),
 	)
 })
 
@@ -1253,12 +1258,14 @@ var _ = Describe("podManagerImpl_CreateUnloaderPod", func() {
 			ServiceAccountName: serviceAccountName,
 		}
 
+		moduleConfigToUse := moduleConfig
+		moduleConfigToUse.Modprobe.FirmwarePath = "/firmware-path"
 		status := &kmmv1beta1.NodeModuleStatus{
 			ModuleItem: mi,
-			Config:     &moduleConfig,
+			Config:     &moduleConfigToUse,
 		}
 
-		expected := getBaseWorkerPod("unload", WorkerActionUnload, nmc)
+		expected := getBaseWorkerPod("unload", WorkerActionUnload, nmc, nil, true)
 
 		container, _ := podcmd.FindContainerByName(expected, "worker")
 		Expect(container).NotTo(BeNil())
@@ -1379,7 +1386,7 @@ var _ = Describe("podManagerImpl_ListWorkerPodsOnNode", func() {
 	})
 })
 
-func getBaseWorkerPod(subcommand string, action WorkerAction, owner ctrlclient.Object) *v1.Pod {
+func getBaseWorkerPod(subcommand string, action WorkerAction, owner ctrlclient.Object, firmwareClassPath *string, withFirmware bool) *v1.Pod {
 	GinkgoHelper()
 
 	const (
@@ -1391,15 +1398,7 @@ func getBaseWorkerPod(subcommand string, action WorkerAction, owner ctrlclient.O
 	hostPathDirectory := v1.HostPathDirectory
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 
-	pod := v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      workerPodName(nmcName, moduleName),
-			Namespace: namespace,
-			Labels: map[string]string{
-				actionLabelKey:            string(action),
-				constants.ModuleNameLabel: moduleName,
-			},
-			Annotations: map[string]string{configAnnotationKey: `containerImage: container image
+	configAnnotationValue := `containerImage: container image
 inTreeModuleToRemove: intree
 insecurePull: true
 kernelVersion: kernel version
@@ -1414,18 +1413,38 @@ modprobe:
   parameters:
   - a
   - b
-`,
-				"modules-order": `softdep a pre: b
+`
+	modulesOrderValue := `softdep a pre: b
 softdep b pre: c
-`,
+`
+
+	args := []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"}
+	if firmwareClassPath != nil {
+		args = append(args, "--set-firmware-class-path", *firmwareClassPath)
+	}
+	if !withFirmware {
+		configAnnotationValue = strings.ReplaceAll(configAnnotationValue, "firmwarePath: /firmware-path\n  ", "")
+	} else {
+		args = append(args, "--set-firmware-mount-path", "/var/lib/firmware")
+	}
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workerPodName(nmcName, moduleName),
+			Namespace: namespace,
+			Labels: map[string]string{
+				actionLabelKey:            string(action),
+				constants.ModuleNameLabel: moduleName,
 			},
+			Annotations: map[string]string{
+				configAnnotationKey: configAnnotationValue,
+				modulesOrderKey:     modulesOrderValue},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
 					Name:  "worker",
 					Image: workerImage,
-					Args:  []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"},
+					Args:  args,
 					Resources: v1.ResourceRequirements{
 						Limits:   limits,
 						Requests: requests,
@@ -1445,10 +1464,6 @@ softdep b pre: c
 							Name:      volNameUsrLibModules,
 							MountPath: "/usr/lib/modules",
 							ReadOnly:  true,
-						},
-						{
-							Name:      volNameVarLibFirmware,
-							MountPath: "/var/lib/firmware",
 						},
 						{
 							Name:      "modules-order",
@@ -1496,22 +1511,13 @@ softdep b pre: c
 					},
 				},
 				{
-					Name: volNameVarLibFirmware,
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{
-							Path: "/var/lib/firmware",
-							Type: &hostPathDirectoryOrCreate,
-						},
-					},
-				},
-				{
 					Name: "modules-order",
 					VolumeSource: v1.VolumeSource{
 						DownwardAPI: &v1.DownwardAPIVolumeSource{
 							Items: []v1.DownwardAPIVolumeFile{
 								{
 									Path:     "softdep.conf",
-									FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.annotations['modules-order']"},
+									FieldRef: &v1.ObjectFieldSelector{FieldPath: fmt.Sprintf("metadata.annotations['%s']", modulesOrderKey)},
 								},
 							},
 						},
@@ -1519,6 +1525,29 @@ softdep b pre: c
 				},
 			},
 		},
+	}
+
+	if withFirmware {
+		hostPath := "/var/lib/firmware"
+		if firmwareClassPath != nil {
+			hostPath = *firmwareClassPath
+		}
+		fwVolMount := v1.VolumeMount{
+			Name:      volNameVarLibFirmware,
+			MountPath: "/var/lib/firmware",
+		}
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, fwVolMount)
+		fwVol := v1.Volume{
+			Name: volNameVarLibFirmware,
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: hostPath,
+					Type: &hostPathDirectoryOrCreate,
+				},
+			},
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, fwVol)
+
 	}
 
 	Expect(

--- a/internal/worker/constants.go
+++ b/internal/worker/constants.go
@@ -2,8 +2,10 @@ package worker
 
 const (
 	FlagFirmwareClassPath = "set-firmware-class-path"
+	FlagFirmwareMountPath = "set-firmware-mount-path"
 
 	FirmwareClassPathLocation = "/sys/module/firmware_class/parameters/path"
 	ImagesDir                 = "/var/run/kmm/images"
 	PullSecretsDir            = "/var/run/kmm/pull-secrets"
+	FirmwareMountPath         = "/var/lib/firmware"
 )

--- a/internal/worker/mock_worker.go
+++ b/internal/worker/mock_worker.go
@@ -40,17 +40,17 @@ func (m *MockWorker) EXPECT() *MockWorkerMockRecorder {
 }
 
 // LoadKmod mocks base method.
-func (m *MockWorker) LoadKmod(ctx context.Context, cfg *v1beta1.ModuleConfig) error {
+func (m *MockWorker) LoadKmod(ctx context.Context, cfg *v1beta1.ModuleConfig, firmwareMountPath string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadKmod", ctx, cfg)
+	ret := m.ctrl.Call(m, "LoadKmod", ctx, cfg, firmwareMountPath)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LoadKmod indicates an expected call of LoadKmod.
-func (mr *MockWorkerMockRecorder) LoadKmod(ctx, cfg any) *gomock.Call {
+func (mr *MockWorkerMockRecorder) LoadKmod(ctx, cfg, firmwareMountPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadKmod", reflect.TypeOf((*MockWorker)(nil).LoadKmod), ctx, cfg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadKmod", reflect.TypeOf((*MockWorker)(nil).LoadKmod), ctx, cfg, firmwareMountPath)
 }
 
 // SetFirmwareClassPath mocks base method.
@@ -68,15 +68,15 @@ func (mr *MockWorkerMockRecorder) SetFirmwareClassPath(value any) *gomock.Call {
 }
 
 // UnloadKmod mocks base method.
-func (m *MockWorker) UnloadKmod(ctx context.Context, cfg *v1beta1.ModuleConfig) error {
+func (m *MockWorker) UnloadKmod(ctx context.Context, cfg *v1beta1.ModuleConfig, firmwareMountPath string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnloadKmod", ctx, cfg)
+	ret := m.ctrl.Call(m, "UnloadKmod", ctx, cfg, firmwareMountPath)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnloadKmod indicates an expected call of UnloadKmod.
-func (mr *MockWorkerMockRecorder) UnloadKmod(ctx, cfg any) *gomock.Call {
+func (mr *MockWorkerMockRecorder) UnloadKmod(ctx, cfg, firmwareMountPath any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadKmod", reflect.TypeOf((*MockWorker)(nil).UnloadKmod), ctx, cfg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadKmod", reflect.TypeOf((*MockWorker)(nil).UnloadKmod), ctx, cfg, firmwareMountPath)
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/go-logr/logr"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+	cp "github.com/otiai10/copy"
 )
 
 //go:generate mockgen -source=worker.go -package=worker -destination=mock_worker.go
 
 type Worker interface {
-	LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) error
+	LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig, firmwareMountPath string) error
 	SetFirmwareClassPath(value string) error
-	UnloadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) error
+	UnloadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig, firmwareMountPath string) error
 }
 
 type worker struct {
@@ -32,7 +34,7 @@ func NewWorker(ip ImagePuller, mr ModprobeRunner, logger logr.Logger) Worker {
 	}
 }
 
-func (w *worker) LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) error {
+func (w *worker) LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig, firmwareMountPath string) error {
 	imageName := cfg.ContainerImage
 
 	w.logger.Info("Pulling image", "name", imageName)
@@ -50,8 +52,22 @@ func (w *worker) LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) err
 		}
 	}
 
-	// TODO copy firmware
-	// TODO handle ModulesLoadingOrder
+	// prepare firmware
+	if cfg.Modprobe.FirmwarePath != "" {
+		imageFirmwarePath := filepath.Join(pr.fsDir, cfg.Modprobe.FirmwarePath)
+		w.logger.Info("preparing firmware for loading", "image directory", imageFirmwarePath, "host mount directory", firmwareMountPath)
+		options := cp.Options{
+			OnError: func(src, dest string, err error) error {
+				if err != nil {
+					return fmt.Errorf("internal copy error: failed to copy from %s to %s: %v", src, dest, err)
+				}
+				return nil
+			},
+		}
+		if err = cp.Copy(imageFirmwarePath, firmwareMountPath, options); err != nil {
+			return fmt.Errorf("failed to copy firmware from path %s to path %s: %v", imageFirmwarePath, firmwareMountPath, err)
+		}
+	}
 
 	moduleName := cfg.Modprobe.ModuleName
 
@@ -97,7 +113,7 @@ func (w *worker) SetFirmwareClassPath(value string) error {
 	return nil
 }
 
-func (w *worker) UnloadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) error {
+func (w *worker) UnloadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig, firmwareMountPath string) error {
 	imageName := cfg.ContainerImage
 
 	w.logger.Info("Pulling image", "name", imageName)
@@ -129,7 +145,32 @@ func (w *worker) UnloadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig) e
 		return fmt.Errorf("could not unload module %s: %v", moduleName, err)
 	}
 
-	// TODO remove firmware
+	//remove firmware files only (no directories)
+	if cfg.Modprobe.FirmwarePath != "" {
+		imageFirmwarePath := filepath.Join(pr.fsDir, cfg.Modprobe.FirmwarePath)
+		err = filepath.Walk(imageFirmwarePath, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				relPath, err := filepath.Rel(imageFirmwarePath, path)
+				if err != nil {
+					w.logger.Info(utils.WarnString("failed to get relative path"), "imageFirmwarePath", imageFirmwarePath, "path", path, "error", err)
+					return nil
+				}
+				fileToRemove := filepath.Join(firmwareMountPath, relPath)
+				w.logger.Info("Removing firmware file", "file", fileToRemove)
+				err = os.Remove(fileToRemove)
+				if err != nil {
+					w.logger.Info(utils.WarnString("failed to delete file"), "file", fileToRemove, "error", err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			w.logger.Info(utils.WarnString("failed to remove all firmware blobs"), "error", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
1) mapping of the host firmware directory into the load/unload pod only
   in case firmware for the Module is defined
2) during Loading operation, worker pod is copying all firmware files and
   directories from image onto the mapped host directory
3) during Unloading operation, worker pod is deleting all firmware
   files, but not directories ( since those can be shared with other
   modules' firmware files
4) unit tests