### PR TITLE
Adding tolerations specifications from Module to device plugin pods

### DIFF
--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -387,6 +387,7 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 				NodeSelector:       nodeSelector,
 				ServiceAccountName: mod.Spec.DevicePlugin.ServiceAccountName,
 				Volumes:            append([]v1.Volume{devicePluginVolume}, mod.Spec.DevicePlugin.Volumes...),
+				Tolerations:        mod.Spec.Tolerations,
 			},
 		},
 	}

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -628,6 +628,12 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		args := []string{"some", "args"}
 		command := []string{"some", "command"}
 
+		testToleration := v1.Toleration{
+			Key:    "test-key",
+			Value:  "test-value",
+			Effect: v1.TaintEffectNoExecute,
+		}
+
 		const ipp = v1.PullIfNotPresent
 
 		mod := kmmv1beta1.Module{
@@ -655,6 +661,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 				},
 				ImageRepoSecret: &repoSecret,
 				Selector:        map[string]string{"has-feature-x": "true"},
+				Tolerations:     []v1.Toleration{testToleration},
 			},
 		}
 		ds := appsv1.DaemonSet{
@@ -733,6 +740,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 							},
 							dpVol,
 						},
+						Tolerations: []v1.Toleration{testToleration},
 					},
 				},
 			},


### PR DESCRIPTION
Curently tolerations are applied only to worker pods, but not to the DevicePlugin pod. This PR adds the toleration definition from Module to the DevicePlugin's pod.