### PR TITLE
Shorten UpdateNodeLabelsAndRecordEvents function in nmc_reconciler.go

### DIFF
--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -15,6 +15,8 @@ import (
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,6 +85,18 @@ func (mr *MocknmcReconcilerHelperMockRecorder) ProcessUnconfiguredModuleStatus(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessUnconfiguredModuleStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessUnconfiguredModuleStatus), ctx, nmc, status)
 }
 
+// RecordEvents mocks base method.
+func (m *MocknmcReconcilerHelper) RecordEvents(node *v1.Node, loadedModules, unloadedModules []types.NamespacedName) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RecordEvents", node, loadedModules, unloadedModules)
+}
+
+// RecordEvents indicates an expected call of RecordEvents.
+func (mr *MocknmcReconcilerHelperMockRecorder) RecordEvents(node, loadedModules, unloadedModules any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordEvents", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).RecordEvents), node, loadedModules, unloadedModules)
+}
+
 // RemovePodFinalizers mocks base method.
 func (m *MocknmcReconcilerHelper) RemovePodFinalizers(ctx context.Context, nodeName string) error {
 	m.ctrl.T.Helper()
@@ -111,18 +125,127 @@ func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
 }
 
-// UpdateNodeLabelsAndRecordEvents mocks base method.
-func (m *MocknmcReconcilerHelper) UpdateNodeLabelsAndRecordEvents(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+// UpdateNodeLabels mocks base method.
+func (m *MocknmcReconcilerHelper) UpdateNodeLabels(ctx context.Context, nmc *v1beta1.NodeModulesConfig, node *v1.Node) ([]types.NamespacedName, []types.NamespacedName, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNodeLabelsAndRecordEvents", ctx, nmc)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "UpdateNodeLabels", ctx, nmc, node)
+	ret0, _ := ret[0].([]types.NamespacedName)
+	ret1, _ := ret[1].([]types.NamespacedName)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UpdateNodeLabels indicates an expected call of UpdateNodeLabels.
+func (mr *MocknmcReconcilerHelperMockRecorder) UpdateNodeLabels(ctx, nmc, node any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodeLabels", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).UpdateNodeLabels), ctx, nmc, node)
+}
+
+// MocklabelPreparationHelper is a mock of labelPreparationHelper interface.
+type MocklabelPreparationHelper struct {
+	ctrl     *gomock.Controller
+	recorder *MocklabelPreparationHelperMockRecorder
+}
+
+// MocklabelPreparationHelperMockRecorder is the mock recorder for MocklabelPreparationHelper.
+type MocklabelPreparationHelperMockRecorder struct {
+	mock *MocklabelPreparationHelper
+}
+
+// NewMocklabelPreparationHelper creates a new mock instance.
+func NewMocklabelPreparationHelper(ctrl *gomock.Controller) *MocklabelPreparationHelper {
+	mock := &MocklabelPreparationHelper{ctrl: ctrl}
+	mock.recorder = &MocklabelPreparationHelperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklabelPreparationHelper) EXPECT() *MocklabelPreparationHelperMockRecorder {
+	return m.recorder
+}
+
+// addEqualLabels mocks base method.
+func (m *MocklabelPreparationHelper) addEqualLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName], specLabels, statusLabels map[types.NamespacedName]v1beta1.ModuleConfig) []types.NamespacedName {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "addEqualLabels", nodeModuleReadyLabels, specLabels, statusLabels)
+	ret0, _ := ret[0].([]types.NamespacedName)
 	return ret0
 }
 
-// UpdateNodeLabelsAndRecordEvents indicates an expected call of UpdateNodeLabelsAndRecordEvents.
-func (mr *MocknmcReconcilerHelperMockRecorder) UpdateNodeLabelsAndRecordEvents(ctx, nmc any) *gomock.Call {
+// addEqualLabels indicates an expected call of addEqualLabels.
+func (mr *MocklabelPreparationHelperMockRecorder) addEqualLabels(nodeModuleReadyLabels, specLabels, statusLabels any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodeLabelsAndRecordEvents", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).UpdateNodeLabelsAndRecordEvents), ctx, nmc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addEqualLabels", reflect.TypeOf((*MocklabelPreparationHelper)(nil).addEqualLabels), nodeModuleReadyLabels, specLabels, statusLabels)
+}
+
+// getDeprecatedKernelModuleReadyLabels mocks base method.
+func (m *MocklabelPreparationHelper) getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getDeprecatedKernelModuleReadyLabels", node)
+	ret0, _ := ret[0].(sets.Set[string])
+	return ret0
+}
+
+// getDeprecatedKernelModuleReadyLabels indicates an expected call of getDeprecatedKernelModuleReadyLabels.
+func (mr *MocklabelPreparationHelperMockRecorder) getDeprecatedKernelModuleReadyLabels(node any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getDeprecatedKernelModuleReadyLabels", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getDeprecatedKernelModuleReadyLabels), node)
+}
+
+// getNodeKernelModuleReadyLabels mocks base method.
+func (m *MocklabelPreparationHelper) getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getNodeKernelModuleReadyLabels", node)
+	ret0, _ := ret[0].(sets.Set[types.NamespacedName])
+	return ret0
+}
+
+// getNodeKernelModuleReadyLabels indicates an expected call of getNodeKernelModuleReadyLabels.
+func (mr *MocklabelPreparationHelperMockRecorder) getNodeKernelModuleReadyLabels(node any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNodeKernelModuleReadyLabels", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getNodeKernelModuleReadyLabels), node)
+}
+
+// getSpecLabelsAndTheirConfigs mocks base method.
+func (m *MocklabelPreparationHelper) getSpecLabelsAndTheirConfigs(nmc *v1beta1.NodeModulesConfig) map[types.NamespacedName]v1beta1.ModuleConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getSpecLabelsAndTheirConfigs", nmc)
+	ret0, _ := ret[0].(map[types.NamespacedName]v1beta1.ModuleConfig)
+	return ret0
+}
+
+// getSpecLabelsAndTheirConfigs indicates an expected call of getSpecLabelsAndTheirConfigs.
+func (mr *MocklabelPreparationHelperMockRecorder) getSpecLabelsAndTheirConfigs(nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getSpecLabelsAndTheirConfigs", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getSpecLabelsAndTheirConfigs), nmc)
+}
+
+// getStatusLabelsAndTheirConfigs mocks base method.
+func (m *MocklabelPreparationHelper) getStatusLabelsAndTheirConfigs(nmc *v1beta1.NodeModulesConfig) map[types.NamespacedName]v1beta1.ModuleConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getStatusLabelsAndTheirConfigs", nmc)
+	ret0, _ := ret[0].(map[types.NamespacedName]v1beta1.ModuleConfig)
+	return ret0
+}
+
+// getStatusLabelsAndTheirConfigs indicates an expected call of getStatusLabelsAndTheirConfigs.
+func (mr *MocklabelPreparationHelperMockRecorder) getStatusLabelsAndTheirConfigs(nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatusLabelsAndTheirConfigs", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getStatusLabelsAndTheirConfigs), nmc)
+}
+
+// removeOrphanedLabels mocks base method.
+func (m *MocklabelPreparationHelper) removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName], specLabels, statusLabels map[types.NamespacedName]v1beta1.ModuleConfig) []types.NamespacedName {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "removeOrphanedLabels", nodeModuleReadyLabels, specLabels, statusLabels)
+	ret0, _ := ret[0].([]types.NamespacedName)
+	return ret0
+}
+
+// removeOrphanedLabels indicates an expected call of removeOrphanedLabels.
+func (mr *MocklabelPreparationHelperMockRecorder) removeOrphanedLabels(nodeModuleReadyLabels, specLabels, statusLabels any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeOrphanedLabels", reflect.TypeOf((*MocklabelPreparationHelper)(nil).removeOrphanedLabels), nodeModuleReadyLabels, specLabels, statusLabels)
 }
 
 // MockpodManager is a mock of podManager interface.

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -153,9 +153,15 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	if err := r.helper.GarbageCollectInUseLabels(ctx, &nmcObj); err != nil {
 		errs = append(errs, fmt.Errorf("failed to GC in-use labels for NMC %s: %v", req.NamespacedName, err))
 	}
+	node := v1.Node{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: nmcObj.Name}, &node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not get node %s: %v", nmcObj.Name, err)
+	}
 
-	if err := r.helper.UpdateNodeLabelsAndRecordEvents(ctx, &nmcObj); err != nil {
+	if loaded, unloaded, err := r.helper.UpdateNodeLabels(ctx, &nmcObj, &node); err != nil {
 		errs = append(errs, fmt.Errorf("could not update node's labels for NMC %s: %v", req.NamespacedName, err))
+	} else {
+		r.helper.RecordEvents(&node, loaded, unloaded)
 	}
 
 	return ctrl.Result{}, errors.Join(errs...)
@@ -213,7 +219,8 @@ type nmcReconcilerHelper interface {
 	ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, status *kmmv1beta1.NodeModuleStatus) error
 	RemovePodFinalizers(ctx context.Context, nodeName string) error
 	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
-	UpdateNodeLabelsAndRecordEvents(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
+	UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, node *v1.Node) ([]types.NamespacedName, []types.NamespacedName, error)
+	RecordEvents(node *v1.Node, loadedModules, unloadedModules []types.NamespacedName)
 }
 
 type nmcReconcilerHelperImpl struct {
@@ -221,6 +228,7 @@ type nmcReconcilerHelperImpl struct {
 	pm       podManager
 	recorder record.EventRecorder
 	nodeAPI  node.Node
+	lph      labelPreparationHelper
 }
 
 func newNMCReconcilerHelper(client client.Client, pm podManager, recorder record.EventRecorder, nodeAPI node.Node) nmcReconcilerHelper {
@@ -229,6 +237,7 @@ func newNMCReconcilerHelper(client client.Client, pm podManager, recorder record
 		pm:       pm,
 		recorder: recorder,
 		nodeAPI:  nodeAPI,
+		lph:      newLabelPreparationHelper(),
 	}
 }
 
@@ -555,95 +564,102 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 	return errors.Join(errs...)
 }
 
-func (h *nmcReconcilerHelperImpl) UpdateNodeLabelsAndRecordEvents(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error {
-	node := v1.Node{}
-	if err := h.client.Get(ctx, types.NamespacedName{Name: nmc.Name}, &node); err != nil {
-		return fmt.Errorf("could not get node %s: %v", nmc.Name, err)
-	}
+type labelPreparationHelper interface {
+	getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string]
+	getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName]
+	getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
+	getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
+	addEqualLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
+	removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
+}
+type labelPreparationHelperImpl struct{}
 
-	// get all the kernel module ready labels of the node
+func newLabelPreparationHelper() labelPreparationHelper {
+	return &labelPreparationHelperImpl{}
+}
+
+func (lph *labelPreparationHelperImpl) getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName] {
 	nodeModuleReadyLabels := sets.New[types.NamespacedName]()
-	deprecatedNodeModuleReadyLabels := sets.New[string]()
 
 	for label := range node.GetLabels() {
 		if ok, namespace, name := utils.IsKernelModuleReadyNodeLabel(label); ok {
 			nodeModuleReadyLabels.Insert(types.NamespacedName{Namespace: namespace, Name: name})
 		}
+	}
+	return nodeModuleReadyLabels
+}
 
+func (lph *labelPreparationHelperImpl) getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string] {
+	deprecatedNodeModuleReadyLabels := sets.New[string]()
+
+	for label := range node.GetLabels() {
 		if utils.IsDeprecatedKernelModuleReadyNodeLabel(label) {
 			deprecatedNodeModuleReadyLabels.Insert(label)
 		}
 	}
+	return deprecatedNodeModuleReadyLabels
+}
 
-	// get spec labels and their config
+func (lph *labelPreparationHelperImpl) getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
 	specLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
+
 	for _, module := range nmc.Spec.Modules {
 		specLabels[types.NamespacedName{Namespace: module.Namespace, Name: module.Name}] = module.Config
 	}
+	return specLabels
+}
 
-	// get status labels and their config
+func (lph *labelPreparationHelperImpl) getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
 	statusLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
+
 	for _, module := range nmc.Status.Modules {
 		label := types.NamespacedName{Namespace: module.Namespace, Name: module.Name}
 		statusLabels[label] = module.Config
 	}
+	return statusLabels
+}
 
-	unloaded := make([]types.NamespacedName, 0, len(nodeModuleReadyLabels))
-	loaded := make([]types.NamespacedName, 0, len(specLabels))
+func (h *nmcReconcilerHelperImpl) UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, node *v1.Node) ([]types.NamespacedName, []types.NamespacedName, error) {
 
-	patchFrom := client.MergeFrom(node.DeepCopy())
+	// get all the kernel module ready labels of the node
+	nodeModuleReadyLabels := h.lph.getNodeKernelModuleReadyLabels(*node)
+	deprecatedNodeModuleReadyLabels := h.lph.getDeprecatedKernelModuleReadyLabels(*node)
+
+	// get spec labels and their config
+	specLabels := h.lph.getSpecLabelsAndTheirConfigs(nmc)
+
+	// get status labels and their config
+	statusLabels := h.lph.getStatusLabelsAndTheirConfigs(nmc)
 
 	// label in node but not in spec or status - should be removed
-	for nsn := range nodeModuleReadyLabels {
-		_, inSpec := specLabels[nsn]
-		_, inStatus := statusLabels[nsn]
-		if !inSpec && !inStatus {
-			meta.RemoveLabel(
-				&node,
-				utils.GetKernelModuleReadyNodeLabel(nsn.Namespace, nsn.Name),
-			)
-
-			unloaded = append(unloaded, nsn)
-		}
-	}
-
-	// v1 ready labels, deprecated - should be removed
-	for label := range deprecatedNodeModuleReadyLabels {
-		meta.RemoveLabel(&node, label)
-	}
+	nsnLabelsToBeRemoved := h.lph.removeOrphanedLabels(nodeModuleReadyLabels, specLabels, statusLabels)
 
 	// label in spec and status and config equal - should be added
-	for nsn, specConfig := range specLabels {
-		statusConfig, ok := statusLabels[nsn]
-		if ok && reflect.DeepEqual(specConfig, statusConfig) && !nodeModuleReadyLabels.Has(nsn) {
-			meta.SetLabel(
-				&node,
-				utils.GetKernelModuleReadyNodeLabel(nsn.Namespace, nsn.Name),
-				"",
-			)
+	nsnLabelsToBeLoaded := h.lph.addEqualLabels(nodeModuleReadyLabels, specLabels, statusLabels)
 
-			loaded = append(loaded, nsn)
-		}
+	var loadedLabels []string
+	unloadedLabels := deprecatedNodeModuleReadyLabels.UnsortedList()
+
+	for _, label := range nsnLabelsToBeRemoved {
+		unloadedLabels = append(unloadedLabels, utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name))
+	}
+	for _, label := range nsnLabelsToBeLoaded {
+		loadedLabels = append(loadedLabels, utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name))
 	}
 
-	if err := h.client.Patch(ctx, &node, patchFrom); err != nil {
-		return fmt.Errorf("could not patch node: %v", err)
+	if err := h.nodeAPI.UpdateLabels(ctx, node, loadedLabels, unloadedLabels); err != nil {
+		return nil, nil, fmt.Errorf("could not update labels on the node: %v", err)
 	}
 
-	for _, nsn := range unloaded {
+	return nsnLabelsToBeLoaded, nsnLabelsToBeRemoved, nil
+}
+
+func (h *nmcReconcilerHelperImpl) RecordEvents(node *v1.Node, loadedModules, unloadedModules []types.NamespacedName) {
+	for _, nsn := range loadedModules {
 		h.recorder.AnnotatedEventf(
-			&node,
-			map[string]string{"module": nsn.String()},
-			v1.EventTypeNormal,
-			"ModuleUnloaded",
-			"Module %s unloaded from the kernel",
-			nsn.String(),
-		)
-	}
-
-	for _, nsn := range loaded {
-		h.recorder.AnnotatedEventf(
-			&node,
+			node,
 			map[string]string{"module": nsn.String()},
 			v1.EventTypeNormal,
 			"ModuleLoaded",
@@ -651,8 +667,44 @@ func (h *nmcReconcilerHelperImpl) UpdateNodeLabelsAndRecordEvents(ctx context.Co
 			nsn.String(),
 		)
 	}
+	for _, nsn := range unloadedModules {
+		h.recorder.AnnotatedEventf(
+			node,
+			map[string]string{"module": nsn.String()},
+			v1.EventTypeNormal,
+			"ModuleUnloaded",
+			"Module %s unloaded from the kernel",
+			nsn.String(),
+		)
+	}
+}
 
-	return nil
+func (lph *labelPreparationHelperImpl) removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+	specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName {
+
+	unloaded := make([]types.NamespacedName, 0, len(nodeModuleReadyLabels))
+
+	for nsn := range nodeModuleReadyLabels {
+		_, inSpec := specLabels[nsn]
+		_, inStatus := statusLabels[nsn]
+		if !inSpec && !inStatus {
+			unloaded = append(unloaded, nsn)
+		}
+	}
+	return unloaded
+}
+func (lph *labelPreparationHelperImpl) addEqualLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+	specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName {
+
+	loaded := make([]types.NamespacedName, 0, len(nodeModuleReadyLabels))
+
+	for nsn, specConfig := range specLabels {
+		statusConfig, ok := statusLabels[nsn]
+		if ok && reflect.DeepEqual(specConfig, statusConfig) && !nodeModuleReadyLabels.Has(nsn) {
+			loaded = append(loaded, nsn)
+		}
+	}
+	return loaded
 }
 
 const (

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -96,3 +96,17 @@ func (mr *MockNodeMockRecorder) IsNodeSchedulable(node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeSchedulable", reflect.TypeOf((*MockNode)(nil).IsNodeSchedulable), node)
 }
+
+// UpdateLabels mocks base method.
+func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLabels", ctx, node, toBeAdded, toBeRemoved)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLabels indicates an expected call of UpdateLabels.
+func (mr *MockNodeMockRecorder) UpdateLabels(ctx, node, toBeAdded, toBeRemoved any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabels", reflect.TypeOf((*MockNode)(nil).UpdateLabels), ctx, node, toBeAdded, toBeRemoved)
+}


### PR DESCRIPTION
## Summary
Today, the UpdateNodeLabelsAndRecordEvents function has around 100 lines of code. This commit aims to enhance its readability and maintainability by using helper functions, thereby reducing its total length. Additionally, adding unit tests that covers the new helper functions.