### PR TITLE
Reverting a config changes that was merged by mistake.

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,8 +9,8 @@ patches:
 
 images:
 - name: controller
-  newName: quay.io/yshnaidm/kmmo
-  newTag: metrics
+  newName: gcr.io/k8s-staging-kmm/kernel-module-management-operator
+  newTag: latest
 - name: worker
   newName: gcr.io/k8s-staging-kmm/kernel-module-management-worker
   newTag: latest


### PR DESCRIPTION
This is happening when the operator is tested locally with a custom manager image. We probably missed it during review and merged it by accident.

---

/assign @yevgeny-shnaidman 