### PR TITLE
Update Reconcile Test to Validate Specific Errors

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -145,7 +145,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		if err := r.helper.ProcessUnconfiguredModuleStatus(ctrl.LoggerInto(ctx, logger), &nmcObj, status); err != nil {
 			errs = append(
 				errs,
-				fmt.Errorf("erorr processing orphan status for Module %s: %v", statusNameKey, err),
+				fmt.Errorf("error processing orphan status for Module %s: %v", statusNameKey, err),
 			)
 		}
 	}


### PR DESCRIPTION
Until now, the test for `Reconcile` function in _nmc_reconciler.go_ only checked that the errors were not nil. Now, the test will ensure that the returned errors match the expected errors exactly.