### PR TITLE
Bumping the Github runners Ubuntu version.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
 
   build-operator-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: Build the KMMO container image
 
@@ -31,7 +31,7 @@ jobs:
           retention-days: 1
 
   build-operator-hub-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: Build the KMMO-hub container image
 
@@ -54,7 +54,7 @@ jobs:
           retention-days: 1
 
   build-signing-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: Build the signing image
 
@@ -77,7 +77,7 @@ jobs:
           retention-days: 1
 
   build-worker-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: Build the worker image
 
@@ -100,7 +100,7 @@ jobs:
           retention-days: 1
 
   build-webhook-image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     name: Build the webhook server image
 
@@ -137,7 +137,7 @@ jobs:
             import_hub_image: true
             script: ./ci/prow/e2e-hub-spoke-incluster-build
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     needs: [build-operator-image, build-operator-hub-image, build-signing-image, build-webhook-image, build-worker-image]
 
@@ -206,7 +206,7 @@ jobs:
 
   operator-upgrade:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: operator-upgrade
     needs: [build-operator-image, build-signing-image, build-webhook-image, build-worker-image]
 

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kmm-kmod-dockerfile
 data:
   dockerfile: |
-    FROM ubuntu:20.04 as builder
+    FROM ubuntu:24.04 as builder
 
     ARG KERNEL_VERSION
 
@@ -25,7 +25,7 @@ data:
 
     RUN KERNEL_SRC_DIR=/usr/src/linux-headers-${KERNEL_VERSION} make all
 
-    FROM ubuntu:20.04
+    FROM ubuntu:24.04
 
     ARG KERNEL_VERSION
 

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -25,7 +25,7 @@ echo "Verify that dummy is loaded"
 minikube ssh -- lsmod | grep dummy
 
 echo "Create a build secret..."
-oc create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+kubectl create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
 
 echo "Add a configmap that contain the kernel module build dockerfile..."
 kubectl apply -f ci/kmm-kmod-dockerfile.yaml

--- a/docs/mkdocs/lab/gke/build-configmap.yaml
+++ b/docs/mkdocs/lab/gke/build-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: build-module
 data:
   dockerfile: |
-    FROM ubuntu:20.04 as builder
+    FROM ubuntu:24.04 as builder
     ARG KERNEL_VERSION=''
     RUN apt-get update && \ 
     apt-get -y upgrade && \
@@ -23,7 +23,7 @@ data:
     WORKDIR kernel-module-management/ci/kmm-kmod 
     RUN make 
     
-    FROM ubuntu:20.04 
+    FROM ubuntu:24.04 
     ARG KERNEL_VERSION
     RUN apt-get -y update && apt-get -y install kmod && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Ubuntu 20.04 is no longer available in Github's CI. Bumping to the latest version available.

---

/assign @yevgeny-shnaidman 