### PR TITLE
Adding `ModuleImagesConfig` and `ModuleBuildSignConfig` CRDs manifests.

### DIFF
--- a/api/v1beta1/modulebuildsignconfig_types.go
+++ b/api/v1beta1/modulebuildsignconfig_types.go
@@ -24,7 +24,7 @@ import (
 // +kubebuilder:subresource:status
 
 // ModuleBuildSignConfig keeps the request for images' build/sign for a KMM Module.
-// +kubebuilder:resource:path=modulebuildsignconfig,scope=Namespaced,shortName=mbsc
+// +kubebuilder:resource:path=modulebuildsignconfigs,scope=Namespaced,shortName=mbsc
 // +operator-sdk:csv:customresourcedefinitions:displayName="Module Build Sign Config"
 type ModuleBuildSignConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -84,7 +84,6 @@ type NodeModulesConfigStatus struct {
 // +kubebuilder:subresource:status
 
 // NodeModulesConfig keeps spec and state of the KMM modules on a node.
-// +kubebuilder:resource:path=nodemodulesconfigs,scope=Cluster
 // +kubebuilder:resource:path=nodemodulesconfigs,scope=Cluster,shortName=nmc
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node Modules Config"
 type NodeModulesConfig struct {

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -4,13 +4,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
-  name: modulebuildsignconfig.kmm.sigs.x-k8s.io
+  name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
 spec:
   group: kmm.sigs.x-k8s.io
   names:
     kind: ModuleBuildSignConfig
     listKind: ModuleBuildSignConfigList
-    plural: modulebuildsignconfig
+    plural: modulebuildsignconfigs
     shortNames:
     - mbsc
     singular: modulebuildsignconfig

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,6 +7,8 @@ kind: Kustomization
 resources:
 - bases/kmm.sigs.x-k8s.io_modules.yaml
 - bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+- bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+- bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
 - bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 


### PR DESCRIPTION
Those are new API objects that were recently introduced but were not added to the manifest files.

---

/assign @yevgeny-shnaidman 