### PR TITLE
Fixing MBSC object's owner creation

### DIFF
--- a/internal/mbsc/mbsc.go
+++ b/internal/mbsc/mbsc.go
@@ -57,7 +57,7 @@ func (m *mbsc) CreateOrPatch(ctx context.Context, micObj *kmmv1beta1.ModuleImage
 	_, err := controllerutil.CreateOrPatch(ctx, m.client, mbscObj, func() error {
 		setModuleImageSpec(mbscObj, moduleImageSpec, action)
 		mbscObj.Spec.ImageRepoSecret = micObj.Spec.ImageRepoSecret
-		return controllerutil.SetOwnerReference(micObj, mbscObj, m.scheme)
+		return controllerutil.SetControllerReference(micObj, mbscObj, m.scheme)
 	})
 	return err
 }


### PR DESCRIPTION
When MBSC object is created/updated by MIC controler , its owner reference should be set with controller=true ,in order to be able to receive events based on the "Own" controller-runtime construct