### PR TITLE
Un-exporting some of `WorkerPodManager` interface env variables.

### DIFF
--- a/internal/pod/mock_workerpodmanager.go
+++ b/internal/pod/mock_workerpodmanager.go
@@ -83,6 +83,20 @@ func (mr *MockWorkerPodManagerMockRecorder) DeletePod(ctx, pod any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockWorkerPodManager)(nil).DeletePod), ctx, pod)
 }
 
+// GetConfigAnnotation mocks base method.
+func (m *MockWorkerPodManager) GetConfigAnnotation(p *v1.Pod) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigAnnotation", p)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetConfigAnnotation indicates an expected call of GetConfigAnnotation.
+func (mr *MockWorkerPodManagerMockRecorder) GetConfigAnnotation(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetConfigAnnotation), p)
+}
+
 // GetWorkerPod mocks base method.
 func (m *MockWorkerPodManager) GetWorkerPod(ctx context.Context, podName, namespace string) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
@@ -96,6 +110,48 @@ func (m *MockWorkerPodManager) GetWorkerPod(ctx context.Context, podName, namesp
 func (mr *MockWorkerPodManagerMockRecorder) GetWorkerPod(ctx, podName, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerPod", reflect.TypeOf((*MockWorkerPodManager)(nil).GetWorkerPod), ctx, podName, namespace)
+}
+
+// HashAnnotationDiffer mocks base method.
+func (m *MockWorkerPodManager) HashAnnotationDiffer(p1, p2 *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HashAnnotationDiffer", p1, p2)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HashAnnotationDiffer indicates an expected call of HashAnnotationDiffer.
+func (mr *MockWorkerPodManagerMockRecorder) HashAnnotationDiffer(p1, p2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HashAnnotationDiffer", reflect.TypeOf((*MockWorkerPodManager)(nil).HashAnnotationDiffer), p1, p2)
+}
+
+// IsLoaderPod mocks base method.
+func (m *MockWorkerPodManager) IsLoaderPod(p *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLoaderPod", p)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLoaderPod indicates an expected call of IsLoaderPod.
+func (mr *MockWorkerPodManagerMockRecorder) IsLoaderPod(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaderPod", reflect.TypeOf((*MockWorkerPodManager)(nil).IsLoaderPod), p)
+}
+
+// IsUnloaderPod mocks base method.
+func (m *MockWorkerPodManager) IsUnloaderPod(p *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUnloaderPod", p)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsUnloaderPod indicates an expected call of IsUnloaderPod.
+func (mr *MockWorkerPodManagerMockRecorder) IsUnloaderPod(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnloaderPod", reflect.TypeOf((*MockWorkerPodManager)(nil).IsUnloaderPod), p)
 }
 
 // ListWorkerPodsOnNode mocks base method.

--- a/internal/pod/workerpodmanager_test.go
+++ b/internal/pod/workerpodmanager_test.go
@@ -150,7 +150,7 @@ var _ = Describe("CreateLoaderPod", func() {
 		hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+		expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 		gomock.InOrder(
 			client.EXPECT().Create(ctx, cmpmock.DiffEq(expected)),
@@ -215,7 +215,7 @@ var _ = Describe("CreateLoaderPod", func() {
 			hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+			expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 			gomock.InOrder(
 				client.EXPECT().Create(ctx, cmpmock.DiffEq(expected)),
@@ -320,7 +320,7 @@ var _ = Describe("CreateUnloaderPod", func() {
 		hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+		expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 		client.EXPECT().Create(ctx, cmpmock.DiffEq(expected))
 
@@ -391,7 +391,7 @@ var _ = Describe("ListWorkerPodsOnNode", func() {
 	})
 
 	opts := []interface{}{
-		ctrlclient.HasLabels{ActionLabelKey},
+		ctrlclient.HasLabels{actionLabelKey},
 		ctrlclient.MatchingFields{".spec.nodeName": nodeName},
 	}
 
@@ -437,9 +437,9 @@ func getBaseWorkerPod(subcommand string, owner ctrlclient.Object, firmwareHostPa
 		volNameVarLibFirmware = "lib-firmware"
 	)
 
-	action := WorkerActionLoad
+	action := workerActionLoad
 	if !isLoaderPod {
-		action = WorkerActionUnload
+		action = workerActionUnload
 	}
 
 	hostPathDirectory := v1.HostPathDirectory
@@ -493,11 +493,11 @@ cp -R /firmware-path/* /tmp/firmware-path;
 				"app.kubernetes.io/component": "worker",
 				"app.kubernetes.io/name":      "kmm",
 				"app.kubernetes.io/part-of":   "kmm",
-				ActionLabelKey:                string(action),
+				actionLabelKey:                string(action),
 				constants.ModuleNameLabel:     moduleName,
 			},
 			Annotations: map[string]string{
-				ConfigAnnotationKey: configAnnotationValue,
+				configAnnotationKey: configAnnotationValue,
 				modulesOrderKey:     modulesOrderValue,
 			},
 		},
@@ -579,7 +579,7 @@ cp -R /firmware-path/* /tmp/firmware-path;
 								{
 									Path: "config.yaml",
 									FieldRef: &v1.ObjectFieldSelector{
-										FieldPath: fmt.Sprintf("metadata.annotations['%s']", ConfigAnnotationKey),
+										FieldPath: fmt.Sprintf("metadata.annotations['%s']", configAnnotationKey),
 									},
 								},
 							},


### PR DESCRIPTION
When this interface was transitioned to the `pod` package, it was copied as is (as much as possible) and some variables had to be exported to be used as before.

Once the transition done, it was simpler to review some of those new exported env variables and convert them to usefull methods inside the `WorkerPodManager` interface.

---

/assign @yevgeny-shnaidman 