### PR TITLE
Removing labels when node NotReady

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -127,8 +127,12 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return ctrl.Result{}, fmt.Errorf("could not get node %s: %v", nmcObj.Name, err)
 	}
 
-	// skipping handling NMC spec, labelling, events until node becomes ready
+	// skipping handling NMC spec, events until node becomes ready
+	// removing label of loaded kmods
 	if !r.nodeAPI.IsNodeSchedulable(&node) {
+		if err := r.nodeAPI.RemoveNodeReadyLabels(ctx, &node); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could remove node %s labels: %v", node.Name, err)
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -98,6 +98,20 @@ func (mr *MockNodeMockRecorder) NodeBecomeReadyAfter(node, checkTime any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeBecomeReadyAfter", reflect.TypeOf((*MockNode)(nil).NodeBecomeReadyAfter), node, checkTime)
 }
 
+// RemoveNodeReadyLabels mocks base method.
+func (m *MockNode) RemoveNodeReadyLabels(ctx context.Context, node *v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveNodeReadyLabels", ctx, node)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveNodeReadyLabels indicates an expected call of RemoveNodeReadyLabels.
+func (mr *MockNodeMockRecorder) RemoveNodeReadyLabels(ctx, node any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveNodeReadyLabels", reflect.TypeOf((*MockNode)(nil).RemoveNodeReadyLabels), ctx, node)
+}
+
 // UpdateLabels mocks base method.
 func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Until now, nodes retained their kmod labels even when they became NotReady for any reason (e.g., a reboot).
Today, we are removing these labels when a node is NotReady to address a potential race condition.

---

Besides updating the unit tests, I also tested this manually with simple-kmod, and it works as expected (label was deleted when Node became NotReady).

---

### Note
I am also checking whether to remove the label using `IsDeprecatedKernelModuleReadyNodeLabel`. If this is not relevant, please let me know, and I will update it accordingly.

/cc @yevgeny-shnaidman @ybettan 