### PR TITLE
Increasing the timeout for `cert-manager` deployments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ KUSTOMIZE_CONFIG_CERT_MANAGER ?= https://github.com/cert-manager/cert-manager/re
 .PHONY: deploy-cert-manager
 deploy-cert-manager:
 	kubectl apply -f $(KUSTOMIZE_CONFIG_CERT_MANAGER)
-	kubectl -n cert-manager wait --timeout=2m --for=condition=Available deployment \
+	kubectl -n cert-manager wait --timeout=5m --for=condition=Available deployment \
 		cert-manager \
 		cert-manager-cainjector \
 		cert-manager-webhook


### PR DESCRIPTION
We are pretty often hitting a timeout waiting for the `cert-manager-webhook` deployment which becomes ready after the failure.

Timeout is now increased to give enough time for the webhook to be deployed.

---

/assign @yevgeny-shnaidman 

Here is a [failing job example](https://github.com/kubernetes-sigs/kernel-module-management/actions/runs/12860299514/job/35852064202?pr=977).