### PR TITLE
bump build bundles to golang 1.23-alpine3.21

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -82,7 +82,7 @@ steps:
       - gcr.io/$PROJECT_ID/kernel-module-management-worker
     waitFor: [build-worker]
   - id: build-bundles
-    name: golang:1.22-alpine3.19
+    name: golang:1.23-alpine3.21
     env:
       - '_GIT_TAG=$_GIT_TAG'
     entrypoint: sh


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/130457


https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kernel-module-management-push-images/1895046355202609152 
failed for 

> BUILD FAILURE: Build step failure: build step 10 "golang:1.22-alpine3.19" failed: step exited with non-zero status: 2
> ERROR: (gcloud.builds.submit) build 7[862](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kernel-module-management-push-images/1895046355202609152#1:build-log.txt%3A862)5c53-80f3-4a19-a4ac-1c57bed63037 completed with status "FAILURE"
> Step #10 - "build-bundles": /workspace/bin/controller-gen crd paths="./api/..." output:crd:artifacts:config=config/crd/bases
> Step #10 - "build-bundles": Error: load packages in root "/workspace/api": err: exit status 1: stderr: go: ../go.mod requires go >= 1.23.0 (running go 1.22.10; GOTOOLCHAIN=local)
> Step #10 - "build-bundles": 
> Step #10 - "build-bundles": Usage:
> Step #10 - "build-bundles":   controller-gen [flags]
