### PR TITLE
Adding GetImageStatus API to mbsc package

### DIFF
--- a/internal/mbsc/mbsc.go
+++ b/internal/mbsc/mbsc.go
@@ -21,6 +21,7 @@ type MBSC interface {
 		moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) error
 	GetImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string) *kmmv1beta1.ModuleBuildSignSpec
 	SetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string, action kmmv1beta1.BuildOrSignAction, status kmmv1beta1.BuildOrSignStatus)
+	GetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string, action kmmv1beta1.BuildOrSignAction) kmmv1beta1.BuildOrSignStatus
 }
 
 type mbsc struct {
@@ -83,6 +84,15 @@ func (m *mbsc) SetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image s
 		}
 	}
 	mbscObj.Status.Images = append(mbscObj.Status.Images, imageState)
+}
+
+func (m *mbsc) GetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string, action kmmv1beta1.BuildOrSignAction) kmmv1beta1.BuildOrSignStatus {
+	for _, imageState := range mbscObj.Status.Images {
+		if imageState.Image == image && imageState.Action == action {
+			return imageState.Status
+		}
+	}
+	return kmmv1beta1.BuildOrSignStatus("")
 }
 
 func setModuleImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) {

--- a/internal/mbsc/mbsc_test.go
+++ b/internal/mbsc/mbsc_test.go
@@ -226,3 +226,42 @@ var _ = Describe("SetImageSpec", func() {
 		Expect(testMBSC.Status.Images[2].Action).To(Equal(kmmv1beta1.BuildImage))
 	})
 })
+
+var _ = Describe("GetImageStatus", func() {
+	testMBSC := kmmv1beta1.ModuleBuildSignConfig{
+		Status: kmmv1beta1.ModuleBuildSignConfigStatus{
+			Images: []kmmv1beta1.BuildSignImageState{
+				{
+					Image:  "image1",
+					Status: kmmv1beta1.ActionSuccess,
+					Action: kmmv1beta1.BuildImage,
+				},
+				{
+					Image:  "image2",
+					Status: kmmv1beta1.ActionFailure,
+					Action: kmmv1beta1.SignImage,
+				},
+			},
+		},
+	}
+
+	mbscAPI := New(nil, nil)
+
+	It("get images status for both present and not present statuses", func() {
+		By("image and action are present")
+		res := mbscAPI.GetImageStatus(&testMBSC, "image1", kmmv1beta1.BuildImage)
+		Expect(res).To(Equal(kmmv1beta1.ActionSuccess))
+
+		By("image present, action missing")
+		res = mbscAPI.GetImageStatus(&testMBSC, "image2", kmmv1beta1.BuildImage)
+		Expect(res).To(Equal(kmmv1beta1.BuildOrSignStatus("")))
+
+		By("image missing, action present")
+		res = mbscAPI.GetImageStatus(&testMBSC, "image3", kmmv1beta1.BuildImage)
+		Expect(res).To(Equal(kmmv1beta1.BuildOrSignStatus("")))
+
+		By("image missing, action missing")
+		res = mbscAPI.GetImageStatus(&testMBSC, "image3", kmmv1beta1.SignImage)
+		Expect(res).To(Equal(kmmv1beta1.BuildOrSignStatus("")))
+	})
+})

--- a/internal/mbsc/mock_mbsc.go
+++ b/internal/mbsc/mock_mbsc.go
@@ -82,6 +82,20 @@ func (mr *MockMBSCMockRecorder) GetImageSpec(mbscObj, image any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSpec", reflect.TypeOf((*MockMBSC)(nil).GetImageSpec), mbscObj, image)
 }
 
+// GetImageStatus mocks base method.
+func (m *MockMBSC) GetImageStatus(mbscObj *v1beta1.ModuleBuildSignConfig, image string, action v1beta1.BuildOrSignAction) v1beta1.BuildOrSignStatus {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageStatus", mbscObj, image, action)
+	ret0, _ := ret[0].(v1beta1.BuildOrSignStatus)
+	return ret0
+}
+
+// GetImageStatus indicates an expected call of GetImageStatus.
+func (mr *MockMBSCMockRecorder) GetImageStatus(mbscObj, image, action any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageStatus", reflect.TypeOf((*MockMBSC)(nil).GetImageStatus), mbscObj, image, action)
+}
+
 // SetImageStatus mocks base method.
 func (m *MockMBSC) SetImageStatus(mbscObj *v1beta1.ModuleBuildSignConfig, image string, action v1beta1.BuildOrSignAction, status v1beta1.BuildOrSignStatus) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This API return the status of the an image in the MBSC object based on the image and the action. Is required by the MBSC controller