### PR TITLE
Fixing image repo secret extraction for unloading worker pod

### DIFF
--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1047,14 +1047,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			},
 			Spec: v1.PodSpec{
 				ServiceAccountName: serviceAccountName,
-				Volumes: []v1.Volume{
-					{
-						Name: volNameImageRepoSecret,
-						VolumeSource: v1.VolumeSource{
-							Secret: &v1.SecretVolumeSource{SecretName: irsName},
-						},
-					},
-				},
+				ImagePullSecrets:   []v1.LocalObjectReference{v1.LocalObjectReference{Name: irsName}},
 			},
 			Status: v1.PodStatus{
 				Phase: v1.PodSucceeded,


### PR DESCRIPTION
image repo secret wasd previously extracted from the volume that was mapped into the loading pod. Since the volume no longer exists, we must extract it from the imagePullSecret of the loading pod