### PR TITLE
Refusing `Modules` with container images without a sha or a tag.

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -113,10 +113,6 @@ func (r *registry) getPullOptions(ctx context.Context, image string, tlsOptions 
 		repo = tag[0]
 	}
 
-	if repo == "" {
-		return nil, fmt.Errorf("image url %s is not valid, does not contain hash or tag", image)
-	}
-
 	options := []crane.Option{
 		crane.WithContext(ctx),
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -57,14 +57,6 @@ var _ = Describe("ImageExists", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
 		})
 
-		It("should fail if the image name isn't valid", func() {
-
-			_, err = reg.ImageExists(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
-		})
-
 		It("should fail if it cannot get key chain from secret", func() {
 
 			mockRegistryAuthGetter.EXPECT().GetKeyChain(ctx).Return(nil, errors.New("some error"))
@@ -220,14 +212,6 @@ var _ = Describe("GetLayersDigests", func() {
 
 		AfterEach(func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
-		})
-
-		It("should fail if the image name isn't valid", func() {
-
-			_, err = reg.ImageExists(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
 		})
 
 		It("should fail if it cannot get key chain from secret", func() {
@@ -391,13 +375,6 @@ var _ = Describe("GetDigest", func() {
 
 		AfterEach(func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
-		})
-
-		It("should fail if the image name isn't valid", func() {
-			_, err = reg.GetDigest(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
 		})
 
 		It("should fail if it cannot get key chain from secret", func() {


### PR DESCRIPTION
In the current code, we handle differently build/sign and deploying a pre-built kmod.

This is the current behavior:
* If a `build`/`sign` section is set in the module, and the image tag isn't specified, then we will return an error.
* If there are no `build`/`sign` section, and the image tag isn't specified, then we will default to the `latest` tag.

This change is adjusting the behavior of both workflow to enforce the customer to explicitely set a sha or a tag in his container image.

---

/cc @yevgeny-shnaidman @TomerNewman 
This PR is replacing https://github.com/kubernetes-sigs/kernel-module-management/pull/826 due to its difficulties.