### PR TITLE
Making GetModuleReady/GetDevicePluginReadyLabels functions public

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.18 as builder
+FROM golang:1.20-alpine3.18 as builder
 
 ENV GO111MODULE=on
 ENV GOFLAGS=""

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -1,0 +1,13 @@
+package labels
+
+import (
+	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+)
+
+func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
+	return utils.GetKernelModuleReadyNodeLabel(namespace, moduleName)
+}
+
+func GetDevicePluginNodeLabel(namespace, moduleName string) string {
+	return utils.GetDevicePluginNodeLabel(namespace, moduleName)
+}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -1,0 +1,18 @@
+package labels
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetModuleReadyAndDevicePluginReadyLabels", func() {
+	It("module ready label", func() {
+		res := GetKernelModuleReadyNodeLabel("some-namespace", "some-module")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-module.ready"))
+	})
+
+	It("device-plugin ready label", func() {
+		res := GetDevicePluginNodeLabel("some-namespace", "some-module")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-module.device-plugin-ready"))
+	})
+})

--- a/pkg/labels/suite_test.go
+++ b/pkg/labels/suite_test.go
@@ -1,0 +1,23 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/test"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var scheme *runtime.Scheme
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var err error
+
+	scheme, err = test.TestScheme()
+	Expect(err).NotTo(HaveOccurred())
+
+	RunSpecs(t, "Job Suite")
+}


### PR DESCRIPTION
since "ready" labels are public APIs of KMM, operators using KMM may want to schedule they workloads based on the presence of those labels.