### PR TITLE
Fixing race condition during cluster upgrade with kernel upgrade

### DIFF
--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -58,31 +58,31 @@ func (mr *MocknmcReconcilerHelperMockRecorder) GarbageCollectInUseLabels(ctx, nm
 }
 
 // ProcessModuleSpec mocks base method.
-func (m *MocknmcReconcilerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus) error {
+func (m *MocknmcReconcilerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus, node *v1.Node) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessModuleSpec", ctx, nmc, spec, status)
+	ret := m.ctrl.Call(m, "ProcessModuleSpec", ctx, nmc, spec, status, node)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessModuleSpec indicates an expected call of ProcessModuleSpec.
-func (mr *MocknmcReconcilerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status, node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status, node)
 }
 
 // ProcessUnconfiguredModuleStatus mocks base method.
-func (m *MocknmcReconcilerHelper) ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus) error {
+func (m *MocknmcReconcilerHelper) ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus, node *v1.Node) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessUnconfiguredModuleStatus", ctx, nmc, status)
+	ret := m.ctrl.Call(m, "ProcessUnconfiguredModuleStatus", ctx, nmc, status, node)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessUnconfiguredModuleStatus indicates an expected call of ProcessUnconfiguredModuleStatus.
-func (mr *MocknmcReconcilerHelperMockRecorder) ProcessUnconfiguredModuleStatus(ctx, nmc, status any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessUnconfiguredModuleStatus(ctx, nmc, status, node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessUnconfiguredModuleStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessUnconfiguredModuleStatus), ctx, nmc, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessUnconfiguredModuleStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessUnconfiguredModuleStatus), ctx, nmc, status, node)
 }
 
 // RecordEvents mocks base method.

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -105,6 +105,26 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should fail if we could not get the node of the NMC", func() {
+		nmc := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
+		}
+		node := v1.Node{}
+		gomock.InOrder(
+			kubeClient.
+				EXPECT().
+				Get(ctx, nmcNsn, &kmmv1beta1.NodeModulesConfig{}).
+				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
+					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
+				}),
+			wh.EXPECT().SyncStatus(ctx, nmc),
+			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(fmt.Errorf("some error")),
+		)
+
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should process spec entries and orphan statuses", func() {
 		const (
 			mod0Name = "mod0"
@@ -167,11 +187,11 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
 			wh.EXPECT().SyncStatus(ctx, nmc),
-			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0),
-			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec1, nil),
-			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2),
-			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
+			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node),
+			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec1, nil, &node),
+			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2, &node),
+			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc),
 			wh.EXPECT().UpdateNodeLabels(ctx, nmc, &node).Return(loaded, unloaded, err),
 			wh.EXPECT().RecordEvents(&node, loaded, unloaded),
 		)
@@ -245,10 +265,10 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
 			wh.EXPECT().SyncStatus(ctx, nmc).Return(nil),
-			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0).Return(fmt.Errorf(errorMeassge)),
-			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2).Return(fmt.Errorf(errorMeassge)),
-			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc).Return(fmt.Errorf(errorMeassge)),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
+			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node).Return(fmt.Errorf(errorMeassge)),
+			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2, &node).Return(fmt.Errorf(errorMeassge)),
+			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc).Return(fmt.Errorf(errorMeassge)),
 			wh.EXPECT().UpdateNodeLabels(ctx, nmc, &node).Return(nil, nil, fmt.Errorf(errorMeassge)),
 		)
 
@@ -424,7 +444,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, nil),
+			wh.ProcessModuleSpec(ctx, nmc, spec, nil, nil),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -457,7 +477,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -490,46 +510,8 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).NotTo(
-			HaveOccurred(),
-		)
-	})
-
-	It("should return an error if we could not get the node", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
-		}
-
-		cfg := kmmv1beta1.ModuleConfig{ContainerImage: "some-image"}
-
-		spec := &kmmv1beta1.NodeModuleSpec{
-			ModuleItem: kmmv1beta1.ModuleItem{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Config: cfg,
-		}
-
-		status := &kmmv1beta1.NodeModuleStatus{
-			ModuleItem: kmmv1beta1.ModuleItem{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Config: cfg,
-		}
-
-		gomock.InOrder(
-			pm.EXPECT().GetWorkerPod(ctx, podName, namespace),
-			client.
-				EXPECT().
-				Get(ctx, types.NamespacedName{Name: nmcName}, &v1.Node{}).
-				Return(errors.New("random error")),
-		)
-
-		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
-		).To(
 			HaveOccurred(),
 		)
 	})
@@ -545,6 +527,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 			Namespace: namespace,
 		},
 	}
+	node := &v1.Node{}
 
 	now := metav1.Now()
 
@@ -568,8 +551,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 
 			gomock.InOrder(
 				pm.EXPECT().GetWorkerPod(ctx, podName, namespace),
-				client.EXPECT().Get(ctx, types.NamespacedName{Name: nmcName}, &v1.Node{}),
-				nm.EXPECT().NodeBecomeReadyAfter(gomock.Any(), status.LastTransitionTime).Return(returnValue),
+				nm.EXPECT().NodeBecomeReadyAfter(node, status.LastTransitionTime).Return(returnValue),
 			)
 
 			if shouldCreate {
@@ -577,7 +559,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 			}
 
 			Expect(
-				wh.ProcessModuleSpec(ctx, nmc, spec, status),
+				wh.ProcessModuleSpec(ctx, nmc, spec, status, node),
 			).NotTo(
 				HaveOccurred(),
 			)
@@ -593,7 +575,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 			Return(&v1.Pod{}, nil)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -612,7 +594,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 			Return(&pod, nil)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -645,7 +627,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).To(
 			HaveOccurred(),
 		)
@@ -685,7 +667,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		)
 
 		Expect(
-			wh.ProcessModuleSpec(ctx, nmc, spec, status),
+			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -701,6 +683,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 
 		client *testclient.MockClient
 		pm     *MockpodManager
+		nm     *node.MockNode
 		helper nmcReconcilerHelper
 	)
 
@@ -708,7 +691,8 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		ctrl := gomock.NewController(GinkgoT())
 		client = testclient.NewMockClient(ctrl)
 		pm = NewMockpodManager(ctrl)
-		helper = newNMCReconcilerHelper(client, pm, nil, nil)
+		nm = node.NewMockNode(ctrl)
+		helper = newNMCReconcilerHelper(client, pm, nil, nm)
 	})
 
 	nmc := &kmmv1beta1.NodeModulesConfig{
@@ -722,14 +706,27 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		},
 	}
 
+	node := v1.Node{}
+
+	It("should do nothing , if the node has been rebooted/ready lately", func() {
+		nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(true)
+
+		Expect(
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
+		).NotTo(
+			HaveOccurred(),
+		)
+	})
+
 	It("should create an unloader Pod if no worker Pod exists", func() {
 		gomock.InOrder(
+			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			pm.EXPECT().GetWorkerPod(ctx, podName, namespace),
 			pm.EXPECT().CreateUnloaderPod(ctx, nmc, status),
 		)
 
 		Expect(
-			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -745,12 +742,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		gomock.InOrder(
+			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			pm.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			pm.EXPECT().DeletePod(ctx, &pod),
 		)
 
 		Expect(
-			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -764,10 +762,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 			},
 		}
 
-		pm.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil)
+		gomock.InOrder(
+			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			pm.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
+		)
 
 		Expect(
-			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -790,12 +791,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		gomock.InOrder(
+			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			pm.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			pm.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(nil, errors.New("random error")),
 		)
 
 		Expect(
-			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
 		).To(
 			HaveOccurred(),
 		)
@@ -822,13 +824,14 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		podTemplate.Annotations[hashAnnotationKey] = "456"
 
 		gomock.InOrder(
+			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			pm.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			pm.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(podTemplate, nil),
 			pm.EXPECT().DeletePod(ctx, &pod),
 		)
 
 		Expect(
-			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
+			helper.ProcessUnconfiguredModuleStatus(ctx, nmc, status, &node),
 		).NotTo(
 			HaveOccurred(),
 		)


### PR DESCRIPTION
The following scenario causes worker pods to be stuck during cluster upgrade:
1) kernel module is loaded into the node. NMC contains both spec and
   status using the current kernel version
2) cluster upgrade starts. As part of the upgrade node becomes
   Unschedulable
3) Module-NMC removes Spec from NMC, since the node is Uschedulable 4) Node becomes schedulable
5) NMC controller tries to unload kernel module using the NMC Status
   confiration, which contains old kernel.
6) Worker unload pods get stuck in Error, since Node is running the new
   kernel
7) Module-NMC updates Spec of NMC, but since worker pod exists, nothing
   is done

Solution:
   When processing orphaned NMC statuses (status exists but spec does
not), NMC controller should ignore modules that have statuses created prior to Node's Ready timestamp