### PR TITLE
Allow KMM to be installed on worker nodes if there is no better choice.

### DIFF
--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -26,16 +26,16 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
+          - weight: 1
+            preference:
+              matchExpressions:
               - key: node-role.kubernetes.io/master
-                operator: Exists
-            - matchExpressions:
-              - key: kmm.node.kubernetes.io/control-plane
                 operator: Exists
       securityContext:
         runAsNonRoot: true

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -20,17 +20,17 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
-              - matchExpressions:
-                  - key: kmm.node.kubernetes.io/control-plane
-                    operator: Exists
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
Some installations of k8s doesn't allow deploying workloads on the control-plane nodes or the control-plane isn't accessible at all.

In these installs, the worker nodes do not have the node-role.kubernetes.io/control-plane or node-role.kubernetes.io/master labels. Because the worker nodes do not have these labels the Kernel Module Management operator will not run out of the box.

This commit changes the nodeAffinity to
preferredDuringSchedulingIgnoredDuringExecution to solve this issue.

---

/assign @yevgeny-shnaidman 