### PR TITLE
Simplifying firmware flags between NMC controller and worker pod

### DIFF
--- a/cmd/worker/funcs_kmod.go
+++ b/cmd/worker/funcs_kmod.go
@@ -36,15 +36,14 @@ func kmodLoadFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not read config file %s: %v", cfgPath, err)
 	}
 
-	if flag := cmd.Flags().Lookup(worker.FlagFirmwareClassPath); flag.Changed {
-		logger.V(1).Info(worker.FlagFirmwareClassPath + " set, setting firmware_class.path")
+	mountPathFlag := cmd.Flags().Lookup(worker.FlagFirmwarePath)
+	if mountPathFlag.Changed {
+		logger.V(1).Info(worker.FlagFirmwarePath + " set, setting firmware_class.path")
 
-		if err := w.SetFirmwareClassPath(flag.Value.String()); err != nil {
+		if err := w.SetFirmwareClassPath(mountPathFlag.Value.String()); err != nil {
 			return fmt.Errorf("could not set the firmware_class.path parameter: %v", err)
 		}
 	}
-
-	mountPathFlag := cmd.Flags().Lookup(worker.FlagFirmwareMountPath)
 
 	return w.LoadKmod(cmd.Context(), cfg, mountPathFlag.Value.String())
 }
@@ -59,25 +58,17 @@ func kmodUnloadFunc(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("could not read config file %s: %v", cfgPath, err)
 	}
 
-	mountPathFlag := cmd.Flags().Lookup(worker.FlagFirmwareMountPath)
-
-	return w.UnloadKmod(cmd.Context(), cfg, mountPathFlag.Value.String())
+	return w.UnloadKmod(cmd.Context(), cfg, cmd.Flags().Lookup(worker.FlagFirmwarePath).Value.String())
 }
 
 func setCommandsFlags() {
 	kmodLoadCmd.Flags().String(
-		worker.FlagFirmwareClassPath,
+		worker.FlagFirmwarePath,
 		"",
-		"if set, this value will be written to "+worker.FirmwareClassPathLocation,
-	)
-
-	kmodLoadCmd.Flags().String(
-		worker.FlagFirmwareMountPath,
-		"",
-		"if set, this the value that firmware host path is mounted to")
+		"if set, this value will be written to "+worker.FirmwareClassPathLocation+" and it is also the value that firmware host path is mounted to")
 
 	kmodUnloadCmd.Flags().String(
-		worker.FlagFirmwareMountPath,
+		worker.FlagFirmwarePath,
 		"",
 		"if set, this the value that firmware host path is mounted to")
 }

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -845,12 +845,11 @@ func (p *podManagerImpl) LoaderPodTemplate(ctx context.Context, nmc client.Objec
 			return nil, fmt.Errorf("firmwareHostPath wasn't set, while the Module requires firmware loading")
 		}
 
-		args = append(args, "--"+worker.FlagFirmwareMountPath, *firmwareHostPath)
+		args = append(args, "--"+worker.FlagFirmwarePath, *firmwareHostPath)
 		if err = setFirmwareVolume(pod, firmwareHostPath); err != nil {
 			return nil, fmt.Errorf("could not map host volume needed for firmware loading: %v", err)
 		}
 
-		args = append(args, "--"+worker.FlagFirmwareClassPath, *firmwareHostPath)
 		privileged = true
 	}
 
@@ -898,7 +897,7 @@ func (p *podManagerImpl) UnloaderPodTemplate(ctx context.Context, nmc client.Obj
 		if firmwareHostPath == nil {
 			return nil, fmt.Errorf("firmwareHostPath was not set while the Module requires firmware unloading")
 		}
-		args = append(args, "--"+worker.FlagFirmwareMountPath, *firmwareHostPath)
+		args = append(args, "--"+worker.FlagFirmwarePath, *firmwareHostPath)
 		if err = setFirmwareVolume(pod, firmwareHostPath); err != nil {
 			return nil, fmt.Errorf("could not map host volume needed for firmware unloading: %v", err)
 		}

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1927,10 +1927,7 @@ softdep b pre: c
 
 	args := []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"}
 	if withFirmware {
-		args = append(args, "--set-firmware-mount-path", *firmwareHostPath)
-		if isLoaderPod && firmwareHostPath != nil {
-			args = append(args, "--set-firmware-class-path", *firmwareHostPath)
-		}
+		args = append(args, "--firmware-path", *firmwareHostPath)
 	} else {
 		configAnnotationValue = strings.ReplaceAll(configAnnotationValue, "firmwarePath: /firmware-path\n  ", "")
 	}

--- a/internal/worker/constants.go
+++ b/internal/worker/constants.go
@@ -1,8 +1,7 @@
 package worker
 
 const (
-	FlagFirmwareClassPath = "set-firmware-class-path"
-	FlagFirmwareMountPath = "set-firmware-mount-path"
+	FlagFirmwarePath = "firmware-path"
 
 	FirmwareClassPathLocation = "/sys/module/firmware_class/parameters/path"
 	ImagesDir                 = "/var/run/kmm/images"


### PR DESCRIPTION
Currently NMC controller passes 2 flag to worker pod: firmware path mount point in pod and firmware search path. Since in our implementation those 2 values are always equal, we can use only one flag to pass these values: --firmware-path, and let worker pod decide when to update the kernel configuration for firmware search