### PR TITLE
Adding an operator-upgrade Github workflow.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -183,3 +183,70 @@ jobs:
         if: ${{ always() }}
         with:
           output-file: ${{ matrix.name }}-support-bundle.tar.gz
+
+  operator-upgrade:
+
+    runs-on: ubuntu-20.04
+    name: operator-upgrade
+    needs: [build-operator-image, build-signing-image, build-worker-image]
+
+    services:
+      registry:
+        image: registry:2
+        ports: ['5000:5000/tcp']
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create the minikube cluster
+        uses: ./.github/actions/create-minikube-cluster
+        with:
+          start-args: --insecure-registry=host.minikube.internal:5000
+
+      - name: Download container images
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Copy kmm, signing and worker images to the registry
+        run: |
+          # KMM is pulled by operator-sdk in the cluster and not by minikube
+          docker load -i artifacts/ci-image-kmm/kmm_local.tar
+          docker load -i artifacts/ci-image-signer/kmm-signimage_local.tar
+          docker load -i artifacts/ci-image-worker/kmm-worker_local.tar
+
+          docker tag kmm:local localhost:5000/kmm/kmm:local
+          docker tag kmm-signimage:local localhost:5000/kmm/signimage:local
+          docker tag kmm-worker:local localhost:5000/kmm/worker:local
+
+          docker push localhost:5000/kmm/kmm:local
+          docker push localhost:5000/kmm/signimage:local
+          docker push localhost:5000/kmm/worker:local
+
+      - name: Set some Ubuntu environment variables
+        run: |
+          grep 'ID=' /etc/os-release >> "$GITHUB_ENV"
+          grep 'VERSION_ID=' /etc/os-release >> "$GITHUB_ENV"
+
+      - name: Cache binaries needed by Makefile
+        id: cache-bin
+        uses: actions/cache@v3
+        with:
+          path: ./bin
+          key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+        if: steps.cache-bin.outputs.cache-hit != 'true'
+
+      - name: Run test
+        run: ./ci/prow/operator-upgrade
+
+      - name: Collect troubleshooting data
+        uses: ./.github/actions/collect-troubleshooting
+        if: ${{ always() }}
+        with:
+          output-file: operator-upgrade-support-bundle.tar.gz

--- a/ci/prow/operator-upgrade
+++ b/ci/prow/operator-upgrade
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# operator-sdk run bundle<-upgrade> doesn't support local images and the image
+# has to be pushed to a remote registry.
+# When the command is run, operator-sdk checks the image twice. At first, it
+# validates that the image exists and then it creates a pod in the cluster
+# deploying the image, therefore, the image has to be accessed from both, the
+# running host and the minikube cluster.
+sudo echo "127.0.0.1 host.minikube.internal" | sudo tee -a /etc/hosts
+
+# Build the bundle from the 'main' branch
+git fetch origin
+git checkout -b main origin/main
+make bundle bundle-build bundle-push \
+    VERSION="1.0.0" \
+    BUNDLE_IMG=localhost:5000/kmm/kmm-bundle:current
+# go back to the last branch
+git checkout -
+
+# Install OLM
+make operator-sdk
+./bin/operator-sdk olm install
+
+# Deploy the current bundle
+./bin/operator-sdk run bundle host.minikube.internal:5000/kmm/kmm-bundle:current \
+    --namespace operators \
+    --use-http \
+    --timeout 5m0s
+
+# Build the new bundle
+make bundle bundle-build bundle-push \
+    VERSION="2.0.0" \
+    IMG=host.minikube.internal:5000/kmm/kmm:local \
+    SIGNER_IMG=host.minikube.internal:5000/kmm/signimage:local \
+    WORKER_IMG=host.minikube.internal:5000/kmm/worker:local \
+    BUNDLE_IMG=localhost:5000/kmm/kmm-bundle:local
+
+# Upgrade to the new bundle
+./bin/operator-sdk run bundle-upgrade host.minikube.internal:5000/kmm/kmm-bundle:local \
+    --namespace operators \
+    --use-http \
+    --timeout 5m0s


### PR DESCRIPTION
This test will ensure the bundle built in the PR can be used to upgrade
from the last bundle available of KMM.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/kubernetes-sigs/kernel-module-management/issues/478