### PR TITLE
Removing the `Generation` field from the `ModuleImagesConfigSpec`.

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -26,7 +26,7 @@ type ImageState string
 const (
 	// ImageExists means that image exists in the specified repo
 	ImageExists ImageState = "Exists"
-	// ImageNotExists means that image does not exist in the specified repo
+	// ImageDoesNotExist means that image does not exist in the specified repo
 	ImageDoesNotExist ImageState = "DoesNotExist"
 	// ImageNeedsBuilding means that image does not exists, but has Build/Sign sections and can be built
 	ImageNeedsBuilding ImageState = "NeedsBuilding"
@@ -54,9 +54,6 @@ type ModuleImageSpec struct {
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 // +kubebuilder:validation:Required
 type ModuleImagesConfigSpec struct {
-	// updating counter triggers a new reconcilation
-	Generation int64 `json:"regeneration"`
-
 	Images []ModuleImageSpec `json:"images"`
 
 	// ImageRepoSecret contains pull secret for the image's repo, if needed

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -222,13 +222,8 @@ spec:
                   - image
                   type: object
                 type: array
-              regeneration:
-                description: updating counter triggers a new reconcilation
-                format: int64
-                type: integer
             required:
             - images
-            - regeneration
             type: object
           status:
             description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -222,13 +222,8 @@ spec:
                   - image
                   type: object
                 type: array
-              regeneration:
-                description: updating counter triggers a new reconcilation
-                format: int64
-                type: integer
             required:
             - images
-            - regeneration
             type: object
           status:
             description: |-


### PR DESCRIPTION
At first, we thought we will need a field to let the `MIC` future controller know that it needs to retry pulling an image that didn't exist, for example if the user has forgot to push the image.

We decided to just set the future pull pod with `restartPolicy=OnFailure` instead that will constantly retry to run the pod when it fails with an exp waiting time before retries and the max waiting time being 5m. If we wish to manually retry the pod without waiting the current waiting time, we can just delete the pull pod and the `MIC` controller will re-create it instantly.

It removed the need for maintaining a `Generation` field separately.

---

/assign @yevgeny-shnaidman 