### PR TITLE
Adding support for Modules with no OOT kmod

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -319,7 +319,8 @@ type ModuleSpec struct {
 
 	// ModuleLoader allows overriding some properties of the container that loads the kernel module on the node.
 	// Name and image are ignored and are set automatically by the KMM Operator.
-	ModuleLoader ModuleLoaderSpec `json:"moduleLoader"`
+	// +optional
+	ModuleLoader *ModuleLoaderSpec `json:"moduleLoader,omitempty"`
 
 	// ImageRepoSecret is an optional secret that is used to pull both the module loader and the device plugin, and
 	// to push the resulting image from the module loader build, if enabled.
@@ -351,7 +352,7 @@ type ModuleStatus struct {
 	// if it was deployed during reconciliation
 	DevicePlugin DaemonSetStatus `json:"devicePlugin,omitempty"`
 	// ModuleLoader contains the status of the ModuleLoader daemonset
-	ModuleLoader DaemonSetStatus `json:"moduleLoader"`
+	ModuleLoader DaemonSetStatus `json:"moduleLoader,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -730,7 +730,11 @@ func (in *ModuleSpec) DeepCopyInto(out *ModuleSpec) {
 		*out = new(DevicePluginSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.ModuleLoader.DeepCopyInto(&out.ModuleLoader)
+	if in.ModuleLoader != nil {
+		in, out := &in.ModuleLoader, &out.ModuleLoader
+		*out = new(ModuleLoaderSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ImageRepoSecret != nil {
 		in, out := &in.ImageRepoSecret, &out.ImageRepoSecret
 		*out = new(v1.LocalObjectReference)

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2728,7 +2728,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - moduleLoader
                 - selector
                 type: object
               selector:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2704,7 +2704,6 @@ spec:
                   type: object
                 type: array
             required:
-            - moduleLoader
             - selector
             type: object
           status:
@@ -2745,8 +2744,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-            required:
-            - moduleLoader
             type: object
         type: object
     served: true

--- a/internal/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler_test.go
@@ -272,7 +272,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			},
 			Spec: v1beta1.ManagedClusterModuleSpec{
 				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 						Container: kmmv1beta1.ModuleLoaderContainerSpec{
 							Build: &kmmv1beta1.Build{},
 						},

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -100,6 +100,11 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 		return ctrl.Result{}, fmt.Errorf("failed to set finalizer on Module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
+	if mod.Spec.ModuleLoader == nil {
+		logger.Info("ModuleLoader is not defined, skipping loading kernel module")
+		return ctrl.Result{}, nil
+	}
+
 	// get nodes targeted by selector
 	targetedNodes, err := mr.nodeAPI.GetNodesListBySelector(ctx, mod.Spec.Selector, mod.Spec.Tolerations)
 	if err != nil {

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -51,6 +51,9 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 
 		mod = &kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: namespace},
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
 		}
 
 		mr = &ModuleReconciler{
@@ -208,6 +211,20 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		)
 
 		res, err := mr.Reconcile(ctx, mod)
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Good flow, should not load kernel module when moduleLoader is missing", func() {
+		modWithoutModuleLoader := mod
+		modWithoutModuleLoader.Spec.ModuleLoader = nil
+		gomock.InOrder(
+			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+		)
+
+		res, err := mr.Reconcile(ctx, modWithoutModuleLoader)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -184,7 +184,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
 				SpokeNamespace: spokeNamespace,
 				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 						Container: kmmv1beta1.ModuleLoaderContainerSpec{
 							Build: &kmmv1beta1.Build{},
 							Sign:  &kmmv1beta1.Sign{},
@@ -247,7 +247,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 		}
 
 		expectedModuleSpec := kmmv1beta1.ModuleSpec{
-			ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+			ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 				Container: kmmv1beta1.ModuleLoaderContainerSpec{
 					Build: nil,
 					Sign:  nil,

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -30,6 +30,7 @@ var _ = Describe("GetModuleLoaderDataForKernel", func() {
 		kh = NewMockkernelMapperHelperAPI(ctrl)
 		km = &kernelMapper{helper: kh}
 		mod = kmmv1beta1.Module{}
+		mod.Spec.ModuleLoader = &kmmv1beta1.ModuleLoaderSpec{}
 	})
 
 	AfterEach(func() {
@@ -166,8 +167,8 @@ var _ = Describe("prepareModuleLoaderData", func() {
 		mockCombiner = NewMockCombiner(ctrl)
 		kh = newKernelMapperHelper(mockCombiner)
 		mod = kmmv1beta1.Module{}
-		mod.Spec.ModuleLoader.Container.ContainerImage = "spec container image"
-		mod.Spec.ModuleLoader.Container.ImagePullPolicy = "Always"
+		ModuleLoader := kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{ContainerImage: "spec container image", ImagePullPolicy: "Always"}}
+		mod.Spec.ModuleLoader = &ModuleLoader
 		mapping = kmmv1beta1.KernelMapping{}
 	})
 

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -51,7 +51,7 @@ func TestPreflight(t *testing.T) {
 				Name: moduleName,
 			},
 			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 					Container: kmmv1beta1.ModuleLoaderContainerSpec{
 						Modprobe: kmmv1beta1.ModprobeSpec{
 							ModuleName: "simple-kmod",


### PR DESCRIPTION
When KMM is used by 3rd party vendor operators, they need an option to configure KMM Module to not load OOT kernel driver, but use the in-tree one, and just run the device-plugin.
This commit makes moduleLoader in Module cr a pointer, and so making it an optional field.

---

/cc @ybettan @yevgeny-shnaidman 
