### PR TITLE
Renaming the webhook deployment from `webhook-server` to `webhook`.

### DIFF
--- a/ci/install-ci-hub/kustomization.yaml
+++ b/ci/install-ci-hub/kustomization.yaml
@@ -32,7 +32,7 @@ patches:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: webhook-server
+      name: webhook
       namespace: system
     spec:
       template:

--- a/ci/install-ci/kustomization.yaml
+++ b/ci/install-ci/kustomization.yaml
@@ -35,7 +35,7 @@ patches:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: webhook-server
+      name: webhook
       namespace: system
     spec:
       template:

--- a/ci/prow/e2e-hub-spoke-incluster-build
+++ b/ci/prow/e2e-hub-spoke-incluster-build
@@ -51,9 +51,9 @@ make deploy deploy-hub
 
 kubectl wait --for=condition=Available -n ${OPERATOR_NAMESPACE} \
   deployment/kmm-operator-hub-controller \
-  deployment/kmm-operator-hub-webhook-server \
+  deployment/kmm-operator-hub-webhook \
   deployment/kmm-operator-controller \
-  deployment/kmm-operator-webhook-server \
+  deployment/kmm-operator-webhook \
 
 # Make the ManagedCluster selected by the ManagedClusterModule
 kubectl label managedcluster minikube name=minikube

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -33,7 +33,7 @@ kubectl apply -f ci/kmm-kmod-dockerfile.yaml
 echo "Add Secrets containing the signing key and certificate..."
 kubectl apply -f ci/secret_kmm-kmod-signing.yaml
 
-kubectl wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook-server -n kmm-operator-system
+kubectl wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook -n kmm-operator-system
 
 echo "Add an kmm-ci Module that contains a valid mapping..."
 kubectl apply -f ci/module-kmm-ci-build-sign.yaml

--- a/ci/prow/operator-upgrade
+++ b/ci/prow/operator-upgrade
@@ -47,5 +47,5 @@ make bundle bundle-build bundle-push \
     --timeout 5m0s
 kubectl wait --for=condition=Available -n operators --timeout=1m \
     deployment/kmm-operator-controller \
-    deployment/kmm-operator-webhook-server
+    deployment/kmm-operator-webhook
 

--- a/config/deploy-hub/kustomization.yaml
+++ b/config/deploy-hub/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 patches:
 - target:
     kind: Deployment
-    name: webhook-server
+    name: webhook
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 patches:
 - target:
     kind: Deployment
-    name: webhook-server
+    name: webhook
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-

--- a/config/webhook-cert/kustomization.yaml
+++ b/config/webhook-cert/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: webhook-server
+      name: webhook
       namespace: system
     spec:
       template:

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webhook-server
+  name: webhook
   namespace: system
   labels:
     control-plane: webhook-server

--- a/docs/mkdocs/documentation/troubleshooting.md
+++ b/docs/mkdocs/documentation/troubleshooting.md
@@ -15,8 +15,8 @@ In the commands below, the value of `$namespace` depends on your [installation m
 
 | Component | Command                                                                     |
 |-----------|-----------------------------------------------------------------------------|
-| KMM       | `kubectl logs -fn "$namespace" deployments/kmm-operator-webhook-server`     |
-| KMM-Hub   | `kubectl logs -fn "$namespace" deployments/kmm-operator-hub-webhook-server` |
+| KMM       | `kubectl logs -fn "$namespace" deployments/kmm-operator-webhook`     |
+| KMM-Hub   | `kubectl logs -fn "$namespace" deployments/kmm-operator-hub-webhook` |
 
 ## Observing events
 


### PR DESCRIPTION
* When we generate files with `controller-gen` it generates a service called `webhook-service` and it is not configurable.

* When we deploy KMM with OLM, OLM deploys a service for the webhook called `<webhook-deployment-name>-service`.

Therefore, before this change, we were getting 2 services for the same deployment. One generated by `controller-gen` and added to the bundle manifests and the other one created "on the fly" by OLM.

This change will make OLM find an already existing service called `webhook-service` in the cluster because the deployment is called `webhook`, therefore, it won't create a second service as before.

Services in KMM's namespace before the changes:
```
kmm-operator-controller-metrics-service   ClusterIP   10.129.169.25   <none>  8443/TCP   2d2h
kmm-operator-webhook-server-service       ClusterIP   10.130.107.158  <none>  443/TCP    2d2h
kmm-operator-webhook-service              ClusterIP   10.128.244.171  <none>  443/TCP    2d2h
```

Services in KMM's namespace after the changes:
```
kmm-operator-controller-metrics-service   ClusterIP   10.99.75.82     <none>  8443/TCP   88m
kmm-operator-webhook-service              ClusterIP   10.105.163.241  <none>  443/TCP    88m
```
---

/assign @yevgeny-shnaidman 
/cc @TomerNewman 