### PR TITLE
Removed the `PodType` consts in the `buildsign` package.

### DIFF
--- a/internal/build/pod/maker.go
+++ b/internal/build/pod/maker.go
@@ -90,7 +90,7 @@ func (m *maker) MakePodTemplate(
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-build-",
 			Namespace:    mld.Namespace,
-			Labels:       m.buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, pod.PodTypeBuild),
+			Labels:       m.buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, PodTypeBuild),
 			Annotations:  map[string]string{constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash)},
 			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},

--- a/internal/build/pod/maker_test.go
+++ b/internal/build/pod/maker_test.go
@@ -240,7 +240,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, pod.PodTypeBuild).Return(labels),
+			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, PodTypeBuild).Return(labels),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, true)
@@ -306,7 +306,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			mockBuildSignPodManager.EXPECT().PodLabels(mod.Name, kernelNormalizedVersion, pod.PodTypeBuild).Return(map[string]string{}),
+			mockBuildSignPodManager.EXPECT().PodLabels(mod.Name, kernelNormalizedVersion, PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, pushImage)
@@ -385,7 +385,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, pod.PodTypeBuild).Return(map[string]string{}),
+			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, false)
@@ -422,7 +422,7 @@ var _ = Describe("MakePodTemplate", func() {
 					return nil
 				},
 			),
-			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, pod.PodTypeBuild).Return(map[string]string{}),
+			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, PodTypeBuild).Return(map[string]string{}),
 		)
 
 		actual, err := m.MakePodTemplate(ctx, &mld, mld.Owner, true)

--- a/internal/build/pod/manager.go
+++ b/internal/build/pod/manager.go
@@ -17,6 +17,11 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
+const (
+	PodTypeBuild = "build"
+	PodTypeSign  = "sign"
+)
+
 type podManager struct {
 	client              client.Client
 	maker               Maker
@@ -38,7 +43,7 @@ func NewBuildManager(
 }
 
 func (pm *podManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
-	pods, err := pm.buildSignPodManager.GetModulePods(ctx, modName, namespace, pod.PodTypeBuild, owner)
+	pods, err := pm.buildSignPodManager.GetModulePods(ctx, modName, namespace, PodTypeBuild, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get build pods for module %s: %v", modName, err)
 	}
@@ -98,7 +103,7 @@ func (pm *podManager) Sync(
 	}
 
 	p, err := pm.buildSignPodManager.GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-		mld.KernelNormalizedVersion, pod.PodTypeBuild, owner)
+		mld.KernelNormalizedVersion, PodTypeBuild, owner)
 
 	if err != nil {
 		if !errors.Is(err, pod.ErrNoMatchingPod) {

--- a/internal/build/pod/manager_test.go
+++ b/internal/build/pod/manager_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Sync", func() {
 			gomock.InOrder(
 				maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
 				mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-					kernelNormalizedVersion, pod.PodTypeBuild, mld.Owner).Return(&j, nil),
+					kernelNormalizedVersion, PodTypeBuild, mld.Owner).Return(&j, nil),
 				mockBuildSignPodManager.EXPECT().IsPodChanged(&j, &j).Return(false, nil),
 				mockBuildSignPodManager.EXPECT().GetPodStatus(&j).Return(podStatus, nil),
 			)
@@ -230,7 +230,7 @@ var _ = Describe("Sync", func() {
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeBuild, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
+				kernelNormalizedVersion, PodTypeBuild, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &j).Return(errors.New("some error")),
 		)
 
@@ -260,7 +260,7 @@ var _ = Describe("Sync", func() {
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeBuild, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
+				kernelNormalizedVersion, PodTypeBuild, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &j).Return(nil),
 		)
 
@@ -303,7 +303,7 @@ var _ = Describe("Sync", func() {
 		gomock.InOrder(
 			maker.EXPECT().MakePodTemplate(ctx, mld, mld.Owner, true).Return(&newPod, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeBuild, mld.Owner).Return(&j, nil),
+				kernelNormalizedVersion, PodTypeBuild, mld.Owner).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&j, &newPod).Return(true, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &j).Return(nil),
 		)
@@ -370,7 +370,7 @@ var _ = Describe("GarbageCollect", func() {
 			}
 
 			mockBuildSignPodManager.EXPECT().GetModulePods(context.Background(), mod.Name,
-				mod.Namespace, pod.PodTypeBuild, &mod).Return([]v1.Pod{pod1, pod2}, returnedError)
+				mod.Namespace, PodTypeBuild, &mod).Return([]v1.Pod{pod1, pod2}, returnedError)
 			if !expectsErr {
 				if pod1.Status.Phase == v1.PodSucceeded {
 					mockBuildSignPodManager.EXPECT().DeletePod(context.Background(), &pod1).Return(nil)

--- a/internal/buildsign/pod/buildsignpodmanager.go
+++ b/internal/buildsign/pod/buildsignpodmanager.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
@@ -21,9 +22,6 @@ import (
 type Status string
 
 const (
-	PodTypeBuild = "build"
-	PodTypeSign  = "sign"
-
 	StatusCompleted  Status = "completed"
 	StatusCreated    Status = "created"
 	StatusInProgress Status = "in progress"
@@ -213,7 +211,7 @@ func (bspm *buildSignPodManager) MakeBuildResourceTemplate(ctx context.Context, 
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-build-",
 			Namespace:    mld.Namespace,
-			Labels:       bspm.PodLabels(mld.Name, mld.KernelNormalizedVersion, PodTypeBuild),
+			Labels:       bspm.PodLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.BuildImage)),
 			Annotations:  map[string]string{constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash)},
 			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},
@@ -267,7 +265,7 @@ func (bspm *buildSignPodManager) MakeSignResourceTemplate(ctx context.Context, m
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-sign-",
 			Namespace:    mld.Namespace,
-			Labels:       bspm.PodLabels(mld.Name, mld.KernelNormalizedVersion, PodTypeSign),
+			Labels:       bspm.PodLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.SignImage)),
 			Annotations: map[string]string{
 				constants.PodHashAnnotation: fmt.Sprintf("%d", podSpecHash),
 				dockerfileAnnotationKey:     buf.String(),

--- a/internal/buildsign/pod/buildsignpodmanager_test.go
+++ b/internal/buildsign/pod/buildsignpodmanager_test.go
@@ -581,7 +581,7 @@ var _ = Describe("MakeBuildResourceTemplate", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: mld.Name + "-build-",
 				Namespace:    namespace,
-				Labels:       buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, PodTypeBuild),
+				Labels:       buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.BuildImage)),
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         "kmm.sigs.x-k8s.io/v1beta1",
@@ -1024,7 +1024,7 @@ COPY --from=signimage /tmp/signroot/modules/simple-procfs-kmod.ko /modules/simpl
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: mld.Name + "-sign-",
 				Namespace:    namespace,
-				Labels:       buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, PodTypeSign),
+				Labels:       buildSignPodManager.PodLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.SignImage)),
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         "kmm.sigs.x-k8s.io/v1beta1",

--- a/internal/buildsign/pod/manager_test.go
+++ b/internal/buildsign/pod/manager_test.go
@@ -45,7 +45,8 @@ var _ = Describe("GetStatus", func() {
 
 	It("failed flow, GetModulePodByKernel fails", func() {
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
-		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, PodTypeBuild, &testMBSC).
+		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+			string(kmmv1beta1.BuildImage), &testMBSC).
 			Return(nil, fmt.Errorf("some error"))
 
 		status, err := mgr.GetStatus(ctx, mbscName, mbscNamespace, kernelVersion, kmmv1beta1.BuildImage, &testMBSC)
@@ -55,7 +56,8 @@ var _ = Describe("GetStatus", func() {
 
 	It("GetModulePodByKernel returns pod does not exists", func() {
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
-		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, PodTypeBuild, &testMBSC).
+		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+			string(kmmv1beta1.BuildImage), &testMBSC).
 			Return(nil, ErrNoMatchingPod)
 
 		status, err := mgr.GetStatus(ctx, mbscName, mbscNamespace, kernelVersion, kmmv1beta1.BuildImage, &testMBSC)
@@ -67,7 +69,8 @@ var _ = Describe("GetStatus", func() {
 		foundPod := v1.Pod{}
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
 		gomock.InOrder(
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&foundPod, nil),
 			mockBuildSignPodManager.EXPECT().GetPodStatus(&foundPod).Return(Status(""), fmt.Errorf("some error")),
 		)
@@ -81,7 +84,8 @@ var _ = Describe("GetStatus", func() {
 		foundPod := v1.Pod{}
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
 		gomock.InOrder(
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&foundPod, nil),
 			mockBuildSignPodManager.EXPECT().GetPodStatus(&foundPod).Return(podStatus, nil),
 		)
@@ -143,7 +147,8 @@ var _ = Describe("Sync", func() {
 	It("GetModulePodByKernel failed", func() {
 		gomock.InOrder(
 			mockBuildSignPodManager.EXPECT().MakeBuildResourceTemplate(ctx, testMLD, &testMBSC, true).Return(nil, nil),
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(nil, fmt.Errorf("some error")),
 		)
 		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
@@ -154,7 +159,8 @@ var _ = Describe("Sync", func() {
 		testTemplate := v1.Pod{}
 		gomock.InOrder(
 			mockBuildSignPodManager.EXPECT().MakeBuildResourceTemplate(ctx, testMLD, &testMBSC, true).Return(&testTemplate, nil),
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(nil, ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &testTemplate).Return(fmt.Errorf("some error")),
 		)
@@ -167,7 +173,8 @@ var _ = Describe("Sync", func() {
 		testPod := v1.Pod{}
 		gomock.InOrder(
 			mockBuildSignPodManager.EXPECT().MakeBuildResourceTemplate(ctx, testMLD, &testMBSC, true).Return(&testTemplate, nil),
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&testPod, nil),
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&testPod, &testTemplate).Return(false, fmt.Errorf("some error")),
 		)
@@ -180,7 +187,8 @@ var _ = Describe("Sync", func() {
 		testPod := v1.Pod{}
 		gomock.InOrder(
 			mockBuildSignPodManager.EXPECT().MakeBuildResourceTemplate(ctx, testMLD, &testMBSC, true).Return(&testTemplate, nil),
-			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&testPod, nil),
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&testPod, &testTemplate).Return(true, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPod).Return(fmt.Errorf("some error")),
@@ -190,12 +198,10 @@ var _ = Describe("Sync", func() {
 	})
 
 	DescribeTable("check good flow", func(buildAction, podExists, podChanged, pushImage bool) {
-		testAction := kmmv1beta1.BuildImage
 		testPodTemplate := v1.Pod{}
 		existingTestPod := v1.Pod{}
-		podType := PodTypeBuild
+		testAction := kmmv1beta1.BuildImage
 		if !buildAction {
-			podType = PodTypeSign
 			testAction = kmmv1beta1.SignImage
 		}
 
@@ -208,7 +214,8 @@ var _ = Describe("Sync", func() {
 		if !podExists {
 			getPodError = ErrNoMatchingPod
 		}
-		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion, podType, &testMBSC).Return(&existingTestPod, getPodError)
+		mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+			string(testAction), &testMBSC).Return(&existingTestPod, getPodError)
 		if !podExists {
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &testPodTemplate).Return(nil)
 			goto executeTestFunction
@@ -259,7 +266,8 @@ var _ = Describe("GarbageCollect", func() {
 	testMBSC := kmmv1beta1.ModuleBuildSignConfig{}
 
 	It("failed to get module pods", func() {
-		mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC).Return(nil, fmt.Errorf("some error"))
+		mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace,
+			string(kmmv1beta1.BuildImage), &testMBSC).Return(nil, fmt.Errorf("some error"))
 
 		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
@@ -272,7 +280,7 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		gomock.InOrder(
-			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeSign, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, string(kmmv1beta1.SignImage), &testMBSC).
 				Return([]v1.Pod{testPod}, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPod).Return(fmt.Errorf("some error")),
 		)
@@ -304,7 +312,7 @@ var _ = Describe("GarbageCollect", func() {
 		}
 		returnedPods := []v1.Pod{testPodSuccess, testPodFailure, testPodRunning, testPodUnknown, testPodPending}
 		gomock.InOrder(
-			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, PodTypeBuild, &testMBSC).
+			mockBuildSignPodManager.EXPECT().GetModulePods(ctx, mbscName, mbscNamespace, string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(returnedPods, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &testPodSuccess).Return(nil),
 		)

--- a/internal/controllers/build_sign_events_reconciler.go
+++ b/internal/controllers/build_sign_events_reconciler.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/kubernetes-sigs/kernel-module-management/internal/buildsign/pod"
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/meta"
 	"golang.org/x/exp/maps"
@@ -168,7 +168,7 @@ func (r *JobEventReconciler) Reconcile(ctx context.Context, pod *v1.Pod) (reconc
 var jobEventPredicate = predicate.NewPredicateFuncs(func(obj client.Object) bool {
 	label := obj.GetLabels()[constants.PodType]
 
-	return (label == pod.PodTypeBuild || label == pod.PodTypeSign) &&
+	return (label == string(kmmv1beta1.BuildImage) || label == string(kmmv1beta1.SignImage)) &&
 		controllerutil.ContainsFinalizer(obj, constants.JobEventFinalizer)
 })
 

--- a/internal/controllers/build_sign_events_reconciler_test.go
+++ b/internal/controllers/build_sign_events_reconciler_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	kmmv1beta2 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta2"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/buildsign/pod"
 	testclient "github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/meta"
@@ -161,7 +160,7 @@ var _ = Describe("JobEventReconciler_Reconcile", func() {
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					constants.PodType:            pod.PodTypeBuild,
+					constants.PodType:            string(kmmv1beta1.BuildImage),
 					constants.TargetKernelTarget: kernelVersion,
 				},
 				OwnerReferences: []metav1.OwnerReference{or},
@@ -185,7 +184,7 @@ var _ = Describe("JobEventReconciler_Reconcile", func() {
 
 		events := closeAndGetAllEvents(fakeRecorder.Events)
 		Expect(events).To(HaveLen(1))
-		Expect(events[0]).To(ContainSubstring("Normal BuildCreated Build created for kernel " + kernelVersion))
+		Expect(events[0]).To(ContainSubstring("Normal BuildimageCreated Buildimage created for kernel " + kernelVersion))
 	})
 
 	It("should do nothing if the annotation is already there and the pod is still running", func() {
@@ -194,7 +193,7 @@ var _ = Describe("JobEventReconciler_Reconcile", func() {
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations:     map[string]string{createdAnnotationKey: ""},
-				Labels:          map[string]string{constants.PodType: pod.PodTypeBuild},
+				Labels:          map[string]string{constants.PodType: string(kmmv1beta1.BuildImage)},
 				Namespace:       namespace,
 				OwnerReferences: []metav1.OwnerReference{or},
 			},
@@ -219,7 +218,7 @@ var _ = Describe("JobEventReconciler_Reconcile", func() {
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:          map[string]string{constants.PodType: pod.PodTypeBuild},
+				Labels:          map[string]string{constants.PodType: string(kmmv1beta1.BuildImage)},
 				Finalizers:      []string{constants.JobEventFinalizer},
 				Namespace:       namespace,
 				OwnerReferences: []metav1.OwnerReference{or},
@@ -425,11 +424,11 @@ var _ = Describe("jobEventPredicate", func() {
 				Equal(expectedResult),
 			)
 		},
-		Entry(nil, pod.PodTypeBuild, true, true),
-		Entry(nil, pod.PodTypeSign, true, true),
+		Entry(nil, string(kmmv1beta1.BuildImage), true, true),
+		Entry(nil, string(kmmv1beta1.SignImage), true, true),
 		Entry(nil, "random", true, false),
 		Entry(nil, "", true, false),
-		Entry("finalizer", pod.PodTypeBuild, true, true),
-		Entry("no finalizer", pod.PodTypeBuild, false, false),
+		Entry("finalizer", string(kmmv1beta1.BuildImage), true, true),
+		Entry("no finalizer", string(kmmv1beta1.SignImage), false, false),
 	)
 })

--- a/internal/controllers/job_gc_reconciler.go
+++ b/internal/controllers/job_gc_reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/kubernetes-sigs/kernel-module-management/internal/buildsign/pod"
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -58,7 +58,7 @@ func (r *JobGCReconciler) Reconcile(ctx context.Context, pod *v1.Pod) (reconcile
 }
 
 func (r *JobGCReconciler) SetupWithManager(mgr manager.Manager) error {
-	podTypes := sets.New(pod.PodTypeBuild, pod.PodTypeSign)
+	podTypes := sets.New(string(kmmv1beta1.BuildImage), string(kmmv1beta1.SignImage))
 
 	p := predicate.NewPredicateFuncs(func(object client.Object) bool {
 		return podTypes.Has(

--- a/internal/sign/pod/manager.go
+++ b/internal/sign/pod/manager.go
@@ -17,6 +17,11 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 )
 
+const (
+	PodTypeBuild = "build"
+	PodTypeSign  = "sign"
+)
+
 type signPodManager struct {
 	client              client.Client
 	signer              Signer
@@ -38,7 +43,7 @@ func NewSignPodManager(
 }
 
 func (spm *signPodManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
-	pods, err := spm.buildSignPodManager.GetModulePods(ctx, modName, namespace, pod.PodTypeSign, owner)
+	pods, err := spm.buildSignPodManager.GetModulePods(ctx, modName, namespace, PodTypeSign, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get sign pods for module %s: %v", modName, err)
 	}
@@ -90,7 +95,7 @@ func (spm *signPodManager) Sync(
 	}
 
 	p, err := spm.buildSignPodManager.GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-		mld.KernelNormalizedVersion, pod.PodTypeSign, owner)
+		mld.KernelNormalizedVersion, PodTypeSign, owner)
 	if err != nil {
 		if !errors.Is(err, pod.ErrNoMatchingPod) {
 			return "", fmt.Errorf("error getting the signing pod: %v", err)

--- a/internal/sign/pod/manager_test.go
+++ b/internal/sign/pod/manager_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Sync", func() {
 				mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, "sign").Return(labels),
 				maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
 				mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-					kernelNormalizedVersion, pod.PodTypeSign, mld.Owner).Return(&newPod, nil),
+					kernelNormalizedVersion, PodTypeSign, mld.Owner).Return(&newPod, nil),
 				mockBuildSignPodManager.EXPECT().IsPodChanged(&j, &newPod).Return(false, nil),
 				mockBuildSignPodManager.EXPECT().GetPodStatus(&newPod).Return(podStatus, poderr),
 			)
@@ -242,7 +242,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, "sign").Return(labels),
 			maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeSign, mld.Owner).Return(nil, errors.New("random error")),
+				kernelNormalizedVersion, PodTypeSign, mld.Owner).Return(nil, errors.New("random error")),
 		)
 
 		Expect(
@@ -269,7 +269,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, "sign").Return(labels),
 			maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeSign, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
+				kernelNormalizedVersion, PodTypeSign, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &j).Return(errors.New("unable to create pod")),
 		)
 
@@ -298,7 +298,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, "sign").Return(labels),
 			maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeSign, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
+				kernelNormalizedVersion, PodTypeSign, mld.Owner).Return(nil, pod.ErrNoMatchingPod),
 			mockBuildSignPodManager.EXPECT().CreatePod(ctx, &j).Return(nil),
 		)
 
@@ -328,7 +328,7 @@ var _ = Describe("Sync", func() {
 			mockBuildSignPodManager.EXPECT().PodLabels(mld.Name, kernelNormalizedVersion, "sign").Return(labels),
 			maker.EXPECT().MakePodTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&newPod, nil),
 			mockBuildSignPodManager.EXPECT().GetModulePodByKernel(ctx, mld.Name, mld.Namespace,
-				kernelNormalizedVersion, pod.PodTypeSign, mld.Owner).Return(&newPod, nil),
+				kernelNormalizedVersion, PodTypeSign, mld.Owner).Return(&newPod, nil),
 			mockBuildSignPodManager.EXPECT().IsPodChanged(&newPod, &newPod).Return(true, nil),
 			mockBuildSignPodManager.EXPECT().DeletePod(ctx, &newPod).Return(nil),
 		)
@@ -390,7 +390,7 @@ var _ = Describe("GarbageCollect", func() {
 			}
 
 			mockBuildSignPodManager.EXPECT().GetModulePods(context.Background(), mld.Name, mld.Namespace,
-				pod.PodTypeSign, mld.Owner).Return([]v1.Pod{pod1, pod2}, returnedError)
+				PodTypeSign, mld.Owner).Return([]v1.Pod{pod1, pod2}, returnedError)
 			if !expectsErr {
 				if pod1.Status.Phase == v1.PodSucceeded {
 					mockBuildSignPodManager.EXPECT().DeletePod(context.Background(), &pod1).Return(nil)


### PR DESCRIPTION
We can directly use the API's `BuildImage` and `SignImage`. No need to use local consts and do the translation.

---

/assign @yevgeny-shnaidman 