### PR TITLE
Fixing DevicePlugin upgrade from v1.x to v2.x

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -7,6 +7,7 @@ const (
 	PodType              = "kmm.node.kubernetes.io/pod-type"
 	PodHashAnnotation    = "kmm.node.kubernetes.io/last-hash"
 	KernelLabel          = "kmm.node.kubernetes.io/kernel-version.full"
+	DaemonSetRole        = "kmm.node.kubernetes.io/role"
 
 	WorkerPodVersionLabelPrefix    = "beta.kmm.node.kubernetes.io/version-worker-pod"
 	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
@@ -20,6 +21,8 @@ const (
 	DockerfileCMKey                = "dockerfile"
 	PublicSignDataKey              = "cert"
 	PrivateSignDataKey             = "key"
+
+	ModuleLoaderRoleLabelValue = "module-loader"
 
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -169,7 +169,16 @@ func (dprh *devicePluginReconcilerHelper) getModuleDevicePluginDaemonSets(ctx co
 	if err := dprh.client.List(ctx, &dsList, opts...); err != nil {
 		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
 	}
-	return dsList.Items, nil
+
+	devicePluginsList := make([]appsv1.DaemonSet, 0, len(dsList.Items))
+	// remove the older version module loader daemonsets
+	for _, ds := range dsList.Items {
+		if ds.GetLabels()[constants.DaemonSetRole] != constants.ModuleLoaderRoleLabelValue {
+			devicePluginsList = append(devicePluginsList, ds)
+		}
+	}
+
+	return devicePluginsList, nil
 }
 
 func (dprh *devicePluginReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error {


### PR DESCRIPTION
In v1.x we had 2 type of Daemonsets: DevicePlugin and ModuleLoader, which could be distingished by the DaemonsetRole label In v2.x, there only 1 type of daemonset, DevicePlugin, so the DaemonsetRole labels was removed.
During DevicePlugin reconciliation, reconcile get all the device plugin Ds based only on module name label, which means that in case there is a v1.1 ModuleLoader DS running it will also be chosen. Once reconciler tries to reconcile ModuleLoader DS, it will fail
This PR, updates the function that chooses the DevicePlugin DS, by removing old ModuleLoader Ds based on Role label