### PR TITLE
Allow the controller to delete NodeModulesConfigs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,7 @@ rules:
   - nodemodulesconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -31,7 +31,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create;delete
 
 const (
 	ModuleNMCReconcilerName = "ModuleNMCReconciler"


### PR DESCRIPTION
Make the OwnerReferencesPermissionEnforcement admission plugin happy.

/cc @yevgeny-shnaidman 