### PR TITLE
[WIP] Adding firmware to the `e2e` CI job.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the image
-        run: make docker-build IMG=kmm:local
+        run: make docker-build IMG=localhost/k8s-sigs/kmm:local
 
       - name: Export the image
-        run: docker save -o kmm_local.tar kmm:local
+        run: docker save -o kmm_local.tar localhost/k8s-sigs/kmm:local
 
       - name: Upload the image
         uses: actions/upload-artifact@v4
@@ -40,10 +40,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the image
-        run: make docker-build-hub HUB_IMG=kmm-hub:local
+        run: make docker-build-hub HUB_IMG=localhost/k8s-sigs/kmm-hub:local
 
       - name: Export the image
-        run: docker save -o kmm-hub_local.tar kmm-hub:local
+        run: docker save -o kmm-hub_local.tar localhost/k8s-sigs/kmm-hub:local
 
       - name: Upload the image
         uses: actions/upload-artifact@v4
@@ -63,10 +63,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the image
-        run:  make signimage-build SIGNER_IMG=kmm-signimage:local
+        run:  make signimage-build SIGNER_IMG=localhost/k8s-sigs/kmm-signimage:local
 
       - name: Export the image
-        run: docker save -o kmm-signimage_local.tar kmm-signimage:local
+        run: docker save -o kmm-signimage_local.tar localhost/k8s-sigs/kmm-signimage:local
 
       - name: Upload the image
         uses: actions/upload-artifact@v4
@@ -86,10 +86,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the image
-        run:  make workerimage-build WORKER_IMG=kmm-worker:local
+        run:  make workerimage-build WORKER_IMG=localhost/k8s-sigs/kmm-worker:local
 
       - name: Export the image
-        run: docker save -o kmm-worker_local.tar kmm-worker:local
+        run: docker save -o kmm-worker_local.tar localhost/k8s-sigs/kmm-worker:local
 
       - name: Upload the image
         uses: actions/upload-artifact@v4
@@ -109,10 +109,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build the image
-        run: make webhookimage-build WEBHOOK_IMG=kmm-webhook-server:local
+        run: make webhookimage-build WEBHOOK_IMG=localhost/k8s-sigs/kmm-webhook-server:local
 
       - name: Export the image
-        run: docker save -o kmm-webhook-server_local.tar kmm-webhook-server:local
+        run: docker save -o kmm-webhook-server_local.tar localhost/k8s-sigs/kmm-webhook-server:local
 
       - name: Upload the image
         uses: actions/upload-artifact@v4
@@ -151,10 +151,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Extract firmware host path
+        id: firmware
+        run: |
+          echo "firmware_host_path=$(grep firmwareHostPath config/manager/controller_config.yaml | cut -d" " -f4-)" \
+          >> $GITHUB_OUTPUT
+
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
         with:
-          start-args: --insecure-registry=host.minikube.internal:5000
+          start-args: |
+            --insecure-registry=host.minikube.internal:5000 \
+            --container-runtime=crio \
+            --mount --mount-string="${{ steps.firmware.outputs.firmware_host_path }}:${{ steps.firmware.outputs.firmware_host_path }}"
 
       - name: Download container images
         uses: actions/download-artifact@v4
@@ -163,20 +172,30 @@ jobs:
 
       - name: Import the KMM operator, webhook server and worker images into minikube
         run: |
-          minikube image load artifacts/ci-image-kmm/kmm_local.tar
-          minikube image load artifacts/ci-image-webhook-server/kmm-webhook-server_local.tar
-          minikube image load artifacts/ci-image-worker/kmm-worker_local.tar
+
+          # minikube image load from a tar file is changing the image name and breaking the flow
+          docker image load  -i artifacts/ci-image-kmm/kmm_local.tar
+          docker image load  -i artifacts/ci-image-webhook-server/kmm-webhook-server_local.tar
+          docker image load  -i artifacts/ci-image-worker/kmm-worker_local.tar
+
+          minikube image load localhost/k8s-sigs/kmm:local
+          minikube image load localhost/k8s-sigs/kmm-webhook-server:local
+          minikube image load localhost/k8s-sigs/kmm-worker:local
 
       - name: Import the KMM-hub operator image into minikube
-        run: minikube image load artifacts/ci-image-kmm-hub/kmm-hub_local.tar
+        run: |
+
+          # minikube image load from a tar file is changing the image name and breaking the flow
+          docker image load  -i artifacts/ci-image-kmm-hub/kmm-hub_local.tar
+          minikube image load localhost/k8s-sigs/kmm-hub:local
         if: ${{ matrix.import_hub_image }}
 
       # This image is pulled by the signing pod, so it needs to be stored externally - not in the minikube container runtime.
       - name: Copy the signing image into the registry
         run: |
           docker load -i artifacts/ci-image-signer/kmm-signimage_local.tar
-          docker tag kmm-signimage:local localhost:5000/kmm/signimage:local
-          docker push localhost:5000/kmm/signimage:local
+          docker tag localhost/k8s-sigs/kmm-signimage:local localhost:5000/k8s-sigs/signimage:local
+          docker push localhost:5000/k8s-sigs/signimage:local
 
       - name: Set some Ubuntu environment variables
         run: |
@@ -238,15 +257,15 @@ jobs:
           docker load -i artifacts/ci-image-webhook-server/kmm-webhook-server_local.tar
           docker load -i artifacts/ci-image-worker/kmm-worker_local.tar
 
-          docker tag kmm:local localhost:5000/kmm/kmm:local
-          docker tag kmm-signimage:local localhost:5000/kmm/signimage:local
-          docker tag kmm-webhook-server:local localhost:5000/kmm/webhook-server:local
-          docker tag kmm-worker:local localhost:5000/kmm/worker:local
+          docker tag localhost/k8s-sigs/kmm:local localhost:5000/k8s-sigs/kmm:local
+          docker tag localhost/k8s-sigs/kmm-signimage:local localhost:5000/k8s-sigs/signimage:local
+          docker tag localhost/k8s-sigs/kmm-webhook-server:local localhost:5000/k8s-sigs/webhook-server:local
+          docker tag localhost/k8s-sigs/kmm-worker:local localhost:5000/k8s-sigs/worker:local
 
-          docker push localhost:5000/kmm/kmm:local
-          docker push localhost:5000/kmm/signimage:local
-          docker push localhost:5000/kmm/webhook-server:local
-          docker push localhost:5000/kmm/worker:local
+          docker push localhost:5000/k8s-sigs/kmm:local
+          docker push localhost:5000/k8s-sigs/signimage:local
+          docker push localhost:5000/k8s-sigs/webhook-server:local
+          docker push localhost:5000/k8s-sigs/worker:local
 
       - name: Set some Ubuntu environment variables
         run: |

--- a/ci/install-ci-hub/kustomization.yaml
+++ b/ci/install-ci-hub/kustomization.yaml
@@ -6,13 +6,13 @@ resources:
 
 images:
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-operator-hub
-  newName: kmm-hub
+  newName: localhost/k8s-sigs/kmm-hub
   newTag: local
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-signimage
-  newName: host.minikube.internal:5000/kmm/signimage
+  newName: host.minikube.internal:5000/k8s-sigs/signimage
   newTag: local
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-webhook-server
-  newName: kmm-webhook-server
+  newName: localhost/k8s-sigs/kmm-webhook-server
   newTag: local
 
 patches:

--- a/ci/install-ci/kustomization.yaml
+++ b/ci/install-ci/kustomization.yaml
@@ -6,16 +6,16 @@ resources:
 
 images:
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-operator
-  newName: kmm
+  newName: localhost/k8s-sigs/kmm
   newTag: local
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-signimage
-  newName: host.minikube.internal:5000/kmm/signimage
+  newName: host.minikube.internal:5000/k8s-sigs/signimage
   newTag: local
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-webhook-server
-  newName: kmm-webhook-server
+  newName: localhost/k8s-sigs/kmm-webhook-server
   newTag: local
 - name: gcr.io/k8s-staging-kmm/kernel-module-management-worker
-  newName: kmm-worker
+  newName: localhost/k8s-sigs/kmm-worker
   newTag: local
 
 patches:

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -34,4 +34,8 @@ data:
 
     COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
     COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+
+    RUN mkdir /firmware && \
+      echo -n "kmm_kmod_firmware validation string" > /firmware/kmm_kmod_firmware.bin
+
     RUN depmod -b /opt

--- a/ci/kmm-kmod/kmm_ci_a.c
+++ b/ci/kmm-kmod/kmm_ci_a.c
@@ -3,13 +3,56 @@
 #include <linux/kernel.h>
 
 MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Quentin Barrand");
+MODULE_AUTHOR("Yevgeny Shnaidman");
 MODULE_DESCRIPTION("A simple kernel module for KMM CI");
 MODULE_VERSION("0.01");
 
 static int __init kmm_ci_init(void) {
+    struct platform_device *pdev;
+    const char fw_data[] = "kmm_ci validation string";
+    const char fw_name[] = "kmm_ci_firmware.bin";
+    const struct firmware *fw;
+    int err;
+
     printk(KERN_INFO "Hello, World!\n");
-    return 0;
+
+    pdev = platform_device_register_kmm_ci("kmm_ci_firmware_1", 0, NULL, 0);
+    if (IS_ERR(pdev)) {
+	    printk(KERN_ERR "Failed to register device for \"%s\"\n", fw_name);
+	    err = -1;
+	    goto out;
+    }
+
+    err = request_firmware(&fw, fw_name, &pdev->dev);
+    if (err) {
+	    printk(KERN_ERR "Failed to load image \"%s\" err %d\n", fw_name, err);
+	    goto unregister_platform;
+    }
+
+    if (fw->size != strlen(fw_data)) {
+	    printk(KERN_ERR "The firmware data size is different from what we expect: %ld != %ld\n", strlen(fw_data), fw->size);
+	    err = -1;
+	    goto release_firmware;
+    }
+
+    if (strncmp(fw_data, fw->data, fw->size)) {
+	    printk(KERN_ERR "The firmware data <%s> != the expected data <%s>\n", fw->data, fw_data);
+	    err = -1;
+	    goto release_firmware;
+    }
+
+    printk(KERN_INFO "ALL GOOD WITH FIRMWARE kmm_ci\n");
+
+release_firmware:
+    release_firmware(fw);
+unregister_platform:
+    platform_device_unregister(pdev);
+
+    /*
+     * A non 0 return means init_module failed; module can't be loaded.
+     */
+out:
+    return err;
 }
 
 static void __exit kmm_ci_exit(void) {

--- a/ci/module-kmm-ci-build-sign.yaml
+++ b/ci/module-kmm-ci-build-sign.yaml
@@ -11,6 +11,7 @@ spec:
       modprobe:
         moduleName: kmm_ci_a
         modulesLoadingOrder: [kmm_ci_a, kmm_ci_b]
+        firmwarePath: /firmware
       kernelMappings:
         - regexp: '^.+$'
           containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION


### PR DESCRIPTION
In order to do so, a few steps were required:

* Add firmware to the driver .c file.
* Add a firmware binary to the container image.
* Add a `modprobe.firmwarePath` section in the `Module`
* Run `minikube` with `--container-runtime=crio` because crio gives the pod permissions write to `/sys/module/firmware_class/parameters/path`.
* Mounting the firmware lookup path from the host to minikube because the code looking for the firmware file is in the driver which runs from the kernel which is not part of the `minikube` container.

--

/assign @yevgeny-shnaidman 