### PR TITLE
Reverting RestartPolicy back to Never

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -900,7 +900,7 @@ func (p *podManagerImpl) baseWorkerPod(
 				},
 			},
 			NodeName:           nodeName,
-			RestartPolicy:      v1.RestartPolicyOnFailure,
+			RestartPolicy:      v1.RestartPolicyNever,
 			ServiceAccountName: item.ServiceAccountName,
 			Volumes:            append(volumes, psv...),
 		},

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1459,7 +1459,7 @@ softdep b pre: c
 				},
 			},
 			NodeName:           nmcName,
-			RestartPolicy:      v1.RestartPolicyOnFailure,
+			RestartPolicy:      v1.RestartPolicyNever,
 			ServiceAccountName: serviceAccountName,
 			Volumes: []v1.Volume{
 				{


### PR DESCRIPTION
We need to revert the restart policy from RestartOnFailure to Never. In case restart policy is RestartOnFailure, the Phase of the Pod will always be Running and never Failed. This in turn causes 2 things:
1. even when the Module is removed from NMC Spec, NMC status is always in Progress, and Moduke is never removed from NMC Status. This means that in-use label never removed and Module deletion is never successfully finilized
2. in case Pod fails, and the NMC spec is updated, the new Pod is never created, since the old pod is InProgress