### PR TITLE
Revert "Bump actions/cache from 3 to 4"

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -232,7 +232,7 @@ jobs:
 
       - name: Cache binaries needed by Makefile
         id: cache-bin
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ./bin
           key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}


### PR DESCRIPTION
Reverts kubernetes-sigs/kernel-module-management#706

--- 

We should revert this PR in order to be able to revert https://github.com/kubernetes-sigs/kernel-module-management/pull/693