### PR TITLE
Making ImagePullPolicy in NMC optional

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -25,6 +25,7 @@ type ModuleConfig struct {
 	KernelVersion  string `json:"kernelVersion"`
 	ContainerImage string `json:"containerImage"`
 	// +kubebuilder:default=IfNotPresent
+	//+optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy"`
 	// When InsecurePull is true, the container image can be pulled without TLS.
 	InsecurePull bool `json:"insecurePull"`

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -194,7 +194,6 @@ spec:
                           type: array
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe
@@ -384,7 +383,6 @@ spec:
                           type: array
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe


### PR DESCRIPTION
Currently ImagePullPolicy has a kubebuilder instruction for default value, which automatically makes it a required field. In previous version, this field was optional, meaning: when upgrading KMM operator, the upgrade will fail , since NMC object will be missing the required field
This commit keep the default value, but makes this field optional, in order to solve the upgrade issue