### PR TITLE
Update the Go version in more places

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
     - if: matrix.language == 'go'
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -82,7 +82,7 @@ steps:
       - gcr.io/$PROJECT_ID/kernel-module-management-worker
     waitFor: [build-worker]
   - id: build-bundles
-    name: golang:1.21-alpine3.19
+    name: golang:1.22-alpine3.19
     env:
       - '_GIT_TAG=$_GIT_TAG'
     entrypoint: sh


### PR DESCRIPTION
Use Go 1.22 in Google Cloud Build and a CI job.

/cc @mresvanis 