### PR TITLE
Rename the webhook service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,6 @@ endif
 IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 HUB_IMG ?= $(IMAGE_TAG_BASE)-hub:$(IMAGE_TAG)
 
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -126,8 +123,8 @@ vet: ## Run go vet against code.
 TEST ?= ./...
 
 .PHONY: unit-test
-unit-test: vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
+unit-test: vet ## Run tests.
+	go test $(TEST) -coverprofile cover.out
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint against code.
@@ -252,12 +249,6 @@ kustomize: ## Download kustomize locally if necessary.
 	@if [ ! -f ${KUSTOMIZE} ]; then \
 		BINDIR=$(shell pwd)/bin ./hack/download-kustomize; \
 	fi
-
-
-ENVTEST = $(shell pwd)/bin/setup-envtest
-.PHONY: envtest
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 # go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/config/crd-hub/patches/webhook_in_managedclustermodules.yaml
+++ b/config/crd-hub/patches/webhook_in_managedclustermodules.yaml
@@ -10,7 +10,7 @@ spec:
       clientConfig:
         service:
           namespace: system
-          name: webhook-service
+          name: webhook-server-service
           path: /convert
       conversionReviewVersions:
       - v1

--- a/config/crd/patches/webhook_in_modules.yaml
+++ b/config/crd/patches/webhook_in_modules.yaml
@@ -10,7 +10,7 @@ spec:
       clientConfig:
         service:
           namespace: system
-          name: webhook-service
+          name: webhook-server-service
           path: /convert
       conversionReviewVersions:
       - v1

--- a/config/crd/patches/webhook_in_preflightvalidations.yaml
+++ b/config/crd/patches/webhook_in_preflightvalidations.yaml
@@ -10,7 +10,7 @@ spec:
       clientConfig:
         service:
           namespace: system
-          name: webhook-service
+          name: webhook-server-service
           path: /convert
       conversionReviewVersions:
       - v1beta2

--- a/config/default-hub/kustomization.yaml
+++ b/config/default-hub/kustomization.yaml
@@ -80,7 +80,7 @@ replacements:
   # Patch dnsNames in webhook Certificate
   - source:
       kind: Service
-      name: webhook-service
+      name: webhook-server-service
       fieldPath: metadata.name
     targets:
       - select:
@@ -91,7 +91,7 @@ replacements:
           delimiter: .
   - source:
       kind: Service
-      name: webhook-service
+      name: webhook-server-service
       fieldPath: metadata.namespace
     targets:
       - select:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -101,7 +101,7 @@ replacements:
   # Patch dnsNames in webhook Certificate
   - source:
       kind: Service
-      name: webhook-service
+      name: webhook-server-service
       fieldPath: metadata.name
     targets:
       - select:
@@ -112,7 +112,7 @@ replacements:
           delimiter: .
   - source:
       kind: Service
-      name: webhook-service
+      name: webhook-server-service
       fieldPath: metadata.namespace
     targets:
       - select:

--- a/config/webhook-hub/kustomization.yaml
+++ b/config/webhook-hub/kustomization.yaml
@@ -7,3 +7,15 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+# controller-gen generates the ValidatingWebhookConfiguration targeting "webhook-service", and that is not configurable.
+# OLM wants it to be called "${DEPLOYMENT_NAME}-service", so webhook-server-service.
+replacements:
+- source:
+    kind: Service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - webhooks.*.clientConfig.service.name

--- a/config/webhook-hub/service.yaml
+++ b/config/webhook-hub/service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/instance: webhook-server-service
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: kernel-module-management
     app.kubernetes.io/part-of: kernel-module-management
     app.kubernetes.io/managed-by: kustomize
-  name: webhook-service
+  name: webhook-server-service
   namespace: system
 spec:
   ports:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -10,3 +10,15 @@ configurations:
 
 patches:
 - path: manifests_namespace_selector_patch.yaml
+
+# controller-gen generates the ValidatingWebhookConfiguration targeting "webhook-service", and that is not configurable.
+# OLM wants it to be called "${DEPLOYMENT_NAME}-service", so webhook-server-service.
+replacements:
+  - source:
+      kind: Service
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: ValidatingWebhookConfiguration
+        fieldPaths:
+          - webhooks.*.clientConfig.service.name

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: service
-    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/instance: webhook-server-service
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: kernel-module-management
     app.kubernetes.io/part-of: kernel-module-management
     app.kubernetes.io/managed-by: kustomize
-  name: webhook-service
+  name: webhook-server-service
   namespace: system
 spec:
   ports:


### PR DESCRIPTION
controller-gen generates webhook configuration targeting `webhook-service`.
Unfortunately OLM requires that the webhook Service be named `${DEPLOYMENT_NAME}-service`, so `webhook-server-service`. Not following that requirement results in duplicate Services being created, and sometimes in TLS issues.
Rename the webhook service to `webhook-server-service` and add a kustomize replacement rule to modify the target service for webhooks.

/cc @mresvanis @yevgeny-shnaidman @ybettan 