### PR TITLE
Updating MIC and MBSC definitions

### DIFF
--- a/api/v1beta1/modulebuildsignconfig_types.go
+++ b/api/v1beta1/modulebuildsignconfig_types.go
@@ -74,8 +74,9 @@ type ModuleBuildSignConfigStatus struct {
 	Images []BuildSignImageState `json:"images"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Namespaced
 
 // ModuleBuildSignConfig keeps the request for images' build/sign for a KMM Module.
 // +kubebuilder:resource:path=modulebuildsignconfigs,scope=Namespaced,shortName=mbsc
@@ -88,7 +89,7 @@ type ModuleBuildSignConfig struct {
 	Status ModuleBuildSignConfigStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
+//+kubebuilder:object:root=true
 
 // ModuleBuildSignConfigList is a list of ModuleBuildSignConfig objects.
 type ModuleBuildSignConfigList struct {

--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -80,8 +80,9 @@ type ModuleImagesConfigStatus struct {
 	ImagesStates []ModuleImageState `json:"imagesStates"`
 }
 
-// +kubebuilder:object:root=true
-// +kubebuilder:subresource:status
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Namespaced
 
 // ModuleImagesConfig keeps the request for images' state for a KMM Module.
 // +kubebuilder:resource:path=moduleimagesconfigs,scope=Namespaced,shortName=mic


### PR DESCRIPTION
MIC and MBSC objects should be namespaced, since they are the direct derivitive of the Module object