### PR TITLE
Creating mic resource also when images field is empty

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -50,9 +50,8 @@ type ModuleImageSpec struct {
 
 // ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-// +kubebuilder:validation:Required
 type ModuleImagesConfigSpec struct {
-	Images []ModuleImageSpec `json:"images"`
+	Images []ModuleImageSpec `json:"images,omitempty"`
 
 	// ImageRepoSecret contains pull secret for the image's repo, if needed
 	// +optional

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -222,8 +222,6 @@ spec:
                   - image
                   type: object
                 type: array
-            required:
-            - images
             type: object
           status:
             description: |-

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -461,6 +461,12 @@ var _ = Describe("handleMIC", func() {
 		Expect(err.Error()).To(ContainSubstring("failed to apply"))
 	})
 
+	It("should not do anything if targetedNodes is empty", func() {
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		err := mrh.handleMIC(ctx, mod, []v1.Node{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should work as expected", func() {
 
 		img := "example.registry.com/org/image:tag"


### PR DESCRIPTION
Until now, when the node selectors were not match to any of the actual nodes, it still tried to create mic resource, even though we expect it to do nothing.
This commit allows to apply mic resources with an empty images field.

---
what we are getting is:
` "Reconciler error" err="failed to handle MIC: failed to apply default/example-module MIC: failed to create or patch default/example-module: ModuleImagesConfig.kmm.sigs.x-k8s.io \"example-module\" is invalid: spec.images: Required value" logger="kmm" controller="ModuleReconciler" controllerGroup="kmm.sigs.x-k8s.io" controllerKind="Module" Module="default/example-module" namespace="default" name="example-module" reconcileID="bbaed649-8ffe-4c36-a27d-442af70c3e3c"
`
over and over and over again

---
/cc @ybettan @yevgeny-shnaidman 