### PR TITLE
`make operatorhub-release`: bind all environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ workerimage-build: ## Build docker image for worker app.
 	docker build -f Dockerfile.worker -t $(WORKER_IMG) .
 
 operatorhub-release:
-	IMG=$(IMG) HUB_IMG=$(HUB_IMG) VERSION=$(VERSION) ./hack/release-operatorhub
+	IMG=$(IMG) HUB_IMG=$(HUB_IMG) WORKER_IMG=$(WORKER_IMG) SIGNER_IMG=$(SIGNER_IMG) VERSION=$(VERSION) ./hack/release-operatorhub
 
 include docs.mk
 


### PR DESCRIPTION
`hack/release-operatorhub` now needs the `WORKER_IMG` and `SIGNER_IMG` environment variables.

/cc @mresvanis 