### PR TITLE
Restrict checks for image existence

### DIFF
--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -333,14 +333,19 @@ func (mnrh *moduleNMCReconcilerHelper) prepareSchedulingData(ctx context.Context
 
 func (mnrh *moduleNMCReconcilerHelper) enableModuleOnNode(ctx context.Context, mld *api.ModuleLoaderData, node *v1.Node) error {
 	logger := log.FromContext(ctx)
-	exists, err := module.ImageExists(ctx, mnrh.client, mnrh.registryAPI, mld, mld.Namespace, mld.ContainerImage)
-	if err != nil {
-		return fmt.Errorf("failed to verify is image %s exists: %v", mld.ContainerImage, err)
+
+	if module.ShouldBeBuilt(mld) || module.ShouldBeSigned(mld) {
+		exists, err := module.ImageExists(ctx, mnrh.client, mnrh.registryAPI, mld, mld.Namespace, mld.ContainerImage)
+		if err != nil {
+			return fmt.Errorf("failed to verify that image %s exists: %v", mld.ContainerImage, err)
+		}
+		if !exists {
+			// skip updating NMC, reconciliation will kick in once the build pod is completed
+			logger.V(1).Info("Image does not exist, not adding to NMC", "nmc name", node.Name, "container image", mld.ContainerImage)
+			return nil
+		}
 	}
-	if !exists {
-		// skip updating NMC, reconciliation will kick in once the build pod is completed
-		return nil
-	}
+
 	moduleConfig := kmmv1beta1.ModuleConfig{
 		KernelVersion:        mld.KernelVersion,
 		ContainerImage:       mld.ContainerImage,
@@ -357,8 +362,7 @@ func (mnrh *moduleNMCReconcilerHelper) enableModuleOnNode(ctx context.Context, m
 	}
 
 	opRes, err := controllerutil.CreateOrPatch(ctx, mnrh.client, nmcObj, func() error {
-		err = mnrh.nmcHelper.SetModuleConfig(nmcObj, mld, &moduleConfig)
-		if err != nil {
+		if err := mnrh.nmcHelper.SetModuleConfig(nmcObj, mld, &moduleConfig); err != nil {
 			return err
 		}
 

--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -681,13 +681,22 @@ var _ = Describe("enableModuleOnNode", func() {
 		}
 	})
 
-	It("Image does not exists", func() {
+	It("Build configured and image does not exist", func() {
+		mld.Build = &kmmv1beta1.Build{}
 		rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), gomock.Any()).Return(false, nil)
 		err := mnrh.enableModuleOnNode(ctx, mld, &node)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Failed to check if image exists", func() {
+	It("Sign configured and image does not exist", func() {
+		mld.Sign = &kmmv1beta1.Sign{}
+		rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), gomock.Any()).Return(false, nil)
+		err := mnrh.enableModuleOnNode(ctx, mld, &node)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Build configured and failed to check if image exists", func() {
+		mld.Build = &kmmv1beta1.Build{}
 		rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("some error"))
 		err := mnrh.enableModuleOnNode(ctx, mld, &node)
 		Expect(err).To(HaveOccurred())
@@ -699,7 +708,6 @@ var _ = Describe("enableModuleOnNode", func() {
 		}
 
 		gomock.InOrder(
-			rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), gomock.Any()).Return(true, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			helper.EXPECT().SetModuleConfig(nmc, mld, expectedModuleConfig).Return(nil),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
@@ -727,7 +735,6 @@ var _ = Describe("enableModuleOnNode", func() {
 		)
 
 		gomock.InOrder(
-			rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), gomock.Any()).Return(true, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
 					nmc.SetName(node.Name)


### PR DESCRIPTION
Before populating the `NodeModulesConfig` object, only check if built or signed image exist on the registry.
Add a log message when the `NodeModulesConfig` is not populated for that reason.

/cc @yevgeny-shnaidman @mresvanis 