### PR TITLE
Adding an init container to the worker pod.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -153,6 +153,8 @@ jobs:
 
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
+        with:
+          start-args: --insecure-registry=host.minikube.internal:5000
 
       - name: Download container images
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This init container will be pulled by the container-runtime of the cluster and will copy all `.ko` and firmware files to a shared volume accessible by the worker container to load.

---

/assign @yevgeny-shnaidman 
/hold
Didn't test it e2e yet.