### PR TITLE
Changing the `ImagePullPolicy` for the operator and the webhook.

### DIFF
--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -51,7 +51,6 @@ spec:
             value: gcr.io/kaniko-project/executor:latest
           - name: RELATED_IMAGE_SIGN
             value: signer
-        imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -36,7 +36,6 @@ spec:
       containers:
         - image: webhook-server:latest
           name: webhook-server
-          imagePullPolicy: Always
           args: [--config=controller_config.yaml]
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
For the KMM operator, the `ImagePullPolicy` was set to `Always` for development reasons but it is in fact not the best practice, therefore, it was removed to allowed `kubelet` to have its default pull policy.

The webhook-server's pull policy was also removed to use the default behavior to stay in sync with the KMM operator it is deployed with.

In a nutshell, the default policy is `Always` if the `latest` tag is used and `IfNotPresent` otherwise.

This change is expected to reduce the networking bandwidth.

---

/cc @yevgeny-shnaidman @TomerNewman 