### PR TITLE
Changing the FirmwarePath config flag

### DIFF
--- a/config/manager/controller_config.yaml
+++ b/config/manager/controller_config.yaml
@@ -10,5 +10,4 @@ metrics:
 worker:
   runAsUser: 0
   seLinuxType: spc_t
-  #FIXME: rename
-  setFirmwareClassPath: /lib/firmware
+  firmwareHostPath: /lib/firmware

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,9 @@ type Job struct {
 }
 
 type Worker struct {
-	RunAsUser            *int64  `yaml:"runAsUser"`
-	SELinuxType          string  `yaml:"seLinuxType"`
-	SetFirmwareClassPath *string `yaml:"setFirmwareClassPath,omitempty"`
+	RunAsUser        *int64  `yaml:"runAsUser"`
+	SELinuxType      string  `yaml:"seLinuxType"`
+	FirmwareHostPath *string `yaml:"firmwareHostPath,omitempty"`
 }
 
 type LeaderElection struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,9 +31,9 @@ var _ = Describe("ParseFile", func() {
 			},
 			WebhookPort: 9443,
 			Worker: Worker{
-				RunAsUser:            ptr.To[int64](1234),
-				SELinuxType:          "mySELinuxType",
-				SetFirmwareClassPath: ptr.To("/some/path"),
+				RunAsUser:        ptr.To[int64](1234),
+				SELinuxType:      "mySELinuxType",
+				FirmwareHostPath: ptr.To("/some/path"),
 			},
 		}
 

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -12,5 +12,5 @@ metrics:
 worker:
   runAsUser: 1234
   seLinuxType: mySELinuxType
-  setFirmwareClassPath: /some/path
+  firmwareHostPath: /some/path
 


### PR DESCRIPTION
1) changing the setFirmwareClassPath flag to firmwareHostPath flag. This
   flag is used to:
   a) define the firmware path on the host
   b) define the mount point on the worker pod
   c) define the new firmware search path in the Linux kernel
2) updating NMC controller code to use the new flag for setting firmware
   volume for worker pods and passing parameters to worker pod
   entrypoint
3) updating unit-test