### PR TITLE
Docs typo - Use Cases - `module.name` not `module-name`

### DIFF
--- a/docs/mkdocs/developer/use_cases.md
+++ b/docs/mkdocs/developer/use_cases.md
@@ -17,7 +17,7 @@ For each `DaemonSet` belonging to `Module`, we set the following labels:
 
 | key                                          | value         |
 | -------------------------------------------- | ------------- |
-| `kmm.node.kubernetes.io/module-name`               | `$moduleName` |
+| `kmm.node.kubernetes.io/module.name`               | `$moduleName` |
 | `kmm.node.kubernetes.io/kernel-version.full` | `$kernel`     |
 
 We either create those `DaemonSets` (if they do not already exist) or update them (if a `DaemonSet` already exists with


### PR DESCRIPTION
`const` [`ModuleNameLabel      = "kmm.node.kubernetes.io/module.name"`](https://github.com/kubernetes-sigs/kernel-module-management/blob/940e25e11ed701e6c218577066e29cadb4d9a62d/internal/constants/constants.go#L4).