### PR TITLE
Changing the Generation and ObservedGeneration

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -40,8 +40,6 @@ const (
 type ModuleImageSpec struct {
 	// image
 	Image string `json:"image"`
-	// generation counter of the image config
-	Generation string `json:"generation"`
 
 	// Build contains build instructions, in case image needs building
 	// +optional
@@ -56,6 +54,9 @@ type ModuleImageSpec struct {
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +kubebuilder:validation:Required
 type ModuleImagesConfigSpec struct {
+	// updating counter triggers a new reconcilation
+	Generation int64 `json:"regeneration"`
+
 	Images []ModuleImageSpec `json:"images"`
 
 	// ImageRepoSecret contains pull secret for the image's repo, if needed
@@ -69,8 +70,6 @@ type ModuleImageState struct {
 	// status of the image
 	// one of: Exists, notExists
 	Status ImageState `json:"status"`
-	// observedGeneration counter is updated on each status update
-	ObservedGeneration string `json:"observedGeneration"`
 }
 
 // ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfig.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfig.yaml
@@ -153,9 +153,6 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
-                    generation:
-                      description: generation counter of the image config
-                      type: string
                     image:
                       description: image
                       type: string
@@ -222,12 +219,16 @@ spec:
                       - keySecret
                       type: object
                   required:
-                  - generation
                   - image
                   type: object
                 type: array
+              regeneration:
+                description: updating counter triggers a new reconcilation
+                format: int64
+                type: integer
             required:
             - images
+            - regeneration
             type: object
           status:
             description: |-
@@ -240,10 +241,6 @@ spec:
                     image:
                       description: image
                       type: string
-                    observedGeneration:
-                      description: observedGeneration counter is updated on each status
-                        update
-                      type: string
                     status:
                       description: |-
                         status of the image
@@ -251,7 +248,6 @@ spec:
                       type: string
                   required:
                   - image
-                  - observedGeneration
                   - status
                   type: object
                 type: array

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -153,9 +153,6 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
-                    generation:
-                      description: generation counter of the image config
-                      type: string
                     image:
                       description: image
                       type: string
@@ -222,12 +219,16 @@ spec:
                       - keySecret
                       type: object
                   required:
-                  - generation
                   - image
                   type: object
                 type: array
+              regeneration:
+                description: updating counter triggers a new reconcilation
+                format: int64
+                type: integer
             required:
             - images
+            - regeneration
             type: object
           status:
             description: |-
@@ -240,10 +241,6 @@ spec:
                     image:
                       description: image
                       type: string
-                    observedGeneration:
-                      description: observedGeneration counter is updated on each status
-                        update
-                      type: string
                     status:
                       description: |-
                         status of the image
@@ -251,7 +248,6 @@ spec:
                       type: string
                   required:
                   - image
-                  - observedGeneration
                   - status
                   type: object
                 type: array


### PR DESCRIPTION
Removing generation and observed generation from Image Spec and Status. Adding new Regeneration field in the Spec which will be used for kicking off a new round of reconciliation.
If the image status is "does not exists, the reconcilaition can be re-triggered, even if no objects monitored by the reconciler have been changed (image pushed to repo, Build/Sign dockerfile changed, etc')