### PR TITLE
Update kmod_image.md

### DIFF
--- a/docs/mkdocs/documentation/kmod_image.md
+++ b/docs/mkdocs/documentation/kmod_image.md
@@ -141,7 +141,7 @@ COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /o
 COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_b.ko /opt/lib/modules/${KERNEL_FULL_VERSION}/
 
 # Create the symbolic link
-RUN ln -s /lib/modules/${KERNEL_FULL_VERSION} /opt/lib/modules/${KERNEL_FULL_VERSION}/host
+RUN ln -s /usr/lib/modules/${KERNEL_FULL_VERSION} /opt/lib/modules/${KERNEL_FULL_VERSION}/host
 
 RUN depmod -b /opt ${KERNEL_FULL_VERSION}
 ```


### PR DESCRIPTION
Keep module location consistent.  This isn't the most critical thing because `/lib/modules` should be a symlink to `/usr/lib/modules`, but might as well be consistent with the rest of the docs.