### PR TITLE
Changing the GarbageCollector API of the buildsign manager

### DIFF
--- a/internal/buildsign/manager.go
+++ b/internal/buildsign/manager.go
@@ -15,5 +15,5 @@ type Manager interface {
 	GetStatus(ctx context.Context, name, namespace, kernelVersion string,
 		action kmmv1beta1.BuildOrSignAction, owner metav1.Object) (kmmv1beta1.BuildOrSignStatus, error)
 	Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner metav1.Object, action kmmv1beta1.BuildOrSignAction) error
-	GarbageCollect(ctx context.Context, name, namespace, podType string, owner metav1.Object) ([]string, error)
+	GarbageCollect(ctx context.Context, name, namespace string, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) ([]string, error)
 }

--- a/internal/buildsign/mock_manager.go
+++ b/internal/buildsign/mock_manager.go
@@ -42,18 +42,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, name, namespace, podType string, owner v1.Object) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, name, namespace string, action v1beta1.BuildOrSignAction, owner v1.Object) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, name, namespace, podType, owner)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, name, namespace, action, owner)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, name, namespace, podType, owner any) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, name, namespace, action, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, name, namespace, podType, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, name, namespace, action, owner)
 }
 
 // GetStatus mocks base method.

--- a/internal/buildsign/pod/manager.go
+++ b/internal/buildsign/pod/manager.go
@@ -120,7 +120,11 @@ func (pm *podManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushI
 	return nil
 }
 
-func (pm *podManager) GarbageCollect(ctx context.Context, name, namespace, podType string, owner metav1.Object) ([]string, error) {
+func (pm *podManager) GarbageCollect(ctx context.Context, name, namespace string, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) ([]string, error) {
+	podType := PodTypeBuild
+	if action == kmmv1beta1.SignImage {
+		podType = PodTypeSign
+	}
 	pods, err := pm.buildSignPodManager.GetModulePods(ctx, name, namespace, podType, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get %s pods for mbsc %s/%s: %v", podType, namespace, name, err)

--- a/internal/buildsign/pod/manager_test.go
+++ b/internal/buildsign/pod/manager_test.go
@@ -265,7 +265,7 @@ var _ = Describe("GarbageCollect", func() {
 	It("failed to get module pods", func() {
 		mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC).Return(nil, fmt.Errorf("some error"))
 
-		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC)
+		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -276,12 +276,12 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		gomock.InOrder(
-			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeSign, &testMBSC).
 				Return([]v1.Pod{testPod}, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPod).Return(fmt.Errorf("some error")),
 		)
 
-		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC)
+		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.SignImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -313,7 +313,7 @@ var _ = Describe("GarbageCollect", func() {
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPodSuccess).Return(nil),
 		)
 
-		res, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC)
+		res, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal([]string{"podSuccess"}))
 	})


### PR DESCRIPTION
Currently the GarbageCollector API receives the PodType as an input parameter. The PodType  is defined in the pod package, which should not be used by the callee, since it is a porting layer. This commit changes the API to use kmmv1beta1.BuildOrSignAction, and the translation to the PodType will be done inside the manager code