### PR TITLE
adding unit tests to `node` package

### DIFF
--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -3,13 +3,64 @@ package node
 import (
 	"context"
 	"fmt"
-
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 )
+
+var _ = Describe("IsNodeSchedulable", func() {
+	var (
+		ctrl              *gomock.Controller
+		clnt              *client.MockClient
+		mn                Node
+		isNodeSchedulable bool
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mn = NewNode(clnt)
+	})
+
+	It("Returns false, node is not schedulable", func() {
+
+		node := v1.Node{
+			Spec: v1.NodeSpec{
+				Taints: []v1.Taint{
+					{
+						Effect: v1.TaintEffectNoSchedule,
+					},
+					{
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				},
+			},
+		}
+		isNodeSchedulable = mn.IsNodeSchedulable(&node)
+		Expect(isNodeSchedulable).To(BeFalse())
+
+	})
+	It("Returns true, node is schedulable", func() {
+
+		node := v1.Node{
+			Spec: v1.NodeSpec{
+				Taints: []v1.Taint{
+					{
+						Effect: v1.TaintEffectNoExecute,
+					},
+					{
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				},
+			},
+		}
+		isNodeSchedulable = mn.IsNodeSchedulable(&node)
+		Expect(isNodeSchedulable).To(BeTrue())
+
+	})
+})
 
 var _ = Describe("GetNodesListBySelector", func() {
 	var (
@@ -37,7 +88,7 @@ var _ = Describe("GetNodesListBySelector", func() {
 		node1 := v1.Node{
 			Spec: v1.NodeSpec{
 				Taints: []v1.Taint{
-					v1.Taint{
+					{
 						Effect: v1.TaintEffectNoSchedule,
 					},
 				},
@@ -47,7 +98,7 @@ var _ = Describe("GetNodesListBySelector", func() {
 		node3 := v1.Node{
 			Spec: v1.NodeSpec{
 				Taints: []v1.Taint{
-					v1.Taint{
+					{
 						Effect: v1.TaintEffectPreferNoSchedule,
 					},
 				},
@@ -64,5 +115,108 @@ var _ = Describe("GetNodesListBySelector", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodes).To(Equal([]v1.Node{node2, node3}))
 
+	})
+})
+
+var _ = Describe("GetNumTargetedNodes", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mn   Node
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mn = NewNode(clnt)
+	})
+
+	It("There are not schedulable nodes", func() {
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		numOfNodes, err := mn.GetNumTargetedNodes(context.Background(), map[string]string{})
+
+		Expect(err).To(HaveOccurred())
+		Expect(numOfNodes).To(Equal(0))
+	})
+
+	It("Return the number of schedulable nodes only", func() {
+		node1 := v1.Node{
+			Spec: v1.NodeSpec{
+				Taints: []v1.Taint{
+					{
+						Effect: v1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		}
+		node2 := v1.Node{}
+		node3 := v1.Node{
+			Spec: v1.NodeSpec{
+				Taints: []v1.Taint{
+					{
+						Effect: v1.TaintEffectPreferNoSchedule,
+					},
+				},
+			},
+		}
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *v1.NodeList, _ ...interface{}) error {
+				list.Items = []v1.Node{node1, node2, node3}
+				return nil
+			},
+		)
+		numOfNodes, err := mn.GetNumTargetedNodes(context.Background(), map[string]string{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(numOfNodes).To(Equal(2))
+
+	})
+})
+
+var _ = Describe("FindNodeCondition", func() {
+	var (
+		ctrl           *gomock.Controller
+		clnt           *client.MockClient
+		mn             Node
+		conditionFound *v1.NodeCondition
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mn = NewNode(clnt)
+	})
+
+	It("Finds condition", func() {
+		condition := v1.NodeCondition{
+			Type: v1.NodeReady,
+		}
+		node := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					condition,
+				},
+			},
+		}
+		conditionFound = mn.FindNodeCondition(node.Status.Conditions, v1.NodeReady)
+		Expect(conditionFound).To(Equal(&condition))
+	})
+
+	It("Does not find condition", func() {
+		node := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type: v1.NodeDiskPressure,
+					},
+					{
+						Type: v1.NodeMemoryPressure,
+					},
+				},
+			},
+		}
+		conditionFound = mn.FindNodeCondition(node.Status.Conditions, v1.NodeReady)
+		Expect(conditionFound).To(BeNil())
 	})
 })


### PR DESCRIPTION
## Summary
Some of the functions in the `node` package do not have any unit tests. 
This commit adds new unit tests for them.

---

## Description
This PR adds unit tests to the functions in the `node` package:
1. `IsNodeSchedulable`
2. `GetNumTargetedNodes`
3. `FindNodeCondition`