### PR TITLE
Filtering out node heartbeats events for the NMC controller.

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -197,7 +197,7 @@ func (r *NMCReconciler) SetupWithManager(ctx context.Context, mgr manager.Manage
 		Watches(
 			&v1.Node{},
 			handler.EnqueueRequestsFromMapFunc(nodeToNMCMapFunc),
-			builder.WithPredicates(filter.SkipDeletions()),
+			builder.WithPredicates(filter.NMCReconcilerNodePredicate()),
 		).
 		Complete(r)
 }


### PR DESCRIPTION
Node heartbeats are there to let the k8s API server that the node is still connected and functional and if not filtered, it will spam the events the NMC controller gets.

The NMC controller, is trying to garbage collect pods for NMCs that were removed - it causes a constant reconciliation even when no Module, and therefore no NMC, are applied to the cluster.

This commit is fixing this issue.

---

/assign @yevgeny-shnaidman 