### PR TITLE
Aligning Sync API of the buildsign manager

### DIFF
--- a/internal/buildsign/manager.go
+++ b/internal/buildsign/manager.go
@@ -14,6 +14,6 @@ import (
 type Manager interface {
 	GetStatus(ctx context.Context, name, namespace, kernelVersion string,
 		action kmmv1beta1.BuildOrSignAction, owner metav1.Object) (kmmv1beta1.BuildOrSignStatus, error)
-	Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner metav1.Object, action kmmv1beta1.BuildOrSignAction) error
+	Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) error
 	GarbageCollect(ctx context.Context, name, namespace string, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) ([]string, error)
 }

--- a/internal/buildsign/mock_manager.go
+++ b/internal/buildsign/mock_manager.go
@@ -72,15 +72,15 @@ func (mr *MockManagerMockRecorder) GetStatus(ctx, name, namespace, kernelVersion
 }
 
 // Sync mocks base method.
-func (m *MockManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner v1.Object, action v1beta1.BuildOrSignAction) error {
+func (m *MockManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, action v1beta1.BuildOrSignAction, owner v1.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Sync", ctx, mld, pushImage, owner, action)
+	ret := m.ctrl.Call(m, "Sync", ctx, mld, pushImage, action, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mld, pushImage, owner, action any) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mld, pushImage, action, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mld, pushImage, owner, action)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mld, pushImage, action, owner)
 }

--- a/internal/buildsign/pod/manager.go
+++ b/internal/buildsign/pod/manager.go
@@ -63,7 +63,7 @@ func (pm *podManager) GetStatus(ctx context.Context, name, namespace, kernelVers
 	return kmmv1beta1.BuildOrSignStatus(""), nil
 }
 
-func (pm *podManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner metav1.Object, action kmmv1beta1.BuildOrSignAction) error {
+func (pm *podManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) error {
 	logger := log.FromContext(ctx)
 	var (
 		podType     string

--- a/internal/buildsign/pod/manager_test.go
+++ b/internal/buildsign/pod/manager_test.go
@@ -134,12 +134,12 @@ var _ = Describe("Sync", func() {
 	It("MakePodTemplate failed", func() {
 		By("test build action")
 		mockMaker.EXPECT().MakePodTemplate(ctx, testMLD, &testMBSC, true).Return(nil, fmt.Errorf("some error"))
-		err := mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.BuildImage)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 
 		By("test sign action")
 		mockSigner.EXPECT().MakePodTemplate(ctx, testMLD, &testMBSC, true).Return(nil, fmt.Errorf("some error"))
-		err = mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.SignImage)
+		err = mgr.Sync(ctx, testMLD, true, kmmv1beta1.SignImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -149,7 +149,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, PodTypeBuild, &testMBSC).
 				Return(nil, fmt.Errorf("some error")),
 		)
-		err := mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.BuildImage)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -161,7 +161,7 @@ var _ = Describe("Sync", func() {
 				Return(nil, ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &testTemplate).Return(fmt.Errorf("some error")),
 		)
-		err := mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.BuildImage)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -174,7 +174,7 @@ var _ = Describe("Sync", func() {
 				Return(&testPod, nil),
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&testPod, &testTemplate).Return(false, fmt.Errorf("some error")),
 		)
-		err := mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.BuildImage)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -188,7 +188,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&testPod, &testTemplate).Return(true, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPod).Return(fmt.Errorf("some error")),
 		)
-		err := mgr.Sync(ctx, testMLD, true, &testMBSC, kmmv1beta1.BuildImage)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(BeNil())
 	})
 
@@ -222,7 +222,7 @@ var _ = Describe("Sync", func() {
 		}
 
 	executeTestFunction:
-		err := mgr.Sync(ctx, testMLD, pushImage, &testMBSC, testAction)
+		err := mgr.Sync(ctx, testMLD, pushImage, testAction, &testMBSC)
 		Expect(err).To(BeNil())
 	},
 		Entry("action build, build pod does not exists", true, false, false, true),

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -150,7 +150,7 @@ func (mrh *mbscReconcilerHelper) processImagesSpecs(ctx context.Context, mbscObj
 			continue
 		}
 		mld := createMLD(mbscObj, &imageSpec.ModuleImageSpec)
-		err := mrh.buildSignAPI.Sync(ctx, mld, true, &mbscObj.ObjectMeta, imageSpec.Action)
+		err := mrh.buildSignAPI.Sync(ctx, mld, true, imageSpec.Action, &mbscObj.ObjectMeta)
 		if err != nil {
 			errs = append(errs, err)
 			logger.Info(utils.WarnString("sync for image %s, action %s failed: %v"), imageSpec.Image, imageSpec.Action, err)

--- a/internal/controllers/mbsc_reconciler_test.go
+++ b/internal/controllers/mbsc_reconciler_test.go
@@ -203,9 +203,9 @@ var _ = Describe("processImagesSpecs", func() {
 		gomock.InOrder(
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 1", kmmv1beta1.BuildImage).Return(kmmv1beta1.ActionSuccess),
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 2", kmmv1beta1.SignImage).Return(kmmv1beta1.ActionFailure),
-			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, &testMBSC.ObjectMeta, kmmv1beta1.SignImage).Return(nil),
+			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.SignImage, &testMBSC.ObjectMeta).Return(nil),
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 3", kmmv1beta1.BuildImage).Return(kmmv1beta1.BuildOrSignStatus("")),
-			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, &testMBSC.ObjectMeta, kmmv1beta1.BuildImage).Return(fmt.Errorf("some error")),
+			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).Return(fmt.Errorf("some error")),
 		)
 
 		err := mrh.processImagesSpecs(ctx, &testMBSC)


### PR DESCRIPTION
Moving the "owner" input parameter to be the last parameter in order to be aligned with the rest of buildsign manager APIs