### PR TITLE
Normalize kernel version in labels and image tags

### DIFF
--- a/internal/api/moduleloaderdata.go
+++ b/internal/api/moduleloaderdata.go
@@ -16,6 +16,11 @@ import (
 type ModuleLoaderData struct {
 	// kernel version
 	KernelVersion string
+
+	// KernelNormalizedVersion is the kernel version with some characters replaced with '_' so that it can be used in
+	// a Kubernetes label or a container image tag.
+	KernelNormalizedVersion string
+
 	// Repo secret for DS images
 	ImageRepoSecret *v1.LocalObjectReference
 

--- a/internal/build/pod/maker.go
+++ b/internal/build/pod/maker.go
@@ -90,7 +90,7 @@ func (m *maker) MakePodTemplate(
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-build-",
 			Namespace:    mld.Namespace,
-			Labels:       m.podHelper.PodLabels(mld.Name, mld.KernelVersion, utils.PodTypeBuild),
+			Labels:       m.podHelper.PodLabels(mld.Name, mld.KernelNormalizedVersion, utils.PodTypeBuild),
 			Annotations:  map[string]string{constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash)},
 			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},

--- a/internal/build/pod/maker_test.go
+++ b/internal/build/pod/maker_test.go
@@ -26,13 +26,14 @@ import (
 
 var _ = Describe("MakePodTemplate", func() {
 	const (
-		image              = "my.registry/my/image"
-		dockerfile         = "FROM test"
-		kanikoImage        = "some-kaniko-image:some-tag"
-		kernelVersion      = "1.2.3"
-		moduleName         = "module-name"
-		namespace          = "some-namespace"
-		relatedImageEnvVar = "RELATED_IMAGE_BUILD"
+		image                   = "my.registry/my/image"
+		dockerfile              = "FROM test"
+		kanikoImage             = "some-kaniko-image:some-tag"
+		kernelVersion           = "1.2.3+4"
+		kernelNormalizedVersion = "1.2.3_4"
+		moduleName              = "module-name"
+		namespace               = "some-namespace"
+		relatedImageEnvVar      = "RELATED_IMAGE_BUILD"
 	)
 
 	var (
@@ -93,10 +94,11 @@ var _ = Describe("MakePodTemplate", func() {
 				BuildArgs:           buildArgs,
 				DockerfileConfigMap: &dockerfileConfigMap,
 			},
-			ContainerImage: image,
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
-			Selector:       nodeSelector,
-			KernelVersion:  kernelVersion,
+			ContainerImage:          image,
+			RegistryTLS:             &kmmv1beta1.TLSOptions{},
+			Selector:                nodeSelector,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelNormalizedVersion,
 		}
 
 		if useBuildSelector {
@@ -106,7 +108,7 @@ var _ = Describe("MakePodTemplate", func() {
 
 		labels := map[string]string{
 			constants.ModuleNameLabel:    moduleName,
-			constants.TargetKernelTarget: kernelVersion,
+			constants.TargetKernelTarget: kernelNormalizedVersion,
 			constants.PodType:            "build",
 		}
 
@@ -238,7 +240,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			podhelper.EXPECT().PodLabels(mld.Name, kernelVersion, utils.PodTypeBuild).Return(labels),
+			podhelper.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, utils.PodTypeBuild).Return(labels),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, true)
@@ -286,13 +288,14 @@ var _ = Describe("MakePodTemplate", func() {
 		ctx := context.Background()
 
 		mld := api.ModuleLoaderData{
-			Build:          b,
-			ContainerImage: image,
-			RegistryTLS:    tls,
-			Name:           mod.Name,
-			Namespace:      mod.Namespace,
-			Owner:          &mod,
-			KernelVersion:  kernelVersion,
+			Build:                   b,
+			ContainerImage:          image,
+			RegistryTLS:             tls,
+			Name:                    mod.Name,
+			Namespace:               mod.Namespace,
+			Owner:                   &mod,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelNormalizedVersion,
 		}
 
 		gomock.InOrder(
@@ -303,7 +306,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			podhelper.EXPECT().PodLabels(mod.Name, kernelVersion, utils.PodTypeBuild).Return(map[string]string{}),
+			podhelper.EXPECT().PodLabels(mod.Name, kernelNormalizedVersion, utils.PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, pushImage)
@@ -368,9 +371,10 @@ var _ = Describe("MakePodTemplate", func() {
 				DockerfileConfigMap: &dockerfileConfigMap,
 				KanikoParams:        &kmmv1beta1.KanikoParams{Tag: customTag},
 			},
-			ContainerImage: image,
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
-			KernelVersion:  kernelVersion,
+			ContainerImage:          image,
+			RegistryTLS:             &kmmv1beta1.TLSOptions{},
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelNormalizedVersion,
 		}
 
 		gomock.InOrder(
@@ -381,7 +385,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			podhelper.EXPECT().PodLabels(mld.Name, kernelVersion, utils.PodTypeBuild).Return(map[string]string{}),
+			podhelper.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, utils.PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, false)
@@ -401,10 +405,11 @@ var _ = Describe("MakePodTemplate", func() {
 				BuildArgs:           buildArgs,
 				DockerfileConfigMap: &dockerfileConfigMap,
 			},
-			Sign:           &kmmv1beta1.Sign{},
-			ContainerImage: image,
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
-			KernelVersion:  kernelVersion,
+			Sign:                    &kmmv1beta1.Sign{},
+			ContainerImage:          image,
+			RegistryTLS:             &kmmv1beta1.TLSOptions{},
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelNormalizedVersion,
 		}
 
 		expectedImageName := mld.ContainerImage + ":" + mld.Namespace + "_" + mld.Name + "_kmm_unsigned"
@@ -417,7 +422,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			podhelper.EXPECT().PodLabels(mld.Name, kernelVersion, utils.PodTypeBuild).Return(map[string]string{}),
+			podhelper.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, utils.PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, true)

--- a/internal/build/pod/manager.go
+++ b/internal/build/pod/manager.go
@@ -96,7 +96,7 @@ func (pm *podManager) Sync(
 		return "", fmt.Errorf("could not make Pod template: %v", err)
 	}
 
-	pod, err := pm.podHelper.GetModulePodByKernel(ctx, mld.Name, mld.Namespace, mld.KernelVersion, utils.PodTypeBuild, owner)
+	pod, err := pm.podHelper.GetModulePodByKernel(ctx, mld.Name, mld.Namespace, mld.KernelNormalizedVersion, utils.PodTypeBuild, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingPod) {
 			return "", fmt.Errorf("error getting the build: %v", err)

--- a/internal/build/pod/manager_test.go
+++ b/internal/build/pod/manager_test.go
@@ -26,10 +26,9 @@ var _ = Describe("ShouldSync", func() {
 		reg  *registry.MockRegistry
 	)
 	const (
-		moduleName    = "module-name"
-		imageName     = "image-name"
-		namespace     = "some-namespace"
-		kernelVersion = "1.2.3"
+		moduleName = "module-name"
+		imageName  = "image-name"
+		namespace  = "some-namespace"
 	)
 
 	BeforeEach(func() {
@@ -145,9 +144,10 @@ var _ = Describe("Sync", func() {
 	})
 
 	const (
-		moduleName    = "module-name"
-		kernelVersion = "1.2.3"
-		podName       = "some-pod"
+		moduleName              = "module-name"
+		kernelVersion           = "1.2.3+4"
+		kernelNormalizedVersion = "1.2.3_4"
+		podName                 = "some-pod"
 	)
 
 	mod := kmmv1beta1.Module{
@@ -155,11 +155,12 @@ var _ = Describe("Sync", func() {
 	}
 
 	mld := &api.ModuleLoaderData{
-		Name:           moduleName,
-		Build:          &kmmv1beta1.Build{},
-		ContainerImage: imageName,
-		Owner:          &mod,
-		KernelVersion:  kernelVersion,
+		Name:                    moduleName,
+		Build:                   &kmmv1beta1.Build{},
+		ContainerImage:          imageName,
+		Owner:                   &mod,
+		KernelVersion:           kernelVersion,
+		KernelNormalizedVersion: kernelNormalizedVersion,
 	}
 
 	DescribeTable("should return the correct status depending on the pod status",
@@ -175,7 +176,7 @@ var _ = Describe("Sync", func() {
 
 			gomock.InOrder(
 				maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
-				podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.PodTypeBuild, mld.Owner).Return(&j, nil),
+				podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelNormalizedVersion, utils.PodTypeBuild, mld.Owner).Return(&j, nil),
 				podhelper.EXPECT().IsPodChanged(&j, &j).Return(false, nil),
 				podhelper.EXPECT().GetPodStatus(&j).Return(podStatus, nil),
 			)
@@ -227,7 +228,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
-			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.PodTypeBuild, mld.Owner).Return(nil, utils.ErrNoMatchingPod),
+			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelNormalizedVersion, utils.PodTypeBuild, mld.Owner).Return(nil, utils.ErrNoMatchingPod),
 			podhelper.EXPECT().CreatePod(ctx, &j).Return(errors.New("some error")),
 		)
 
@@ -256,7 +257,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
-			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.PodTypeBuild, mld.Owner).Return(nil, utils.ErrNoMatchingPod),
+			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelNormalizedVersion, utils.PodTypeBuild, mld.Owner).Return(nil, utils.ErrNoMatchingPod),
 			podhelper.EXPECT().CreatePod(ctx, &j).Return(nil),
 		)
 
@@ -298,7 +299,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&newPod, nil),
-			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.PodTypeBuild, mld.Owner).Return(&j, nil),
+			podhelper.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace, kernelNormalizedVersion, utils.PodTypeBuild, mld.Owner).Return(&j, nil),
 			podhelper.EXPECT().IsPodChanged(&j, &newPod).Return(true, nil),
 			podhelper.EXPECT().DeletePod(ctx, &j).Return(nil),
 		)

--- a/internal/kernel/kernel.go
+++ b/internal/kernel/kernel.go
@@ -1,0 +1,15 @@
+package kernel
+
+import "strings"
+
+func replaceInvalidChar(r rune) rune {
+	if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' && r != '.' && r != '_' {
+		return '_'
+	}
+
+	return r
+}
+
+func NormalizeVersion(version string) string {
+	return strings.Map(replaceInvalidChar, version)
+}

--- a/internal/kernel/kernel_test.go
+++ b/internal/kernel/kernel_test.go
@@ -1,0 +1,26 @@
+package kernel
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NormalizeVersion", func() {
+	DescribeTable(
+		"should work as expected",
+		func(version, expected string) {
+			Expect(
+				NormalizeVersion(version),
+			).To(
+				Equal(expected),
+			)
+		},
+		Entry(nil, "1.2.3-4", "1.2.3-4"),
+		Entry(nil, "1.2.3+4", "1.2.3_4"),
+		Entry(nil, "1.2.3_4", "1.2.3_4"),
+		Entry(nil, "1.2.3&4", "1.2.3_4"),
+		Entry(nil, "1.2.3%4", "1.2.3_4"),
+		Entry(nil, "1.2.3?4", "1.2.3_4"),
+		Entry(nil, "1.2.3 4", "1.2.3_4"),
+	)
+})

--- a/internal/kernel/suite_test.go
+++ b/internal/kernel/suite_test.go
@@ -1,0 +1,13 @@
+package kernel
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kernel Suite")
+}

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -8,6 +8,7 @@ import (
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/build"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/kernel"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/sign"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
@@ -134,6 +135,7 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 	}
 
 	mld.KernelVersion = kernelVersion
+	mld.KernelNormalizedVersion = kernel.NormalizeVersion(kernelVersion)
 	mld.Name = mod.Name
 	mld.Namespace = mod.Namespace
 	mld.ImageRepoSecret = mod.Spec.ImageRepoSecret
@@ -148,7 +150,7 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 }
 
 func (kh *kernelMapperHelper) replaceTemplates(mld *api.ModuleLoaderData) error {
-	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelVersion)
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelNormalizedVersion)
 	osConfigEnvVars = append(osConfigEnvVars, "MOD_NAME="+mld.Name, "MOD_NAMESPACE="+mld.Namespace)
 
 	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mld.ContainerImage)

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -194,15 +194,16 @@ var _ = Describe("prepareModuleLoaderData", func() {
 		}
 
 		mld := api.ModuleLoaderData{
-			Name:               mod.Name,
-			Namespace:          mod.Namespace,
-			ImageRepoSecret:    mod.Spec.ImageRepoSecret,
-			Owner:              &mod,
-			Selector:           mod.Spec.Selector,
-			ServiceAccountName: mod.Spec.ModuleLoader.ServiceAccountName,
-			Modprobe:           mod.Spec.ModuleLoader.Container.Modprobe,
-			ImagePullPolicy:    mod.Spec.ModuleLoader.Container.ImagePullPolicy,
-			KernelVersion:      kernelVersion,
+			Name:                    mod.Name,
+			Namespace:               mod.Namespace,
+			ImageRepoSecret:         mod.Spec.ImageRepoSecret,
+			Owner:                   &mod,
+			Selector:                mod.Spec.Selector,
+			ServiceAccountName:      mod.Spec.ModuleLoader.ServiceAccountName,
+			Modprobe:                mod.Spec.ModuleLoader.Container.Modprobe,
+			ImagePullPolicy:         mod.Spec.ModuleLoader.Container.ImagePullPolicy,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelVersion,
 		}
 
 		if buildExistsInMapping {
@@ -257,15 +258,16 @@ var _ = Describe("prepareModuleLoaderData", func() {
 	// [TODO] remove this unit test once InTreeModuleToRemove depricated field is removed from CRD
 	DescribeTable("prepare InTreeModules based on InTreeModule", func(inTreeModuleInContainer, inTreeModuleInMapping bool, expectedInTreeModules []string) {
 		mld := api.ModuleLoaderData{
-			Name:               mod.Name,
-			Namespace:          mod.Namespace,
-			ImageRepoSecret:    mod.Spec.ImageRepoSecret,
-			Owner:              &mod,
-			Selector:           mod.Spec.Selector,
-			ServiceAccountName: mod.Spec.ModuleLoader.ServiceAccountName,
-			Modprobe:           mod.Spec.ModuleLoader.Container.Modprobe,
-			ImagePullPolicy:    mod.Spec.ModuleLoader.Container.ImagePullPolicy,
-			KernelVersion:      kernelVersion,
+			Name:                    mod.Name,
+			Namespace:               mod.Namespace,
+			ImageRepoSecret:         mod.Spec.ImageRepoSecret,
+			Owner:                   &mod,
+			Selector:                mod.Spec.Selector,
+			ServiceAccountName:      mod.Spec.ModuleLoader.ServiceAccountName,
+			Modprobe:                mod.Spec.ModuleLoader.Container.Modprobe,
+			ImagePullPolicy:         mod.Spec.ModuleLoader.Container.ImagePullPolicy,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelVersion,
 		}
 		mld.RegistryTLS = &mod.Spec.ModuleLoader.Container.RegistryTLS
 		mld.ContainerImage = mod.Spec.ModuleLoader.Container.ContainerImage
@@ -282,7 +284,7 @@ var _ = Describe("prepareModuleLoaderData", func() {
 
 		res, err := kh.prepareModuleLoaderData(&mapping, &mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(*res).To(Equal(mld))
+		Expect(*res).To(BeComparableTo(mld))
 	},
 		Entry("inTreeModule not defined", false, false, nil),
 		Entry("inTreeModule defined in container", true, false, []string{"inTreeModuleToRemoveInContainer"}),
@@ -298,8 +300,9 @@ var _ = Describe("replaceTemplates", func() {
 
 	It("error input", func() {
 		mld := api.ModuleLoaderData{
-			ContainerImage: "some image:${KERNEL_XYZ",
-			KernelVersion:  kernelVersion,
+			ContainerImage:          "some image:${KERNEL_XYZ",
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelVersion,
 		}
 		err := kh.replaceTemplates(&mld)
 		Expect(err).To(HaveOccurred())
@@ -315,7 +318,8 @@ var _ = Describe("replaceTemplates", func() {
 				},
 				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
-			KernelVersion: kernelVersion,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelVersion,
 		}
 		expectMld := api.ModuleLoaderData{
 			ContainerImage: "some image:5.8.18",
@@ -326,7 +330,8 @@ var _ = Describe("replaceTemplates", func() {
 				},
 				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
-			KernelVersion: kernelVersion,
+			KernelVersion:           kernelVersion,
+			KernelNormalizedVersion: kernelVersion,
 		}
 
 		err := kh.replaceTemplates(&mld)

--- a/internal/sign/helper.go
+++ b/internal/sign/helper.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/kernel"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
@@ -18,7 +19,7 @@ func NewSignerHelper() Helper {
 	return &helper{}
 }
 
-func (m *helper) GetRelevantSign(moduleSign *kmmv1beta1.Sign, mappingSign *kmmv1beta1.Sign, kernel string) (*kmmv1beta1.Sign, error) {
+func (m *helper) GetRelevantSign(moduleSign *kmmv1beta1.Sign, mappingSign *kmmv1beta1.Sign, kernelVersion string) (*kmmv1beta1.Sign, error) {
 	var signConfig *kmmv1beta1.Sign
 	if moduleSign == nil {
 		// km.Sign cannot be nil in case mod.Sign is nil, checked above
@@ -42,7 +43,9 @@ func (m *helper) GetRelevantSign(moduleSign *kmmv1beta1.Sign, mappingSign *kmmv1
 		signConfig.FilesToSign = append(signConfig.FilesToSign, mappingSign.FilesToSign...)
 	}
 
-	osConfigEnvVars := utils.KernelComponentsAsEnvVars(kernel)
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(
+		kernel.NormalizeVersion(kernelVersion),
+	)
 	unsignedImage, err := utils.ReplaceInTemplates(osConfigEnvVars, signConfig.UnsignedImage)
 	if err != nil {
 		return nil, err

--- a/internal/sign/pod/manager.go
+++ b/internal/sign/pod/manager.go
@@ -81,14 +81,14 @@ func (spm *signPodManager) Sync(
 
 	logger.Info("Signing in-cluster")
 
-	labels := spm.podHelper.PodLabels(mld.Name, mld.KernelVersion, "sign")
+	labels := spm.podHelper.PodLabels(mld.Name, mld.KernelNormalizedVersion, "sign")
 
 	podTemplate, err := spm.signer.MakePodTemplate(ctx, mld, labels, imageToSign, pushImage, owner)
 	if err != nil {
 		return "", fmt.Errorf("could not make Pod template: %v", err)
 	}
 
-	pod, err := spm.podHelper.GetModulePodByKernel(ctx, mld.Name, mld.Namespace, mld.KernelVersion, utils.PodTypeSign, owner)
+	pod, err := spm.podHelper.GetModulePodByKernel(ctx, mld.Name, mld.Namespace, mld.KernelNormalizedVersion, utils.PodTypeSign, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingPod) {
 			return "", fmt.Errorf("error getting the signing pod: %v", err)


### PR DESCRIPTION
Handle uncommon kernel versions with characters such as `+`, by replacing them with `_`.

/cc @ybettan @mresvanis 