### PR TITLE
Change Preflight VerifactionStatus and VerifactionStage definitions

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -25,13 +25,11 @@ import (
 )
 
 const (
-	VerificationTrue          = v1beta2.VerificationTrue
-	VerificationFalse         = v1beta2.VerificationFalse
-	VerificationStageImage    = v1beta2.VerificationStageImage
-	VerificationStageBuild    = v1beta2.VerificationStageBuild
-	VerificationStageSign     = v1beta2.VerificationStageSign
-	VerificationStageRequeued = v1beta2.VerificationStageRequeued
-	VerificationStageDone     = v1beta2.VerificationStageDone
+	VerificationSuccess    = v1beta2.VerificationSuccess
+	VerificationFailure    = v1beta2.VerificationFailure
+	VerificationInProgress = v1beta2.VerificationInProgress
+	VerificationStageImage = v1beta2.VerificationStageImage
+	VerificationStageDone  = v1beta2.VerificationStageDone
 )
 
 // PreflightValidationSpec describes the desired state of the resource, such as the kernel version

--- a/api/v1beta2/preflightvalidation_types.go
+++ b/api/v1beta2/preflightvalidation_types.go
@@ -21,13 +21,11 @@ import (
 )
 
 const (
-	VerificationTrue          string = "True"
-	VerificationFalse         string = "False"
-	VerificationStageImage    string = "Image"
-	VerificationStageBuild    string = "Build"
-	VerificationStageSign     string = "Sign"
-	VerificationStageRequeued string = "Requeued"
-	VerificationStageDone     string = "Done"
+	VerificationSuccess    string = "Success"
+	VerificationFailure    string = "Failure"
+	VerificationInProgress string = "InProgress"
+	VerificationStageImage string = "Image"
+	VerificationStageDone  string = "Done"
 )
 
 // PreflightValidationSpec describes the desired state of the resource, such as the kernel version
@@ -50,7 +48,7 @@ type CRBaseStatus struct {
 	// error (error during verification process), unknown (verification has not started yet)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=True;False
+	// +kubebuilder:validation:Enum=Success;Failure;InProgress
 	VerificationStatus string `json:"verificationStatus"`
 
 	// StatusReason contains a string describing the status source.
@@ -61,7 +59,7 @@ type CRBaseStatus struct {
 	// image (image existence verification), build(build process verification)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build;Sign;Requeued;Done
+	// +kubebuilder:validation:Enum=Image;Done
 	VerificationStage string `json:"verificationStage"`
 
 	// LastTransitionTime is the last time the CR status transitioned from one status to another.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -83,9 +83,6 @@ spec:
                         image (image existence verification), build(build process verification)
                       enum:
                       - Image
-                      - Build
-                      - Sign
-                      - Requeued
                       - Done
                       type: string
                     verificationStatus:
@@ -93,8 +90,9 @@ spec:
                         Status of Module CR verification: true (verified), false (verification failed),
                         error (error during verification process), unknown (verification has not started yet)
                       enum:
-                      - "True"
-                      - "False"
+                      - Success
+                      - Failure
+                      - InProgress
                       type: string
                   required:
                   - lastTransitionTime
@@ -186,9 +184,6 @@ spec:
                         image (image existence verification), build(build process verification)
                       enum:
                       - Image
-                      - Build
-                      - Sign
-                      - Requeued
                       - Done
                       type: string
                     verificationStatus:
@@ -196,8 +191,9 @@ spec:
                         Status of Module CR verification: true (verified), false (verification failed),
                         error (error during verification process), unknown (verification has not started yet)
                       enum:
-                      - "True"
-                      - "False"
+                      - Success
+                      - Failure
+                      - InProgress
                       type: string
                   required:
                   - lastTransitionTime


### PR DESCRIPTION
Since preflight is moving to MIC/MBSC implementation, the preflight implementation is also changing. MIC is taking over all the handling of build/sign and image verification, so we only need one stage: Image, and the status is now becoming InProgress/Success/Failure