### PR TITLE
Cloud Build: build bundles with Go 1.21

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -82,7 +82,7 @@ steps:
       - gcr.io/$PROJECT_ID/kernel-module-management-worker
     waitFor: [build-worker]
   - id: build-bundles
-    name: golang:1.20-alpine3.17
+    name: golang:1.21-alpine3.19
     env:
       - '_GIT_TAG=$_GIT_TAG'
     entrypoint: sh


### PR DESCRIPTION
We need to bump this since our `go.mod` now has the `toolchain` directive.

/cc @mresvanis @yevgeny-shnaidman @ybettan 