### PR TITLE
Adding SkipWaitMissingImage field to MIC Spec

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -50,6 +50,10 @@ type ModuleImageSpec struct {
 	// +optional
 	Sign *Sign `json:"sign,omitempty"`
 
+	// SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+	// in case Build andSign not define, and report the image as DoesNotExist
+	SkipWaitMissingImage bool `json:"skipWaitMissingImage,omitempty"`
+
 	// +optional
 	// RegistryTLS set the TLS configs for accessing the registry of the image.
 	RegistryTLS *TLSOptions `json:"registryTLS,omitempty"`

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -239,6 +239,11 @@ spec:
                       - certSecret
                       - keySecret
                       type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
                   required:
                   - action
                   - image

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -234,6 +234,11 @@ spec:
                       - certSecret
                       - keySecret
                       type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
                   required:
                   - image
                   - kernelVersion


### PR DESCRIPTION
Currently, in case image is missing and Build and Sign sections are not defined, MIC controller will keep the image puller pod running and waiting till the images appears. This means that pushing the mising image into the repo will cause the image puller to succeed and the KMM flow will continue running without any need for additional user action. The new field, if set to true, will cause the MIC to report the image as missing and abort the image puller pod (in case Build and Sign sections are not defined). Currently it will be used in the Preflight flow