### PR TITLE
Generating `ModuleConfigImages` objects during `Module` reconciliation.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/kubernetes-sigs/kernel-module-management/internal/mic"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 
 	"github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -122,6 +123,7 @@ func main() {
 	buildHelperAPI := build.NewHelper()
 	nodeAPI := node.NewNode(client)
 	kernelAPI := module.NewKernelMapper(buildHelperAPI, sign.NewSignerHelper())
+	micAPI := mic.NewModuleImagesConfigAPI(client, scheme)
 
 	dpc := controllers.NewDevicePluginReconciler(
 		client,
@@ -140,6 +142,7 @@ func main() {
 		nmcHelper,
 		filterAPI,
 		nodeAPI,
+		micAPI,
 		scheme,
 	)
 	if err = mnc.SetupWithManager(mgr); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,18 @@ rules:
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
+  - moduleimagesconfigs
+  - nodemodulesconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - kmm.sigs.x-k8s.io
+  resources:
   - modules
   verbs:
   - get
@@ -84,17 +96,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - kmm.sigs.x-k8s.io
-  resources:
-  - nodemodulesconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:

--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -99,6 +99,20 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) getNMCsByModuleSet(ctx, mod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNMCsByModuleSet", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).getNMCsByModuleSet), ctx, mod)
 }
 
+// handleMIC mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) handleMIC(ctx context.Context, mod *v1beta1.Module, nodes []v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleMIC", ctx, mod, nodes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleMIC indicates an expected call of handleMIC.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleMIC(ctx, mod, nodes any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMIC", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleMIC), ctx, mod, nodes)
+}
+
 // moduleUpdateWorkerPodsStatus mocks base method.
 func (m *MockmoduleReconcilerHelperAPI) moduleUpdateWorkerPodsStatus(ctx context.Context, mod *v1beta1.Module, targetedNodes []v1.Node) error {
 	m.ctrl.T.Helper()

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -163,6 +163,13 @@ func ModuleReconcilePodPredicate() predicate.Predicate {
 	)
 }
 
+func ModuleReconcileMICPredicate() predicate.Predicate {
+	return predicate.And(
+		skipCreations,
+		skipDeletions,
+	)
+}
+
 func NodeUpdateKernelChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {


### PR DESCRIPTION
The `Module` reconciler will now generate and update
`ModuleImagesConfig`s objects in the cluster.

At this point, those objects aren't reconciled by any controller but
they will in the upcoming commits. For this reason, the `Module` controller
isn't checking the `MIC`'s status but instead keep checking if images exists
using direct HTTP calls.

---

/assign @yevgeny-shnaidman 

Here is the `ModuleImagesConfig` created for a simple `Module` on a minikube cluster:
```
ybettan kernel-module-management (module-reconciler) $  oc get mic/kmm-ci -o yaml | yq
apiVersion: kmm.sigs.x-k8s.io/v1beta1
kind: ModuleImagesConfig
metadata:
  creationTimestamp: "2025-02-06T14:19:13Z"
  generation: 1
  name: kmm-ci
  namespace: default
  ownerReferences:
    - apiVersion: kmm.sigs.x-k8s.io/v1beta1
      kind: Module
      name: kmm-ci
      uid: 3d1efaf1-5389-4ecd-bc3d-89ff94bb7bec
  resourceVersion: "1207250"
  uid: 4b887fe7-2115-4442-82f8-bacfb554e5d9
spec:
  images:
    - image: quay.io/ybettan/kmm-kmod:6.11.9-100.fc39.x86_64
  regeneration: 0
```