### PR TITLE
propgate the pull policy from MOdule to ImagePuller pod

### DIFF
--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -230,7 +230,8 @@ func (rh *managedClusterModuleReconcilerHelper) setMicAsDesired(ctx context.Cont
 
 	micName := mcm.Name + "-" + clusterName
 	micNamespace := rh.clusterAPI.GetDefaultArtifactsNamespace()
-	if err := rh.micAPI.CreateOrPatch(ctx, micName, micNamespace, images, mcm.Spec.ModuleSpec.ImageRepoSecret, mcm); err != nil {
+	if err := rh.micAPI.CreateOrPatch(ctx, micName, micNamespace, images, mcm.Spec.ModuleSpec.ImageRepoSecret,
+		mcm.Spec.ModuleSpec.ModuleLoader.Container.ImagePullPolicy, mcm); err != nil {
 		return fmt.Errorf("failed to createOrPatch MIC %s: %v", micName, err)
 	}
 

--- a/internal/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler_test.go
@@ -33,6 +33,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
@@ -451,7 +452,9 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 				Name: mcmName,
 			},
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				ModuleSpec: kmmv1beta1.ModuleSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+				},
 			},
 		}
 		kernelVersions := []string{"v1.1.1"}
@@ -459,7 +462,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(&api.ModuleLoaderData{}, nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, mcm).
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, v1.PullPolicy(""), mcm).
 				Return(errors.New("some error")),
 		)
 
@@ -475,7 +478,9 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 				Name: mcmName,
 			},
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				ModuleSpec: kmmv1beta1.ModuleSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+				},
 			},
 		}
 		kernelVersions := []string{"v1.1.1", "1.1.2"}
@@ -495,7 +500,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, module.ErrNoMatchingKernelMapping),
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLD, nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), mcm).Return(nil),
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
 		)
 
 		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
@@ -509,7 +514,9 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 				Name: mcmName,
 			},
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				ModuleSpec: kmmv1beta1.ModuleSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+				},
 			},
 		}
 		kernelVersions := []string{"v1.1.1", "1.1.2"}
@@ -539,7 +546,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(expectedMLDs[0], nil),
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLDs[1], nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), mcm).Return(nil),
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
 		)
 
 		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -376,7 +376,8 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 		images = append(images, mis)
 	}
 
-	if err := mrh.micAPI.CreateOrPatch(ctx, mod.Name, mod.Namespace, images, mod.Spec.ImageRepoSecret, mod); err != nil {
+	if err := mrh.micAPI.CreateOrPatch(ctx, mod.Name, mod.Namespace, images, mod.Spec.ImageRepoSecret,
+		mod.Spec.ModuleLoader.Container.ImagePullPolicy, mod); err != nil {
 		errs = append(errs, fmt.Errorf("failed to apply %s/%s MIC: %v", mod.Namespace, mod.Name, err))
 	}
 

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -443,6 +443,7 @@ var _ = Describe("handleMIC", func() {
 				ImageRepoSecret: &v1.LocalObjectReference{
 					Name: "my-secret",
 				},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
 			},
 		}
 		targetedNodes = []v1.Node{
@@ -457,7 +458,7 @@ var _ = Describe("handleMIC", func() {
 	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
 
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).To(HaveOccurred())
@@ -470,7 +471,7 @@ var _ = Describe("handleMIC", func() {
 		mld := &api.ModuleLoaderData{ContainerImage: img}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
 		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
-			mod).Return(errors.New("some error"))
+			v1.PullPolicy(""), mod).Return(errors.New("some error"))
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).To(HaveOccurred())
@@ -478,7 +479,7 @@ var _ = Describe("handleMIC", func() {
 	})
 
 	It("should not do anything if targetedNodes is empty", func() {
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
 		err := mrh.handleMIC(ctx, mod, []v1.Node{})
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -501,7 +502,8 @@ var _ = Describe("handleMIC", func() {
 			RegistryTLS:   mld.RegistryTLS,
 		}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec}, mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec},
+			mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controllers/preflightvalidation_reconciler.go
+++ b/internal/controllers/preflightvalidation_reconciler.go
@@ -230,7 +230,7 @@ func (p *preflightReconcilerHelperImpl) processPreflightValidation(ctx context.C
 			RegistryTLS:   mod.RegistryTLS,
 		}
 		micName := mod.Name + "-preflight"
-		err := p.micAPI.CreateOrPatch(ctx, micName, mod.Namespace, []kmmv1beta1.ModuleImageSpec{micObjSpec}, mod.ImageRepoSecret, pv)
+		err := p.micAPI.CreateOrPatch(ctx, micName, mod.Namespace, []kmmv1beta1.ModuleImageSpec{micObjSpec}, mod.ImageRepoSecret, mod.ImagePullPolicy, pv)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to apply %s/%s MIC: %v", mod.Namespace, mod.Name, err))
 		}

--- a/internal/controllers/preflightvalidation_reconciler_test.go
+++ b/internal/controllers/preflightvalidation_reconciler_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -273,9 +274,11 @@ var _ = Describe("processPreflightValidation", func() {
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace1", "mld name1").Return(v1beta2.VerificationSuccess),
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace2", "mld name2").Return(v1beta2.VerificationFailure),
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace3", "mld name3").Return(v1beta2.VerificationInProgress),
-			mockMic.EXPECT().CreateOrPatch(ctx, "mld name3-preflight", "mld namespace3", []kmmv1beta1.ModuleImageSpec{expectedMic3}, nil, pv).Return(nil),
+			mockMic.EXPECT().CreateOrPatch(ctx, "mld name3-preflight", "mld namespace3", []kmmv1beta1.ModuleImageSpec{expectedMic3},
+				nil, v1.PullPolicy(""), pv).Return(nil),
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace4", "mld name4").Return(""),
-			mockMic.EXPECT().CreateOrPatch(ctx, "mld name4-preflight", "mld namespace4", []kmmv1beta1.ModuleImageSpec{expectedMic4}, nil, pv).Return(nil),
+			mockMic.EXPECT().CreateOrPatch(ctx, "mld name4-preflight", "mld namespace4", []kmmv1beta1.ModuleImageSpec{expectedMic4},
+				nil, v1.PullPolicy(""), pv).Return(nil),
 		)
 
 		err := p.processPreflightValidation(ctx, modsWithMapping, pv)

--- a/internal/mic/mic.go
+++ b/internal/mic/mic.go
@@ -18,7 +18,7 @@ import (
 
 type MIC interface {
 	CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-		imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error
+		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error
 	Get(ctx context.Context, name, ns string) (*kmmv1beta1.ModuleImagesConfig, error)
 	GetModuleImageSpec(micObj *kmmv1beta1.ModuleImagesConfig, image string) *kmmv1beta1.ModuleImageSpec
 	SetImageStatus(micObj *kmmv1beta1.ModuleImagesConfig, image string, status kmmv1beta1.ImageState)
@@ -39,7 +39,7 @@ func New(client client.Client, scheme *runtime.Scheme) MIC {
 }
 
 func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-	imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error {
+	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error {
 
 	logger := log.FromContext(ctx)
 
@@ -55,6 +55,7 @@ func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images 
 		mic.Spec = kmmv1beta1.ModuleImagesConfigSpec{
 			Images:          images,
 			ImageRepoSecret: imageRepoSecret,
+			ImagePullPolicy: pullPolicy,
 		}
 
 		return controllerutil.SetControllerReference(owner, mic, mici.scheme)

--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -45,7 +45,7 @@ var _ = Describe("CreateOrPatch", func() {
 
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, &kmmv1beta1.Module{})
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, "", &kmmv1beta1.Module{})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
@@ -81,7 +81,7 @@ var _ = Describe("CreateOrPatch", func() {
 			},
 		}
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, "", owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -127,7 +127,7 @@ var _ = Describe("CreateOrPatch", func() {
 			},
 		}
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, v1.PullIfNotPresent, owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/internal/mic/mock_mic.go
+++ b/internal/mic/mock_mic.go
@@ -42,17 +42,17 @@ func (m *MockMIC) EXPECT() *MockMICMockRecorder {
 }
 
 // CreateOrPatch mocks base method.
-func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, owner v10.Object) error {
+func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, owner)
+	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, pullPolicy, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOrPatch indicates an expected call of CreateOrPatch.
-func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSecret, owner any) *gomock.Call {
+func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSecret, pullPolicy, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, pullPolicy, owner)
 }
 
 // DoAllImagesExist mocks base method.


### PR DESCRIPTION
imagepuller pod must use the same pull policy as the worker pod, so ImagePullPolicy from from KMM Module must be propagated to the image pulller pod, using MIC CRD and imagepuller interface