### PR TITLE
Updating image puller package with the new pod flow

### DIFF
--- a/internal/pod/imagepuller.go
+++ b/internal/pod/imagepuller.go
@@ -12,6 +12,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type PullPodStatus string
+
+const (
+	PullImageFailed        PullPodStatus = "pullFailed"
+	PullImageSuccess       PullPodStatus = "pullSuccess"
+	PullImageInProcess     PullPodStatus = "pullInProcess"
+	PullImageUnexpectedErr PullPodStatus = "unexpectedError"
+
+	imagePullBackOffReason = "ImagePullBackOff"
+	errImagePullReason     = "ErrImagePull"
+
+	moduleImageLabelKey = "kmm.node.kubernetes.io/module-image-config"
+	pullPodTypeLabelKey = "kmm.node.kubernetes.io/pull-pod-type"
+
+	pullerContainerName = "puller"
+
+	pullPodTypeOneTime  = "one-time-pull"
+	pullPodUntilSuccess = "until-success"
+)
+
 //go:generate mockgen -source=imagepuller.go -package=pod -destination=mock_imagepuller.go
 
 type ImagePuller interface {
@@ -20,13 +40,8 @@ type ImagePuller interface {
 	ListPullPods(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig) ([]v1.Pod, error)
 	GetPullPodForImage(pods []v1.Pod, image string) *v1.Pod
 	GetPullPodImage(pod v1.Pod) string
+	GetPullPodStatus(pod *v1.Pod) PullPodStatus
 }
-
-const (
-	moduleImageLabelKey = "kmm.node.kubernetes.io/module-image-config"
-	imageLabelKey       = "kmm.node.kubernetes.io/module-image"
-	pullerContainerName = "puller"
-)
 
 type imagePullerImpl struct {
 	client client.Client
@@ -43,9 +58,9 @@ func NewImagePuller(client client.Client, scheme *runtime.Scheme) ImagePuller {
 func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, imageSpec *kmmv1beta1.ModuleImageSpec,
 	micObj *kmmv1beta1.ModuleImagesConfig) error {
 
-	restartPolicy := v1.RestartPolicyOnFailure
+	pullPodTypeLabeValue := pullPodUntilSuccess
 	if imageSpec.Build != nil || imageSpec.Sign != nil {
-		restartPolicy = v1.RestartPolicyNever
+		pullPodTypeLabeValue = pullPodTypeOneTime
 	}
 
 	imagePullSecrets := []v1.LocalObjectReference{}
@@ -59,7 +74,7 @@ func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, imageSpec *kmmv1b
 			Namespace:    micObj.Namespace,
 			Labels: map[string]string{
 				moduleImageLabelKey: micObj.Name,
-				imageLabelKey:       imageSpec.Image,
+				pullPodTypeLabelKey: pullPodTypeLabeValue,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -70,7 +85,7 @@ func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, imageSpec *kmmv1b
 					Command: []string{"/bin/sh", "-c", "exit 0"},
 				},
 			},
-			RestartPolicy:    restartPolicy,
+			RestartPolicy:    v1.RestartPolicyNever,
 			ImagePullSecrets: imagePullSecrets,
 		},
 	}
@@ -92,7 +107,7 @@ func (ipi *imagePullerImpl) ListPullPods(ctx context.Context, micObj *kmmv1beta1
 
 	pl := v1.PodList{}
 
-	hl := client.HasLabels{imageLabelKey}
+	hl := client.HasLabels{pullPodTypeLabelKey}
 	ml := client.MatchingLabels{moduleImageLabelKey: micObj.Name}
 
 	ctrl.LoggerFrom(ctx).WithValues("mic name", micObj.Name).V(1).Info("Listing mic image Pods")
@@ -107,7 +122,7 @@ func (ipi *imagePullerImpl) ListPullPods(ctx context.Context, micObj *kmmv1beta1
 func (ipi *imagePullerImpl) GetPullPodForImage(pods []v1.Pod, image string) *v1.Pod {
 
 	for i, pod := range pods {
-		if image == pod.Labels[imageLabelKey] {
+		if image == pod.Spec.Containers[0].Image {
 			return &pods[i]
 		}
 	}
@@ -115,5 +130,38 @@ func (ipi *imagePullerImpl) GetPullPodForImage(pods []v1.Pod, image string) *v1.
 }
 
 func (ipi *imagePullerImpl) GetPullPodImage(pod v1.Pod) string {
-	return pod.Labels[imageLabelKey]
+	return pod.Spec.Containers[0].Image
+}
+
+func (ipi *imagePullerImpl) GetPullPodStatus(pod *v1.Pod) PullPodStatus {
+	switch pod.Status.Phase {
+	case v1.PodSucceeded:
+		return PullImageSuccess
+	case v1.PodFailed, v1.PodUnknown:
+		return PullImageUnexpectedErr
+	case v1.PodRunning:
+		return PullImageInProcess
+	case v1.PodPending:
+		// no container statuses yet, the pod is just starting to pull images
+		if pod.Status.ContainerStatuses == nil {
+			return PullImageInProcess
+		}
+
+		// no wating status, the pull process is still in progress
+		if pod.Status.ContainerStatuses[0].State.Waiting == nil {
+			return PullImageInProcess
+		}
+
+		pullPodType := pod.GetLabels()[pullPodTypeLabelKey]
+		// if pod is targeted to wait till the end - return the InProgress
+		if pullPodType == pullPodUntilSuccess {
+			return PullImageInProcess
+		}
+
+		if waitingReason := pod.Status.ContainerStatuses[0].State.Waiting.Reason; waitingReason == imagePullBackOffReason || waitingReason == errImagePullReason {
+			return PullImageFailed
+		}
+	}
+
+	return PullImageUnexpectedErr
 }

--- a/internal/pod/mock_imagepuller.go
+++ b/internal/pod/mock_imagepuller.go
@@ -96,6 +96,20 @@ func (mr *MockImagePullerMockRecorder) GetPullPodImage(pod any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullPodImage", reflect.TypeOf((*MockImagePuller)(nil).GetPullPodImage), pod)
 }
 
+// GetPullPodStatus mocks base method.
+func (m *MockImagePuller) GetPullPodStatus(pod *v1.Pod) PullPodStatus {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPullPodStatus", pod)
+	ret0, _ := ret[0].(PullPodStatus)
+	return ret0
+}
+
+// GetPullPodStatus indicates an expected call of GetPullPodStatus.
+func (mr *MockImagePullerMockRecorder) GetPullPodStatus(pod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullPodStatus", reflect.TypeOf((*MockImagePuller)(nil).GetPullPodStatus), pod)
+}
+
 // ListPullPods mocks base method.
 func (m *MockImagePuller) ListPullPods(ctx context.Context, micObj *v1beta1.ModuleImagesConfig) ([]v1.Pod, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This commit contains the following changes:
1. Removing image label - image will be obtained from the Spec directly
2. Adding pod type label - one-time pod that should be considered as Failed once the container fails on image pull, and run-until-success, that is considered as InProgess, in case container ails on image pull
3. Adding GetPodStatus API - this api returns pod status based on the following:
   - the pod that fails to pull image stays in the Pending state, and the container status is updated with appropriate reason.So, if the pod is one-time pod, and container failed on image pull - status is Failed. Otherwise status is Running, since we let the pod restart the container with back-offs
4. Pod is created with restartPolicy Never, since if the pod managed to pull image - we consider it a success