### PR TITLE
Optionally delay job garbage collection

### DIFF
--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -143,7 +143,7 @@ func main() {
 	mcmr := hub.NewManagedClusterModuleReconciler(
 		client,
 		manifestwork.NewCreator(client, scheme, kernelAPI, registryAPI, cache, operatorNamespace),
-		cluster.NewClusterAPI(client, kernelAPI, buildAPI, signAPI, operatorNamespace),
+		cluster.NewClusterAPI(client, kernelAPI, buildAPI, signAPI, operatorNamespace, cfg.Job.GCDelay),
 		statusupdater.NewManagedClusterModuleStatusUpdater(client),
 		filterAPI,
 	)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -150,7 +150,8 @@ func main() {
 		buildAPI,
 		signAPI,
 		kernelAPI,
-		filterAPI)
+		filterAPI,
+		cfg.Job.GCDelay)
 	if err = bsc.SetupWithManager(mgr, constants.KernelLabel); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.BuildSignReconcilerName)
 	}

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -12,7 +13,7 @@ import (
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object, delay time.Duration) ([]string, error)
 
 	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -11,6 +11,7 @@ package build
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	utils "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -42,18 +43,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object, delay time.Duration) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner, delay)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner any) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner, delay any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace, owner, delay)
 }
 
 // ShouldSync mocks base method.

--- a/internal/build/pod/maker.go
+++ b/internal/build/pod/maker.go
@@ -92,7 +92,7 @@ func (m *maker) MakePodTemplate(
 			Namespace:    mld.Namespace,
 			Labels:       m.podHelper.PodLabels(mld.Name, mld.KernelVersion, utils.PodTypeBuild),
 			Annotations:  map[string]string{constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash)},
-			Finalizers:   []string{constants.JobEventFinalizer},
+			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},
 		Spec: podSpec,
 	}

--- a/internal/build/pod/maker_test.go
+++ b/internal/build/pod/maker_test.go
@@ -124,7 +124,7 @@ var _ = Describe("MakePodTemplate", func() {
 						BlockOwnerDeletion: ptr.To(true),
 					},
 				},
-				Finalizers: []string{constants.JobEventFinalizer},
+				Finalizers: []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{

--- a/internal/build/pod/manager.go
+++ b/internal/build/pod/manager.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +38,7 @@ func NewBuildManager(
 	}
 }
 
-func (pm *podManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
+func (pm *podManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object, delay time.Duration) ([]string, error) {
 	pods, err := pm.podHelper.GetModulePods(ctx, modName, namespace, utils.PodTypeBuild, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get build pods for module %s: %v", modName, err)
@@ -45,11 +47,19 @@ func (pm *podManager) GarbageCollect(ctx context.Context, modName, namespace str
 	deleteNames := make([]string, 0, len(pods))
 	for _, pod := range pods {
 		if pod.Status.Phase == v1.PodSucceeded {
-			err = pm.podHelper.DeletePod(ctx, &pod)
-			if err != nil {
-				return nil, fmt.Errorf("failed to delete build pod %s: %v", pod.Name, err)
+			if pod.DeletionTimestamp == nil {
+				if err = pm.podHelper.DeletePod(ctx, &pod); err != nil {
+					return nil, fmt.Errorf("failed to delete build pod %s: %v", pod.Name, err)
+				}
 			}
-			deleteNames = append(deleteNames, pod.Name)
+
+			if pod.DeletionTimestamp.Add(delay).Before(time.Now()) {
+				if err = pm.podHelper.RemoveFinalizer(ctx, &pod, constants.GCDelayFinalizer); err != nil {
+					return nil, fmt.Errorf("could not remove the GC delay finalizer from pod %s/%s: %v", pod.Namespace, pod.Name, err)
+				}
+
+				deleteNames = append(deleteNames, pod.Name)
+			}
 		}
 	}
 	return deleteNames, nil
@@ -118,6 +128,11 @@ func (pm *podManager) Sync(
 
 	if changed {
 		logger.Info("The module's build spec has been changed, deleting the current pod so a new one can be created", "name", pod.Name)
+
+		if err = pm.podHelper.RemoveFinalizer(ctx, pod, constants.GCDelayFinalizer); err != nil {
+			return "", fmt.Errorf("could not remove the GC delay finalizer from pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
+
 		err = pm.podHelper.DeletePod(ctx, pod)
 		if err != nil {
 			logger.Info(utils.WarnString(fmt.Sprintf("failed to delete build pod %s: %v", pod.Name, err)))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -10,6 +11,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
+
+type Job struct {
+	GCDelay time.Duration `yaml:"gcDelay,omitempty"`
+}
 
 type Worker struct {
 	RunAsUser            *int64  `yaml:"runAsUser"`
@@ -30,6 +35,7 @@ type Metrics struct {
 
 type Config struct {
 	HealthProbeBindAddress string         `yaml:"healthProbeBindAddress"`
+	Job                    Job            `yaml:"job"`
 	LeaderElection         LeaderElection `yaml:"leaderElection"`
 	Metrics                Metrics        `yaml:"metrics"`
 	WebhookPort            int            `yaml:"webhookPort"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
@@ -15,6 +17,9 @@ var _ = Describe("ParseFile", func() {
 	It("should parse the file correctly", func() {
 		expected := &Config{
 			HealthProbeBindAddress: ":8081",
+			Job: Job{
+				GCDelay: time.Hour,
+			},
 			LeaderElection: LeaderElection{
 				Enabled:    true,
 				ResourceID: "some-resource-id",

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -1,5 +1,7 @@
 healthProbeBindAddress: :8081
 webhookPort: 9443
+job:
+  gcDelay: 1h
 leaderElection:
   enabled: true
   resourceID: some-resource-id

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -14,6 +14,7 @@ const (
 	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
 	ModuleVersionLabelPrefix       = "kmm.node.kubernetes.io/version-module"
 
+	GCDelayFinalizer  = "kmm.node.kubernetes.io/gc-delay"
 	ModuleFinalizer   = "kmm.node.kubernetes.io/module-finalizer"
 	JobEventFinalizer = "kmm.node.kubernetes.io/job-event-finalizer"
 

--- a/internal/controllers/build_sign_reconciler.go
+++ b/internal/controllers/build_sign_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
@@ -51,8 +52,9 @@ func NewBuildSignReconciler(
 	signAPI sign.SignManager,
 	kernelAPI module.KernelMapper,
 	filter *filter.Filter,
+	gcDelay time.Duration,
 ) *BuildSignReconciler {
-	reconHelperAPI := newBuildSignReconcilerHelper(client, buildAPI, signAPI, kernelAPI)
+	reconHelperAPI := newBuildSignReconcilerHelper(client, buildAPI, signAPI, kernelAPI, gcDelay)
 	return &BuildSignReconciler{
 		reconHelperAPI: reconHelperAPI,
 		filter:         filter,
@@ -108,7 +110,7 @@ func (r *BuildSignReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Mod
 	}
 
 	logger.Info("run garbage collector for build/sign pods")
-	err = r.reconHelperAPI.garbageCollect(ctx, mod, mldMappings)
+	err = r.reconHelperAPI.garbageCollect(ctx, mod)
 	if err != nil {
 		return res, fmt.Errorf("failed to run garbage collection: %v", err)
 	}
@@ -125,12 +127,13 @@ type buildSignReconcilerHelperAPI interface {
 	getRelevantKernelMappings(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) (map[string]*api.ModuleLoaderData, error)
 	handleBuild(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 	handleSigning(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
-	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, mldMappings map[string]*api.ModuleLoaderData) error
+	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module) error
 }
 
 type buildSignReconcilerHelper struct {
 	client    client.Client
 	buildAPI  build.Manager
+	gcDelay   time.Duration
 	signAPI   sign.SignManager
 	kernelAPI module.KernelMapper
 }
@@ -138,10 +141,12 @@ type buildSignReconcilerHelper struct {
 func newBuildSignReconcilerHelper(client client.Client,
 	buildAPI build.Manager,
 	signAPI sign.SignManager,
-	kernelAPI module.KernelMapper) buildSignReconcilerHelperAPI {
+	kernelAPI module.KernelMapper,
+	gcDelay time.Duration) buildSignReconcilerHelperAPI {
 	return &buildSignReconcilerHelper{
 		client:    client,
 		buildAPI:  buildAPI,
+		gcDelay:   gcDelay,
 		signAPI:   signAPI,
 		kernelAPI: kernelAPI,
 	}
@@ -268,13 +273,11 @@ func (bsrh *buildSignReconcilerHelper) handleSigning(ctx context.Context, mld *a
 	return completedSuccessfully, nil
 }
 
-func (bsrh *buildSignReconcilerHelper) garbageCollect(ctx context.Context,
-	mod *kmmv1beta1.Module,
-	mldMappings map[string]*api.ModuleLoaderData) error {
+func (bsrh *buildSignReconcilerHelper) garbageCollect(ctx context.Context, mod *kmmv1beta1.Module) error {
 	logger := log.FromContext(ctx)
 
 	// Garbage collect for successfully finished build pods
-	deleted, err := bsrh.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod)
+	deleted, err := bsrh.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod, bsrh.gcDelay)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect build objects: %v", err)
 	}
@@ -282,7 +285,7 @@ func (bsrh *buildSignReconcilerHelper) garbageCollect(ctx context.Context,
 	logger.Info("Garbage-collected Build objects", "names", deleted)
 
 	// Garbage collect for successfully finished sign pods
-	deleted, err = bsrh.signAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod)
+	deleted, err = bsrh.signAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod, bsrh.gcDelay)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect sign objects: %v", err)
 	}

--- a/internal/controllers/mock_build_sign_reconciler.go
+++ b/internal/controllers/mock_build_sign_reconciler.go
@@ -42,17 +42,17 @@ func (m *MockbuildSignReconcilerHelperAPI) EXPECT() *MockbuildSignReconcilerHelp
 }
 
 // garbageCollect mocks base method.
-func (m *MockbuildSignReconcilerHelperAPI) garbageCollect(ctx context.Context, mod *v1beta1.Module, mldMappings map[string]*api.ModuleLoaderData) error {
+func (m *MockbuildSignReconcilerHelperAPI) garbageCollect(ctx context.Context, mod *v1beta1.Module) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "garbageCollect", ctx, mod, mldMappings)
+	ret := m.ctrl.Call(m, "garbageCollect", ctx, mod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // garbageCollect indicates an expected call of garbageCollect.
-func (mr *MockbuildSignReconcilerHelperAPIMockRecorder) garbageCollect(ctx, mod, mldMappings any) *gomock.Call {
+func (mr *MockbuildSignReconcilerHelperAPIMockRecorder) garbageCollect(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "garbageCollect", reflect.TypeOf((*MockbuildSignReconcilerHelperAPI)(nil).garbageCollect), ctx, mod, mldMappings)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "garbageCollect", reflect.TypeOf((*MockbuildSignReconcilerHelperAPI)(nil).garbageCollect), ctx, mod)
 }
 
 // getNodesListBySelector mocks base method.

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"context"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -12,7 +13,7 @@ import (
 //go:generate mockgen -source=manager.go -package=sign -destination=mock_manager.go
 
 type SignManager interface {
-	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object, delay time.Duration) ([]string, error)
 
 	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -11,6 +11,7 @@ package sign
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	utils "github.com/kubernetes-sigs/kernel-module-management/internal/utils"
@@ -42,18 +43,18 @@ func (m *MockSignManager) EXPECT() *MockSignManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockSignManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object) ([]string, error) {
+func (m *MockSignManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object, delay time.Duration) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner, delay)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockSignManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner any) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner, delay any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockSignManager)(nil).GarbageCollect), ctx, modName, namespace, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockSignManager)(nil).GarbageCollect), ctx, modName, namespace, owner, delay)
 }
 
 // ShouldSync mocks base method.

--- a/internal/sign/pod/manager.go
+++ b/internal/sign/pod/manager.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +38,7 @@ func NewSignPodManager(
 	}
 }
 
-func (spm *signPodManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
+func (spm *signPodManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object, delay time.Duration) ([]string, error) {
 	pods, err := spm.podHelper.GetModulePods(ctx, modName, namespace, utils.PodTypeSign, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sign pods for module %s: %v", modName, err)
@@ -45,11 +47,19 @@ func (spm *signPodManager) GarbageCollect(ctx context.Context, modName, namespac
 	deleteNames := make([]string, 0, len(pods))
 	for _, pod := range pods {
 		if pod.Status.Phase == v1.PodSucceeded {
-			err = spm.podHelper.DeletePod(ctx, &pod)
-			if err != nil {
-				return nil, fmt.Errorf("failed to delete build pod %s: %v", pod.Name, err)
+			if pod.DeletionTimestamp == nil {
+				if err = spm.podHelper.DeletePod(ctx, &pod); err != nil {
+					return nil, fmt.Errorf("failed to delete signing pod %s: %v", pod.Name, err)
+				}
 			}
-			deleteNames = append(deleteNames, pod.Name)
+
+			if pod.DeletionTimestamp.Add(delay).Before(time.Now()) {
+				if err = spm.podHelper.RemoveFinalizer(ctx, &pod, constants.GCDelayFinalizer); err != nil {
+					return nil, fmt.Errorf("could not remove the GC delay finalizer from pod %s/%s: %v", pod.Namespace, pod.Name, err)
+				}
+
+				deleteNames = append(deleteNames, pod.Name)
+			}
 		}
 	}
 	return deleteNames, nil
@@ -110,6 +120,11 @@ func (spm *signPodManager) Sync(
 
 	if changed {
 		logger.Info("The module's sign spec has been changed, deleting the current pod so a new one can be created", "name", pod.Name)
+
+		if err = spm.podHelper.RemoveFinalizer(ctx, pod, constants.GCDelayFinalizer); err != nil {
+			return "", fmt.Errorf("could not remove the GC delay finalizer from pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
+
 		err = spm.podHelper.DeletePod(ctx, pod)
 		if err != nil {
 			logger.Info(utils.WarnString(fmt.Sprintf("failed to delete signing pod %s: %v", pod.Name, err)))

--- a/internal/sign/pod/manager_test.go
+++ b/internal/sign/pod/manager_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
+	"github.com/budougumi0617/cmpmock"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
@@ -323,6 +325,7 @@ var _ = Describe("Sync", func() {
 			maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&newPod, nil),
 			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.PodTypeSign, mld.Owner).Return(&newPod, nil),
 			podhelper.EXPECT().IsPodChanged(&newPod, &newPod).Return(true, nil),
+			podhelper.EXPECT().RemoveFinalizer(ctx, &newPod, constants.GCDelayFinalizer),
 			podhelper.EXPECT().DeletePod(ctx, &newPod).Return(nil),
 		)
 
@@ -354,57 +357,126 @@ var _ = Describe("GarbageCollect", func() {
 		Owner: &kmmv1beta1.Module{},
 	}
 
+	type testCase struct {
+		podPhase1, podPhase2                       v1.PodPhase
+		gcDelay                                    time.Duration
+		expectsErr                                 bool
+		resShouldContainPod1, resShouldContainPod2 bool
+	}
+
 	DescribeTable("should return the correct error and names of the collected pods",
-		func(podStatus1 v1.PodStatus, podStatus2 v1.PodStatus, expectsErr bool) {
+		func(tc testCase) {
+			const (
+				pod1Name = "pod-1"
+				pod2Name = "pod-2"
+			)
+
+			ctx := context.Background()
+
 			pod1 := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "podName1",
-				},
-				Status: podStatus1,
+				ObjectMeta: metav1.ObjectMeta{Name: pod1Name},
+				Status:     v1.PodStatus{Phase: tc.podPhase1},
 			}
 			pod2 := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "podName2",
-				},
-				Status: podStatus2,
+				ObjectMeta: metav1.ObjectMeta{Name: pod2Name},
+				Status:     v1.PodStatus{Phase: tc.podPhase2},
 			}
-			expectedNames := []string{}
-			if !expectsErr {
-				if pod1.Status.Phase == v1.PodSucceeded {
-					expectedNames = append(expectedNames, "podName1")
-				}
-				if pod2.Status.Phase == v1.PodSucceeded {
-					expectedNames = append(expectedNames, "podName2")
-				}
-			}
+
 			returnedError := fmt.Errorf("some error")
-			if !expectsErr {
+			if !tc.expectsErr {
 				returnedError = nil
 			}
 
-			podhelper.EXPECT().GetModulePods(context.Background(), mld.Name, mld.Namespace, utils.PodTypeSign, mld.Owner).Return([]v1.Pod{pod1, pod2}, returnedError)
-			if !expectsErr {
-				if pod1.Status.Phase == v1.PodSucceeded {
-					podhelper.EXPECT().DeletePod(context.Background(), &pod1).Return(nil)
-				}
-				if pod2.Status.Phase == v1.PodSucceeded {
-					podhelper.EXPECT().DeletePod(context.Background(), &pod2).Return(nil)
+			podList := []v1.Pod{pod1, pod2}
+
+			calls := []any{
+				podhelper.EXPECT().GetModulePods(ctx, mld.Name, mld.Namespace, utils.PodTypeSign, mld.Owner).Return(podList, returnedError),
+			}
+
+			if !tc.expectsErr {
+				now := metav1.Now()
+
+				for i := 0; i < len(podList); i++ {
+					pod := &podList[i]
+
+					if pod.Status.Phase == v1.PodSucceeded {
+						c := podhelper.
+							EXPECT().
+							DeletePod(ctx, cmpmock.DiffEq(pod)).
+							Do(func(_ context.Context, p *v1.Pod) {
+								p.DeletionTimestamp = &now
+								pod.DeletionTimestamp = &now
+							})
+
+						calls = append(calls, c)
+
+						if time.Now().After(now.Add(tc.gcDelay)) {
+							calls = append(
+								calls,
+								podhelper.EXPECT().RemoveFinalizer(ctx, cmpmock.DiffEq(pod), constants.GCDelayFinalizer),
+							)
+						}
+					}
 				}
 			}
 
-			names, err := mgr.GarbageCollect(context.Background(), mld.Name, mld.Namespace, mld.Owner)
+			gomock.InOrder(calls...)
 
-			if expectsErr {
+			names, err := mgr.GarbageCollect(ctx, mld.Name, mld.Namespace, mld.Owner, tc.gcDelay)
+
+			if tc.expectsErr {
 				Expect(err).To(HaveOccurred())
-				Expect(names).To(BeNil())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(expectedNames).To(Equal(names))
+				return
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+
+			if tc.resShouldContainPod1 {
+				Expect(names).To(ContainElements(pod1Name))
+			}
+
+			if tc.resShouldContainPod2 {
+				Expect(names).To(ContainElements(pod2Name))
 			}
 		},
-		Entry("all pods succeeded", v1.PodStatus{Phase: v1.PodSucceeded}, v1.PodStatus{Phase: v1.PodSucceeded}, false),
-		Entry("1 pod succeeded", v1.PodStatus{Phase: v1.PodSucceeded}, v1.PodStatus{Phase: v1.PodFailed}, false),
-		Entry("0 pod succeeded", v1.PodStatus{Phase: v1.PodFailed}, v1.PodStatus{Phase: v1.PodFailed}, false),
-		Entry("error occured", v1.PodStatus{Phase: v1.PodFailed}, v1.PodStatus{Phase: v1.PodFailed}, true),
+		Entry(
+			"all pods succeeded",
+			testCase{
+				podPhase1:            v1.PodSucceeded,
+				podPhase2:            v1.PodSucceeded,
+				resShouldContainPod1: true,
+				resShouldContainPod2: true,
+			},
+		),
+		Entry(
+			"1 pod succeeded",
+			testCase{
+				podPhase1:            v1.PodSucceeded,
+				podPhase2:            v1.PodFailed,
+				resShouldContainPod1: true,
+			},
+		),
+		Entry(
+			"0 pod succeeded",
+			testCase{
+				podPhase1: v1.PodFailed,
+				podPhase2: v1.PodFailed,
+			},
+		),
+		Entry(
+			"error occurred",
+			testCase{expectsErr: true},
+		),
+		Entry(
+			"GC delayed",
+			testCase{
+				podPhase1:            v1.PodSucceeded,
+				podPhase2:            v1.PodSucceeded,
+				gcDelay:              time.Hour,
+				resShouldContainPod1: false,
+				resShouldContainPod2: false,
+			},
+		),
 	)
+
 })

--- a/internal/sign/pod/signer.go
+++ b/internal/sign/pod/signer.go
@@ -206,7 +206,7 @@ func (s *signer) MakePodTemplate(
 				constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash),
 				dockerfileAnnotationKey:     buf.String(),
 			},
-			Finalizers: []string{constants.JobEventFinalizer},
+			Finalizers: []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},
 		Spec: podSpec,
 	}

--- a/internal/sign/pod/signer_test.go
+++ b/internal/sign/pod/signer_test.go
@@ -163,7 +163,7 @@ COPY --from=signimage /tmp/signroot/modules/simple-procfs-kmod.ko /modules/simpl
 						BlockOwnerDeletion: ptr.To(true),
 					},
 				},
-				Finalizers: []string{constants.JobEventFinalizer},
+				Finalizers: []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 			},
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{

--- a/internal/utils/mock_podhelper.go
+++ b/internal/utils/mock_podhelper.go
@@ -141,3 +141,17 @@ func (mr *MockPodHelperMockRecorder) PodLabels(modName, targetKernel, podType an
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PodLabels", reflect.TypeOf((*MockPodHelper)(nil).PodLabels), modName, targetKernel, podType)
 }
+
+// RemoveFinalizer mocks base method.
+func (m *MockPodHelper) RemoveFinalizer(ctx context.Context, pod *v1.Pod, finalizer string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveFinalizer", ctx, pod, finalizer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveFinalizer indicates an expected call of RemoveFinalizer.
+func (mr *MockPodHelperMockRecorder) RemoveFinalizer(ctx, pod, finalizer any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFinalizer", reflect.TypeOf((*MockPodHelper)(nil).RemoveFinalizer), ctx, pod, finalizer)
+}


### PR DESCRIPTION
Add the `job.gcDelay` operator configuration property to delay the garbage collection of successful build and signing jobs.
Add the new `kmm.node.kubernetes.io/gc-delay finalizer` to all new jobs.
Only clear the finalizer after `deletionTimestamp+gcDelay`.

Fixes #572

/cc @yevgeny-shnaidman @mresvanis @ybettan