### PR TITLE
BootID support for KMM

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -68,6 +68,8 @@ type NodeModuleStatus struct {
 	Config ModuleConfig `json:"config,omitempty"`
 	//+optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	//+optional
+	BootId string `json:"bootId,omitempty"`
 }
 
 // NodeModuleConfigStatus is the most recently observed status of the KMM modules on node.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -241,6 +241,8 @@ spec:
                   state status
                 items:
                   properties:
+                    bootId:
+                      type: string
                     config:
                       properties:
                         containerImage:

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -125,17 +125,17 @@ func (mr *MocknmcReconcilerHelperMockRecorder) RemovePodFinalizers(ctx, nodeName
 }
 
 // SyncStatus mocks base method.
-func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, node *v1.Node) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc)
+	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc, node)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SyncStatus indicates an expected call of SyncStatus.
-func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc, node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc, node)
 }
 
 // UpdateNodeLabels mocks base method.

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -14,7 +14,6 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockNode is a mock of Node interface.
@@ -70,6 +69,20 @@ func (mr *MockNodeMockRecorder) GetNumTargetedNodes(ctx, selector, tolerations a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumTargetedNodes", reflect.TypeOf((*MockNode)(nil).GetNumTargetedNodes), ctx, selector, tolerations)
 }
 
+// IsNodeRebooted mocks base method.
+func (m *MockNode) IsNodeRebooted(node *v1.Node, statusBootId string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNodeRebooted", node, statusBootId)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsNodeRebooted indicates an expected call of IsNodeRebooted.
+func (mr *MockNodeMockRecorder) IsNodeRebooted(node, statusBootId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeRebooted", reflect.TypeOf((*MockNode)(nil).IsNodeRebooted), node, statusBootId)
+}
+
 // IsNodeSchedulable mocks base method.
 func (m *MockNode) IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool {
 	m.ctrl.T.Helper()
@@ -82,20 +95,6 @@ func (m *MockNode) IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration)
 func (mr *MockNodeMockRecorder) IsNodeSchedulable(node, tolerations any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeSchedulable", reflect.TypeOf((*MockNode)(nil).IsNodeSchedulable), node, tolerations)
-}
-
-// NodeBecomeReadyAfter mocks base method.
-func (m *MockNode) NodeBecomeReadyAfter(node *v1.Node, checkTime v10.Time) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NodeBecomeReadyAfter", node, checkTime)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// NodeBecomeReadyAfter indicates an expected call of NodeBecomeReadyAfter.
-func (mr *MockNodeMockRecorder) NodeBecomeReadyAfter(node, checkTime any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeBecomeReadyAfter", reflect.TypeOf((*MockNode)(nil).NodeBecomeReadyAfter), node, checkTime)
 }
 
 // UpdateLabels mocks base method.


### PR DESCRIPTION
KMM loads driver again on node reboot once it detects Node moving from Ready to NotReady back to Ready.
In some cases, like VM node reboot, reboot happens very fast and k8s doesn't report NotReady because of its reporting frequency. Node status, however, has bootID which changes after reboot.
Added support for KMM to detect node reboot using this bootID in cases where reboot happens fast and NotReady state is not reached

Verified that kmm is detecting the boot id change and triggering worker after node is rebooted

```
vm@ubuntu2204:~/kernel-module-management$ kubectl logs -n kube-amd-gpu   amd-gpu-operator-kmm-controller-6fd784d4b4-nfx4z | grep "Detected"
I0328 02:43:46.316244       1 nmc_reconciler.go:348] "Detected BootId change" logger="kmm" controller="NodeModulesConfig" controllerGroup="kmm.sigs.x-k8s.io" controllerKind="NodeModulesConfig" NodeModulesConfig="worker-2" namespace="" name="worker-2" reconcileID="5d8875ad-ed80-4496-a006-49b6502eaacd" module="kube-amd-gpu/test-deviceconfig"
I0328 02:43:56.734541       1 nmc_reconciler.go:348] "Detected BootId change" logger="kmm" controller="NodeModulesConfig" controllerGroup="kmm.sigs.x-k8s.io" controllerKind="NodeModulesConfig" NodeModulesConfig="worker-1" namespace="" name="worker-1" reconcileID="5f2a7d67-b7d9-4596-96d4-6800598add7d" module="kube-amd-gpu/test-deviceconfig"
```

BootId present in nmc:

```
status:
  modules:
  - bootId: ab95e5f6-97e9-4d78-bff6-060f11f15d87
    config:
      containerImage: registry.test.pensando.io:5000/sriram:ubuntu-22.04-5.15.0-134-generic-6.3.2
      imagePullPolicy: ""
      insecurePull: true
      kernelVersion: 5.15.0-134-generic
      modprobe:
        args: {}
        dirName: /opt
        firmwarePath: firmwareDir/updates
        moduleName: amdgpu
        modulesLoadingOrder:
        - amdgpu
        - amdttm
        - amdkcl
    lastTransitionTime: "2025-03-28T02:47:04Z"
    name: test-deviceconfig
    namespace: kube-amd-gpu
    serviceAccountName: amd-gpu-operator-kmm-module-loader
```