### PR TITLE
Fixing the firmware configuration documentation.

### DIFF
--- a/docs/mkdocs/documentation/configure.md
+++ b/docs/mkdocs/documentation/configure.md
@@ -79,7 +79,7 @@ Determines the value of the `seLinuxOptions.type` field of the worker container'
 [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).  
 Recommended value: `spc_t`.
 
-#### `worker.setFirmwareClassPath`
+#### `worker.firmwareHostPath`
 
 If set, the value of this field will be written by the worker into the `/sys/module/firmware_class/parameters/path` file
 on the node.


### PR DESCRIPTION
The config fields to be used in order to modify the firmware path on the host but the user was changed rom `setFirmwareClassPath` to `firmwareHostPath` but the documentation wasn't update accordingly. This commit is about to fix that.

---

Fixes https://github.com/kubernetes-sigs/kernel-module-management/issues/1006 
/assign @yevgeny-shnaidman 