### PR TITLE
Using the Module's `spec.moduleLoader.container.imagePullPolicy`.

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -24,6 +24,8 @@ import (
 type ModuleConfig struct {
 	KernelVersion  string `json:"kernelVersion"`
 	ContainerImage string `json:"containerImage"`
+	// +kubebuilder:default=IfNotPresent
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy"`
 	// When InsecurePull is true, the container image can be pulled without TLS.
 	InsecurePull bool `json:"insecurePull"`
 	//+optional

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -54,6 +54,11 @@ spec:
                       properties:
                         containerImage:
                           type: string
+                        imagePullPolicy:
+                          default: IfNotPresent
+                          description: PullPolicy describes a policy for if/when to
+                            pull a container image
+                          type: string
                         inTreeModuleToRemove:
                           type: string
                         inTreeModulesToRemove:
@@ -151,6 +156,7 @@ spec:
                           type: object
                       required:
                       - containerImage
+                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe
@@ -200,6 +206,11 @@ spec:
                       properties:
                         containerImage:
                           type: string
+                        imagePullPolicy:
+                          default: IfNotPresent
+                          description: PullPolicy describes a policy for if/when to
+                            pull a container image
+                          type: string
                         inTreeModuleToRemove:
                           type: string
                         inTreeModulesToRemove:
@@ -297,6 +308,7 @@ spec:
                           type: object
                       required:
                       - containerImage
+                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -333,6 +333,7 @@ func (mnrh *moduleNMCReconcilerHelper) enableModuleOnNode(ctx context.Context, m
 	moduleConfig := kmmv1beta1.ModuleConfig{
 		KernelVersion:         mld.KernelVersion,
 		ContainerImage:        mld.ContainerImage,
+		ImagePullPolicy:       mld.ImagePullPolicy,
 		InTreeModulesToRemove: mld.InTreeModulesToRemove,
 		Modprobe:              mld.Modprobe,
 	}

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -1052,10 +1052,11 @@ func (p *podManagerImpl) baseWorkerPod(ctx context.Context, nmc client.Object, i
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{
 				{
-					Name:    initContainerName,
-					Image:   moduleConfig.ContainerImage,
-					Command: []string{"/bin/sh", "-c"},
-					Args:    []string{""},
+					Name:            initContainerName,
+					Image:           moduleConfig.ContainerImage,
+					ImagePullPolicy: moduleConfig.ImagePullPolicy,
+					Command:         []string{"/bin/sh", "-c"},
+					Args:            []string{""},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volNameTmp,

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -260,6 +260,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 var moduleConfig = kmmv1beta1.ModuleConfig{
 	KernelVersion:         "kernel-version",
 	ContainerImage:        "container image",
+	ImagePullPolicy:       v1.PullIfNotPresent,
 	InsecurePull:          true,
 	InTreeModulesToRemove: []string{"intree1", "intree2"},
 	Modprobe: kmmv1beta1.ModprobeSpec{
@@ -1904,6 +1905,7 @@ func getBaseWorkerPod(subcommand string, owner ctrlclient.Object, firmwareHostPa
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 
 	configAnnotationValue := `containerImage: container image
+imagePullPolicy: IfNotPresent
 inTreeModulesToRemove:
 - intree1
 - intree2
@@ -1961,10 +1963,11 @@ cp -R /firmware-path/* /tmp/firmware-path;
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{
 				{
-					Name:    "image-extractor",
-					Image:   "container image",
-					Command: []string{"/bin/sh", "-c"},
-					Args:    []string{initContainerArg},
+					Name:            "image-extractor",
+					Image:           "container image",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Command:         []string{"/bin/sh", "-c"},
+					Args:            []string{initContainerArg},
 					Resources: v1.ResourceRequirements{
 						Limits:   limits,
 						Requests: requests,


### PR DESCRIPTION
When we moved to the worker-pod implementation in v2 we started to pull kmod images via HTTP from teh worker-pod directly and we ignored this field.

Now that we moved to pulling using the cluster's container-runtime, the `imagePullPolicy` can be passed to the init-container definition.

---

/assign @yevgeny-shnaidman 