### PR TITLE
Removing kmod labels without appropriate tolerations

### DIFF
--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -98,20 +98,6 @@ func (mr *MockNodeMockRecorder) NodeBecomeReadyAfter(node, checkTime any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeBecomeReadyAfter", reflect.TypeOf((*MockNode)(nil).NodeBecomeReadyAfter), node, checkTime)
 }
 
-// RemoveNodeReadyLabels mocks base method.
-func (m *MockNode) RemoveNodeReadyLabels(ctx context.Context, node *v1.Node) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveNodeReadyLabels", ctx, node)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveNodeReadyLabels indicates an expected call of RemoveNodeReadyLabels.
-func (mr *MockNodeMockRecorder) RemoveNodeReadyLabels(ctx, node any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveNodeReadyLabels", reflect.TypeOf((*MockNode)(nil).RemoveNodeReadyLabels), ctx, node)
-}
-
 // UpdateLabels mocks base method.
 func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
 	m.ctrl.T.Helper()

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/meta"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,7 +18,6 @@ type Node interface {
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
 	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error
 	NodeBecomeReadyAfter(node *v1.Node, checkTime metav1.Time) bool
-	RemoveNodeReadyLabels(ctx context.Context, node *v1.Node) error
 }
 
 type node struct {
@@ -83,20 +81,6 @@ func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeR
 
 	if err := n.client.Patch(ctx, node, patchFrom); err != nil {
 		return fmt.Errorf("could not patch node: %v", err)
-	}
-	return nil
-}
-
-func (n *node) RemoveNodeReadyLabels(ctx context.Context, node *v1.Node) error {
-	var labelsToRemove []string
-	for label := range node.GetLabels() {
-		if ok, _, _ := utils.IsKernelModuleReadyNodeLabel(label); ok ||
-			utils.IsDeprecatedKernelModuleReadyNodeLabel(label) {
-			labelsToRemove = append(labelsToRemove, label)
-		}
-	}
-	if err := n.UpdateLabels(ctx, node, []string{}, labelsToRemove); err != nil {
-		return fmt.Errorf("could update node %s labels: %v", node.Name, err)
 	}
 	return nil
 }

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -160,9 +160,10 @@ var _ = Describe("GetNodesListBySelector", func() {
 })
 
 const (
-	loadedKernelModuleReadyNodeLabel   = "kmm.node.kubernetes.io/loaded-ns.loaded-n.ready"
-	unloadedKernelModuleReadyNodeLabel = "kmm.node.kubernetes.io/unloaded-ns.unloaded-n.ready"
-	notKernelModuleReadyNodeLabel      = "example.node.kubernetes.io/label-not-to-be-removed"
+	firstloadedKernelModuleReadyNodeLabel  = "kmm.node.kubernetes.io/loaded1-ns.loaded1-n.ready"
+	secondloadedKernelModuleReadyNodeLabel = "kmm.node.kubernetes.io/loaded2-ns.loaded2-n.ready"
+	unloadedKernelModuleReadyNodeLabel     = "kmm.node.kubernetes.io/unloaded-ns.unloaded-n.ready"
+	notKernelModuleReadyNodeLabel          = "example.node.kubernetes.io/label-not-to-be-removed"
 )
 
 var _ = Describe("UpdateLabels", func() {
@@ -186,14 +187,14 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{loadedKernelModuleReadyNodeLabel}
+		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
 		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 		err := n.UpdateLabels(ctx, &node, loaded, unloaded)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(node.Labels).To(HaveKey(loadedKernelModuleReadyNodeLabel))
+		Expect(node.Labels).To(HaveKey(firstloadedKernelModuleReadyNodeLabel))
 	})
 
 	It("Should fail to patch node", func() {
@@ -202,7 +203,7 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{loadedKernelModuleReadyNodeLabel}
+		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
 		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
@@ -318,58 +319,6 @@ var _ = Describe("NodeBecomeReadyAfter", func() {
 	})
 })
 
-var _ = Describe("RemoveNodeReadyLabels", func() {
-	var (
-		ctrl *gomock.Controller
-		n    Node
-		node *v1.Node
-		ctx  context.Context
-		clnt *client.MockClient
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		ctx = context.TODO()
-		n = NewNode(clnt)
-		node = &v1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					loadedKernelModuleReadyNodeLabel: "",
-					notKernelModuleReadyNodeLabel:    "",
-				},
-			},
-		}
-	})
-
-	It("Should remove all kmod labels", func() {
-		clnt.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-		err := n.RemoveNodeReadyLabels(ctx, node)
-		Expect(err).To(BeNil())
-		Expect(node.Labels).ToNot(HaveKey(loadedKernelModuleReadyNodeLabel))
-		Expect(node.Labels).To(HaveKey(notKernelModuleReadyNodeLabel))
-	})
-	It("Should fail", func() {
-		clnt.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-		err := n.RemoveNodeReadyLabels(ctx, node)
-		Expect(err).ToNot(BeNil())
-	})
-})
-
-var _ = Describe("addLabels", func() {
-	var node v1.Node
-
-	BeforeEach(func() {
-		node = v1.Node{}
-	})
-
-	It("Should add labels", func() {
-		labels := []string{loadedKernelModuleReadyNodeLabel}
-		addLabels(&node, labels)
-		Expect(node.Labels).To(HaveKey(loadedKernelModuleReadyNodeLabel))
-	})
-})
-
 var _ = Describe("removeLabels", func() {
 	var node v1.Node
 
@@ -377,15 +326,15 @@ var _ = Describe("removeLabels", func() {
 		node = v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					loadedKernelModuleReadyNodeLabel: "",
+					firstloadedKernelModuleReadyNodeLabel: "",
 				},
 			},
 		}
 	})
 
 	It("Should remove labels", func() {
-		labels := []string{loadedKernelModuleReadyNodeLabel}
+		labels := []string{firstloadedKernelModuleReadyNodeLabel}
 		removeLabels(&node, labels)
-		Expect(node.Labels).ToNot(HaveKey(loadedKernelModuleReadyNodeLabel))
+		Expect(node.Labels).ToNot(HaveKey(firstloadedKernelModuleReadyNodeLabel))
 	})
 })


### PR DESCRIPTION
This change addresses #940.
Kmod labels are now deleted only if the kernel module does not have the appropriate tolerations for the taints on the node.

---
/cc @yevgeny-shnaidman  @ybettan 