### PR TITLE
Fixing some `kustomizeconfig.yaml` files.

### DIFF
--- a/config/default-hub/kustomizeconfig.yaml
+++ b/config/default-hub/kustomizeconfig.yaml
@@ -1,4 +1,3 @@
 namePrefix:
 - kind: Deployment
-  name: controller
   path: spec/template/spec/volumes/secret/secretName

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,4 +1,3 @@
 namePrefix:
 - kind: Deployment
-  name: controller
   path: spec/template/spec/volumes/secret/secretName

--- a/config/webhook-cert/kustomizeconfig.yaml
+++ b/config/webhook-cert/kustomizeconfig.yaml
@@ -18,5 +18,4 @@ varReference:
 namePrefix:
 - kind: Certificate
   group: cert-manager.io
-  name: serving-cert
   path: spec/secretName

--- a/hack/download-kustomize
+++ b/hack/download-kustomize
@@ -5,7 +5,7 @@ set -euxo pipefail
 : "$BINDIR"
 
 readonly TMP=$(mktemp -d)
-readonly VERSION=5.3.0
+readonly VERSION=5.4.3
 
 echo "Downloading kustomize in $TMP"
 


### PR DESCRIPTION
Since `kustomize@v5.4.0`, `yaml.UnmarshalStric()` is used instead of `yaml.Unmarshal()` which means that fields in the yamls that doesn't exist in the golang object will fail to unmarshal instead of being ignored like they would without the `strict` behavior.

Therefore, those redundant `name` fields where removed.

In addition, I have bumped `kustomize@5.3.0` --> `kustomize@5.4.3` to make sure we get a closer behavior on machines that comes with `kustomize` pre-installed and those which aren't and install it on-the-fly.

--

/assign @yevgeny-shnaidman 
This PR is blocking a bunch of other PRs like:
* https://github.com/kubernetes-sigs/kernel-module-management/pull/886
* https://github.com/kubernetes-sigs/kernel-module-management/pull/882
* https://github.com/kubernetes-sigs/kernel-module-management/pull/888