### PR TITLE
Allow the Hub to patch pods

### DIFF
--- a/config/rbac-hub/role.yaml
+++ b/config/rbac-hub/role.yaml
@@ -28,6 +28,7 @@ rules:
   - create
   - delete
   - list
+  - patch
   - watch
 - apiGroups:
   - ""

--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -56,7 +56,7 @@ type ManagedClusterModuleReconciler struct {
 //+kubebuilder:rbac:groups=hub.kmm.sigs.x-k8s.io,resources=managedclustermodules/finalizers,verbs=update
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=create;list;watch;delete
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch
 


### PR DESCRIPTION
This is required for the `BuildSignEvents` reconciler to remove the finalizer.

/cc @mresvanis @yevgeny-shnaidman 