### PR TITLE
Update webhook validation for name+namespace length

### DIFF
--- a/api/v1beta1/module_webhook.go
+++ b/api/v1beta1/module_webhook.go
@@ -81,7 +81,7 @@ func (m *Module) ValidateDelete() (admission.Warnings, error) {
 func (m *Module) validate() (admission.Warnings, error) {
 	nameLength := len(m.Name + m.Namespace)
 
-	if m.Spec.ModuleLoader.Container.Version != "" && nameLength > maxCombinedLength {
+	if nameLength > maxCombinedLength {
 		return nil, fmt.Errorf(
 			"module name and namespace have a combined length of %d characters, which exceeds the maximum of %d when version is set",
 			nameLength,

--- a/api/v1beta1/module_webhook_test.go
+++ b/api/v1beta1/module_webhook_test.go
@@ -408,11 +408,10 @@ var _ = Describe("validate", func() {
 
 	DescribeTable(
 		"should work as expected",
-		func(name, ns, version string, errExpected bool) {
+		func(name, ns string, errExpected bool) {
 			mod := validModule
 			mod.Name = name
 			mod.Namespace = ns
-			mod.Spec.ModuleLoader.Container.Version = version
 
 			_, err := mod.validate()
 			exp := Expect(err)
@@ -423,10 +422,8 @@ var _ = Describe("validate", func() {
 				exp.NotTo(HaveOccurred())
 			}
 		},
-		Entry(nil, "name", "ns", "", false),
-		Entry(nil, "name", "ns", "test", false),
-		Entry(nil, chars21, chars21, "", false),
-		Entry(nil, chars21, chars21, "test", true),
+		Entry("not too long", "name", "ns", false),
+		Entry("too long", chars21, chars21, true),
 	)
 })
 


### PR DESCRIPTION
Currently webhook verifies that module's name + namespace length does not exceed 40 chars in case version is defined. This commit removes the version condition and always verifies that length