### PR TITLE
[release-2.0] Bump memory limit to 384Mi

### DIFF
--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -72,7 +72,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 384Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
/cc @yevgeny-shnaidman 