### PR TITLE
Gathering kmm RBAC annotations in Module controller

### DIFF
--- a/internal/controllers/build_sign_reconciler.go
+++ b/internal/controllers/build_sign_reconciler.go
@@ -64,13 +64,6 @@ func NewBuildSignReconciler(
 	}
 }
 
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=pods,verbs=create;list;watch;delete
-
 // Reconcile lists all nodes and looks for kernels that match its mappings.
 // For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image
 // on the nodes with a compatible kernel.

--- a/internal/controllers/device_plugin_pod_reconciler.go
+++ b/internal/controllers/device_plugin_pod_reconciler.go
@@ -18,9 +18,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-//+kubebuilder:rbac:groups="core",resources=pods,verbs=get;patch;list;watch
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
-
 const DevicePluginPodReconcilerName = "DevicePluginPod"
 
 type DevicePluginPodReconciler struct {

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -79,12 +79,6 @@ func (r *DevicePluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 }
 
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-
 func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (ctrl.Result, error) {
 	res := ctrl.Result{}
 

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -63,12 +63,6 @@ func (r *mbscReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 }
 
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=get;list;watch;update;patch;create
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=pods,verbs=create;list;watch;delete
-
 func (r *mbscReconciler) Reconcile(ctx context.Context, mbscObj *kmmv1beta1.ModuleBuildSignConfig) (ctrl.Result, error) {
 	res := ctrl.Result{}
 

--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -63,9 +63,6 @@ func (r *micReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 }
 
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs,verbs=get;list;watch;patch;create;delete
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/status,verbs=get;update;patch
-
 func (r *micReconciler) Reconcile(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig) (ctrl.Result, error) {
 	res := ctrl.Result{}
 	if micObj.GetDeletionTimestamp() != nil {

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -32,9 +32,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-//+kubebuilder:rbac:groups="core",resources=namespaces,verbs=get;list;patch;watch
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
+//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;patch;watch
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;patch
+//+kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;get;list;patch;watch
+//+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=get;list;watch;update;patch;create
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs,verbs=get;list;watch;patch;create;delete
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create;delete
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs/status,verbs=patch
 
 const (
 	ModuleReconcilerName = "ModuleReconciler"

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -37,13 +37,6 @@ const (
 	NodeModulesConfigReconcilerName = "NodeModulesConfig"
 )
 
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs/status,verbs=patch
-//+kubebuilder:rbac:groups="core",resources=pods,verbs=create;delete;get;list;watch
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch
-
 type NMCReconciler struct {
 	client     client.Client
 	helper     nmcReconcilerHelper

--- a/internal/controllers/node_kernel_clusterclaim.go
+++ b/internal/controllers/node_kernel_clusterclaim.go
@@ -21,10 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;list;watch
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
-//+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
-
 const (
 	NodeKernelClusterClaimReconcilerName = "NodeKernelClusterClaim"
 )

--- a/internal/controllers/node_label_module_version_reconciler.go
+++ b/internal/controllers/node_label_module_version_reconciler.go
@@ -16,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-//+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch;patch
-
 // this struct contains all the version labels related to a specific Module
 type modulesVersionLabels struct {
 	name                     string


### PR DESCRIPTION
Until now, RBAC annotations under internal/controllers and internal/controllers/hub were scattered across multiple controller files.

With this commit, the annotations are now centralized only in the Module controller and the MCM controller.

This change addresses the issue where annotations spread across various controllers are applied only to KMM and not to KMM-hub—because all controllers except MCM reside in internal/controllers, and RBAC generation for KMM-hub only scans internal/controllers/hub.

---

/assign @ybettan 
/cc @yevgeny-shnaidman 