### PR TITLE
Hiding the buildsign porting layer initialization

### DIFF
--- a/internal/buildsign/pod/manager.go
+++ b/internal/buildsign/pod/manager.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -24,7 +25,10 @@ type podManager struct {
 	buildSignPodManager BuildSignPodManager
 }
 
-func NewManager(client client.Client, maker Maker, signer Signer, buildSignPodManager BuildSignPodManager) buildsign.Manager {
+func NewManager(client client.Client, helper buildsign.Helper, scheme *runtime.Scheme) buildsign.Manager {
+	buildSignPodManager := NewBuildSignPodManager(client)
+	maker := NewMaker(client, helper, buildSignPodManager, scheme)
+	signer := NewSigner(client, scheme, buildSignPodManager)
 	return &podManager{
 		client:              client,
 		maker:               maker,

--- a/internal/buildsign/pod/manager_test.go
+++ b/internal/buildsign/pod/manager_test.go
@@ -12,7 +12,6 @@ import (
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
-	buildsign "github.com/kubernetes-sigs/kernel-module-management/internal/buildsign"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/kernel"
 )
@@ -24,7 +23,7 @@ var _ = Describe("GetStatus", func() {
 		mockMaker               *MockMaker
 		mockSigner              *MockSigner
 		mockBuildSignPodManager *MockBuildSignPodManager
-		mgr                     buildsign.Manager
+		mgr                     *podManager
 	)
 	const (
 		mbscName      = "some-name"
@@ -39,7 +38,12 @@ var _ = Describe("GetStatus", func() {
 		mockMaker = NewMockMaker(ctrl)
 		mockSigner = NewMockSigner(ctrl)
 		mockBuildSignPodManager = NewMockBuildSignPodManager(ctrl)
-		mgr = NewManager(clnt, mockMaker, mockSigner, mockBuildSignPodManager)
+		mgr = &podManager{
+			client:              clnt,
+			maker:               mockMaker,
+			signer:              mockSigner,
+			buildSignPodManager: mockBuildSignPodManager,
+		}
 	})
 
 	ctx := context.Background()
@@ -105,7 +109,7 @@ var _ = Describe("Sync", func() {
 		mockMaker               *MockMaker
 		mockSigner              *MockSigner
 		mockBuildSignPodManager *MockBuildSignPodManager
-		mgr                     buildsign.Manager
+		mgr                     *podManager
 	)
 	const (
 		mbscName      = "some-name"
@@ -120,7 +124,12 @@ var _ = Describe("Sync", func() {
 		mockMaker = NewMockMaker(ctrl)
 		mockSigner = NewMockSigner(ctrl)
 		mockBuildSignPodManager = NewMockBuildSignPodManager(ctrl)
-		mgr = NewManager(clnt, mockMaker, mockSigner, mockBuildSignPodManager)
+		mgr = &podManager{
+			client:              clnt,
+			maker:               mockMaker,
+			signer:              mockSigner,
+			buildSignPodManager: mockBuildSignPodManager,
+		}
 	})
 
 	ctx := context.Background()
@@ -241,7 +250,7 @@ var _ = Describe("GarbageCollect", func() {
 		mockMaker               *MockMaker
 		mockSigner              *MockSigner
 		mockBuildSignPodManager *MockBuildSignPodManager
-		mgr                     buildsign.Manager
+		mgr                     *podManager
 	)
 	const (
 		mbscName      = "some-name"
@@ -256,7 +265,12 @@ var _ = Describe("GarbageCollect", func() {
 		mockMaker = NewMockMaker(ctrl)
 		mockSigner = NewMockSigner(ctrl)
 		mockBuildSignPodManager = NewMockBuildSignPodManager(ctrl)
-		mgr = NewManager(clnt, mockMaker, mockSigner, mockBuildSignPodManager)
+		mgr = &podManager{
+			client:              clnt,
+			maker:               mockMaker,
+			signer:              mockSigner,
+			buildSignPodManager: mockBuildSignPodManager,
+		}
 	})
 
 	ctx := context.Background()


### PR DESCRIPTION
buildsign/pod is a porting layer, and as such we would like to minimize itsexposure to the outer code. This PR make buildsign manager initialize the maker, signer and buildisngpodmanager interfaces inside its own init function, which will remove the exposure to the porting layer from main