### PR TITLE
Adding KernelVersion to the MIC image spec

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -39,6 +39,9 @@ type ModuleImageSpec struct {
 	// image
 	Image string `json:"image"`
 
+	// kernel version for which this image is targeted
+	KernelVersion string `json:"kernelVersion"`
+
 	// Build contains build instructions, in case image needs building
 	// +optional
 	Build *Build `json:"build,omitempty"`

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -161,6 +161,9 @@ spec:
                     image:
                       description: image
                       type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
                     sign:
                       description: Sign contains sign instructions, in case image
                         needs signing
@@ -226,6 +229,7 @@ spec:
                   required:
                   - action
                   - image
+                  - kernelVersion
                   type: object
                 type: array
             required:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -156,6 +156,9 @@ spec:
                     image:
                       description: image
                       type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
                     sign:
                       description: Sign contains sign instructions, in case image
                         needs signing
@@ -220,6 +223,7 @@ spec:
                       type: object
                   required:
                   - image
+                  - kernelVersion
                   type: object
                 type: array
             type: object

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -349,9 +349,10 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 			continue
 		}
 		mis := kmmv1beta1.ModuleImageSpec{
-			Image: mld.ContainerImage,
-			Build: mld.Build,
-			Sign:  mld.Sign,
+			Image:         mld.ContainerImage,
+			KernelVersion: mld.KernelVersion,
+			Build:         mld.Build,
+			Sign:          mld.Sign,
 		}
 		images = append(images, mis)
 	}

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -470,9 +470,20 @@ var _ = Describe("handleMIC", func() {
 	It("should work as expected", func() {
 
 		img := "example.registry.com/org/image:tag"
-		mld := &api.ModuleLoaderData{ContainerImage: img}
+		mld := &api.ModuleLoaderData{
+			ContainerImage: img,
+			Build:          &kmmv1beta1.Build{},
+			Sign:           &kmmv1beta1.Sign{},
+			KernelVersion:  "some version",
+		}
+		expectedSpec := kmmv1beta1.ModuleImageSpec{
+			Image:         img,
+			KernelVersion: "some version",
+			Build:         mld.Build,
+			Sign:          mld.Sign,
+		}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec}, mod.Spec.ImageRepoSecret, mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
MIC image spec is being propgated as is to the MBSC image spec. As part of building sign and build pod, one of the inputs is the kernel version that this image is targeted for. This PR does the following:
1. Add KernelVersion field to the ModuleImageSpec
2. module reconciler sets the KernelVersion in the imageSpec variable
3. changing unit-tests