### PR TITLE
Remove deprecated module ready labels on nodes

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -571,10 +571,15 @@ func (h *nmcReconcilerHelperImpl) UpdateNodeLabelsAndRecordEvents(ctx context.Co
 
 	// get all the kernel module ready labels of the node
 	nodeModuleReadyLabels := sets.New[types.NamespacedName]()
+	deprecatedNodeModuleReadyLabels := sets.New[string]()
 
 	for label := range node.GetLabels() {
 		if ok, namespace, name := utils.IsKernelModuleReadyNodeLabel(label); ok {
 			nodeModuleReadyLabels.Insert(types.NamespacedName{Namespace: namespace, Name: name})
+		}
+
+		if utils.IsDeprecatedKernelModuleReadyNodeLabel(label) {
+			deprecatedNodeModuleReadyLabels.Insert(label)
 		}
 	}
 
@@ -608,6 +613,11 @@ func (h *nmcReconcilerHelperImpl) UpdateNodeLabelsAndRecordEvents(ctx context.Co
 
 			unloaded = append(unloaded, nsn)
 		}
+	}
+
+	// v1 ready labels, deprecated - should be removed
+	for label := range deprecatedNodeModuleReadyLabels {
+		meta.RemoveLabel(&node, label)
 	}
 
 	// label in spec and status and config equal - should be added

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1224,7 +1224,8 @@ var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabelsAndRecordEvents", func
 	DescribeTable(
 		"nodes labels scenarios",
 		func(tc testCase) {
-			nodeLabels := make(map[string]string)
+			nodeLabels := map[string]string{"kmm.node.kubernetes.io/deprecated-label.ready": ""}
+
 			if tc.nodeLabelPresent {
 				nodeLabels[utils.GetKernelModuleReadyNodeLabel(moduleNamespace, moduleName)] = ""
 			}

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -9,6 +9,7 @@ import (
 )
 
 var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.ready$`)
+var reDeprecatedKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/[a-zA-Z0-9-]+\.ready$`)
 
 func GetModuleVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
@@ -75,6 +76,10 @@ func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
 
 func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
+}
+
+func IsDeprecatedKernelModuleReadyNodeLabel(label string) bool {
+	return reDeprecatedKernelModuleReadyLabel.MatchString(label)
 }
 
 func IsKernelModuleReadyNodeLabel(label string) (bool, string, string) {

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -46,6 +46,25 @@ var _ = Describe("GetNamespaceNameFromVersionLabel", func() {
 	)
 })
 
+var _ = Describe("IsDeprecatedKernelModuleReadyNodeLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expected bool) {
+			Expect(
+				IsDeprecatedKernelModuleReadyNodeLabel(input),
+			).To(
+				Equal(expected),
+			)
+		},
+		Entry(nil, "kmm.node.kubernetes.io/a.ready", true),
+		Entry(nil, "kmm.node.kubernetes.io/1.ready", true),
+		Entry(nil, "kmm.node.kubernetes.io/with-hyphen.ready", true),
+		Entry(nil, "test.ready", false),
+		Entry(nil, "kmm.node.kubernetes.io/ns.name.ready", false),
+		Entry(nil, "kmm.node.kubernetes.io/..ready", false),
+	)
+})
+
 var _ = Describe("IsKernelModuleReadyNodeLabel", func() {
 	DescribeTable(
 		"should work as expected",
@@ -63,7 +82,9 @@ var _ = Describe("IsKernelModuleReadyNodeLabel", func() {
 		},
 		Entry(nil, "kmm.node.kubernetes.io/..ready", false, "", ""),
 		Entry(nil, "kmm.node.kubernetes.io/a..ready", false, "", ""),
+		Entry(nil, "kmm.node.kubernetes.io/a..ready", false, "", ""),
 		Entry(nil, "kmm.node.kubernetes.io/.b.ready", false, "", ""),
+		Entry(nil, "kmm.node.kubernetes.io/a.ready", false, "", ""),
 		Entry(nil, "kmm.node.kubernetes.io/a.b", false, "", ""),
 		Entry(nil, "kmm.node.kubernetes.io/a.b.read", false, "", ""),
 		Entry(nil, "a.b.read", false, "", ""),


### PR DESCRIPTION
This change removes `kmm.node.kubernetes.io/<module>.ready` labels on all nodes, as it was deprecated in v1.1 and removed in v2.0.