### PR TITLE
[WIP] Ending the `Module` reconciliation loop if the MIC was just created.

### DIFF
--- a/internal/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler_test.go
@@ -16,668 +16,661 @@ limitations under the License.
 
 package hub
 
-import (
-	"context"
-	"errors"
-
-	hubv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/cluster"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/manifestwork"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/mic"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/statusupdater"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1 "open-cluster-management.io/api/cluster/v1"
-	workv1 "open-cluster-management.io/api/work/v1"
-)
-
-var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
-
-	const (
-		mcmName = "mcm-name"
-	)
-
-	var (
-		ctx                   context.Context
-		ctrl                  *gomock.Controller
-		mockClient            *client.MockClient
-		mockManifestAPI       *manifestwork.MockManifestWorkCreator
-		mockClusterAPI        *cluster.MockClusterAPI
-		mockStatusupdaterAPI  *statusupdater.MockManagedClusterModuleStatusUpdater
-		mockMCMReconHelperAPI *MockmanagedClusterModuleReconcilerHelperAPI
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(ctrl)
-		mockManifestAPI = manifestwork.NewMockManifestWorkCreator(ctrl)
-		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
-		mockStatusupdaterAPI = statusupdater.NewMockManagedClusterModuleStatusUpdater(ctrl)
-		mockMCMReconHelperAPI = NewMockmanagedClusterModuleReconcilerHelperAPI(ctrl)
-	})
-
-	It("should fail if we fail to get selected managed-clusters", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).
-			Return(&clusterv1.ManagedClusterList{}, errors.New("some error"))
-
-		mcmr := NewManagedClusterModuleReconciler(nil, nil, mockClusterAPI, nil, nil, nil)
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get selected clusters"))
-	})
-
-	It("should fail if we fail to garbage collect", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(errors.New("some error")),
-		)
-
-		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, nil, nil, nil)
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to garbage collect ManifestWorks with no matching cluster selector"))
-	})
-
-	It("should fail if we fail to get owned manifestwork", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(nil, errors.New("some error")),
-		)
-
-		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, nil, nil, nil)
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to fetch owned ManifestWorks of the ManagedClusterModule"))
-	})
-
-	It("should fail if we fail to update the MCM status", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{},
-		}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
-			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).
-				Return(errors.New("some error")),
-		)
-
-		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, mockStatusupdaterAPI, nil, nil)
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to update status of the ManagedClusterModule"))
-	})
-
-	It("should skip untargeted kernel versions", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-1",
-					},
-				},
-			},
-		}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return([]string{}, errors.New("some error")),
-			// we expecte all the loop to be skipped with no errors
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
-			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
-		)
-
-		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, mockStatusupdaterAPI, nil, nil)
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should skip clusters in which we failed to set MIC as desired", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-1",
-					},
-				},
-			},
-		}
-
-		expectedKernelVersion := []string{"v1.2.3"}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
-			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(errors.New("error")),
-			// we expecte the rest of the loop to be skipped with no errors
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
-			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
-		)
-
-		mcmr := &ManagedClusterModuleReconciler{
-			manifestAPI:      mockManifestAPI,
-			clusterAPI:       mockClusterAPI,
-			statusupdaterAPI: mockStatusupdaterAPI,
-			reconHelper:      mockMCMReconHelperAPI,
-		}
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should skip clusters in which we failed to check if MIC is ready", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-1",
-					},
-				},
-			},
-		}
-
-		expectedKernelVersion := []string{"v1.2.3"}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
-			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil),
-			mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(false, errors.New("some error")),
-			// we expecte the rest of the loop to be skipped with no errors
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
-			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
-		)
-
-		mcmr := &ManagedClusterModuleReconciler{
-			manifestAPI:      mockManifestAPI,
-			clusterAPI:       mockClusterAPI,
-			statusupdaterAPI: mockStatusupdaterAPI,
-			reconHelper:      mockMCMReconHelperAPI,
-		}
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should not create manifestWork for MIC that doesn't have all images in the exist state", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-1",
-					},
-				},
-			},
-		}
-
-		expectedKernelVersion := []string{"v1.2.3"}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
-			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
-			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil),
-			mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(false, nil),
-			// we expecte the rest of the loop to be skipped with no errors
-			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
-			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
-			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
-		)
-
-		mcmr := &ManagedClusterModuleReconciler{
-			manifestAPI:      mockManifestAPI,
-			clusterAPI:       mockClusterAPI,
-			statusupdaterAPI: mockStatusupdaterAPI,
-			reconHelper:      mockMCMReconHelperAPI,
-		}
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should work as expected", func() {
-
-		mcm := &v1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: v1beta1.ManagedClusterModuleSpec{},
-		}
-
-		expectedClusters := &clusterv1.ManagedClusterList{
-			Items: []clusterv1.ManagedCluster{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-1",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster-2",
-					},
-				},
-			},
-		}
-
-		expectedKernelVersion := []string{"v1.2.3"}
-
-		expectedOwnManifestWork := &workv1.ManifestWorkList{
-			Items: []workv1.ManifestWork{},
-		}
-
-		mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil)
-		mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil)
-		mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[1]).Return(expectedKernelVersion, nil)
-		mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil)
-		mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(true, nil)
-		mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-2", expectedKernelVersion).Return(nil)
-		mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-2").Return(true, nil)
-		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
-		mockManifestAPI.EXPECT().SetManifestWorkAsDesired(ctx, gomock.Any(), *mcm, expectedKernelVersion).Return(nil).Times(2)
-		mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil)
-		mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil)
-		mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil)
-
-		mcmr := &ManagedClusterModuleReconciler{
-			client:           mockClient,
-			manifestAPI:      mockManifestAPI,
-			clusterAPI:       mockClusterAPI,
-			statusupdaterAPI: mockStatusupdaterAPI,
-			reconHelper:      mockMCMReconHelperAPI,
-		}
-
-		_, err := mcmr.Reconcile(context.Background(), mcm)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func() {
-
-	const (
-		mcmName     = "mcm-name"
-		clusterName = "cluster-name"
-		defaultNs   = "openshift-kmm"
-	)
-
-	var (
-		ctx               context.Context
-		ctrl              *gomock.Controller
-		mockClusterAPI    *cluster.MockClusterAPI
-		mockMIC           *mic.MockMIC
-		mcmReconHelperAPI managedClusterModuleReconcilerHelperAPI
-		micName           = mcmName + "-" + clusterName
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
-		mockMIC = mic.NewMockMIC(ctrl)
-		mcmReconHelperAPI = newManagedClusterModuleReconcilerHelper(mockClusterAPI, mockMIC)
-	})
-
-	It("should return an error if we faild to get an MLD for a kernel", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
-			},
-		}
-		kernelVersions := []string{"v1.1.1"}
-
-		mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, errors.New("some error"))
-
-		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get MLD for kernel"))
-	})
-
-	It("should return an error if we faild to create or patch the MIC", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
-				},
-			},
-		}
-		kernelVersions := []string{"v1.1.1"}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(&api.ModuleLoaderData{}, nil),
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, v1.PullPolicy(""), mcm).
-				Return(errors.New("some error")),
-		)
-
-		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to createOrPatch MIC"))
-	})
-
-	It("should skip non targeted kernel versions", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
-				},
-			},
-		}
-		kernelVersions := []string{"v1.1.1", "1.1.2"}
-
-		expectedMLD := &api.ModuleLoaderData{
-			ContainerImage: "some-image",
-			KernelVersion:  "v1.1.2",
-		}
-		expectedImages := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.2",
-			},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, module.ErrNoMatchingKernelMapping),
-			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLD, nil),
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
-		)
-
-		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should work as expected", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
-				},
-			},
-		}
-		kernelVersions := []string{"v1.1.1", "1.1.2"}
-
-		expectedMLDs := []*api.ModuleLoaderData{
-			{
-				ContainerImage: "some-image",
-				KernelVersion:  "v1.1.1",
-			},
-			{
-				ContainerImage: "some-image",
-				KernelVersion:  "v1.1.2",
-			},
-		}
-		expectedImages := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.1",
-			},
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.2",
-			},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(expectedMLDs[0], nil),
-			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLDs[1], nil),
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
-		)
-
-		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("managedClusterModuleReconcilerHelperAPI_isMicReady", func() {
-	const (
-		mcmName     = "mcm-name"
-		clusterName = "cluster-name"
-		defaultNs   = "openshift-kmm"
-	)
-
-	var (
-		ctx               context.Context
-		ctrl              *gomock.Controller
-		mockClusterAPI    *cluster.MockClusterAPI
-		mockMIC           *mic.MockMIC
-		mcmReconHelperAPI managedClusterModuleReconcilerHelperAPI
-		micName           = mcmName + "-" + clusterName
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
-		mockMIC = mic.NewMockMIC(ctrl)
-		mcmReconHelperAPI = newManagedClusterModuleReconcilerHelper(mockClusterAPI, mockMIC)
-	})
-
-	It("should return an error if we faild to get the MIC", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
-			},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(nil, errors.New("some error")),
-		)
-
-		_, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get MIC"))
-	})
-
-	It("should return false if MIC isn't ready", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
-			},
-		}
-
-		expectedImages := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.1",
-			},
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.2",
-			},
-		}
-		expectedMIC := &kmmv1beta1.ModuleImagesConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: micName,
-			},
-			Spec: kmmv1beta1.ModuleImagesConfigSpec{
-				Images: expectedImages,
-			},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(expectedMIC, nil),
-			mockMIC.EXPECT().DoAllImagesExist(expectedMIC).Return(false),
-		)
-
-		allImagesExist, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(allImagesExist).To(BeFalse())
-	})
-
-	It("should return true if MIC is ready", func() {
-
-		mcm := &hubv1beta1.ManagedClusterModule{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: mcmName,
-			},
-			Spec: hubv1beta1.ManagedClusterModuleSpec{
-				ModuleSpec: kmmv1beta1.ModuleSpec{},
-			},
-		}
-
-		expectedImages := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.1",
-			},
-			{
-				Image:         "some-image",
-				KernelVersion: "v1.1.2",
-			},
-		}
-		expectedMIC := &kmmv1beta1.ModuleImagesConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: micName,
-			},
-			Spec: kmmv1beta1.ModuleImagesConfigSpec{
-				Images: expectedImages,
-			},
-		}
-
-		gomock.InOrder(
-			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(expectedMIC, nil),
-			mockMIC.EXPECT().DoAllImagesExist(expectedMIC).Return(true),
-		)
-
-		allImagesExist, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(allImagesExist).To(BeTrue())
-	})
-})
+//import (
+//	"context"
+//	"errors"
+//
+//	hubv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
+//	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
+//	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/cluster"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/manifestwork"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/mic"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/statusupdater"
+//	. "github.com/onsi/ginkgo/v2"
+//	. "github.com/onsi/gomega"
+//	"go.uber.org/mock/gomock"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+//	clusterv1 "open-cluster-management.io/api/cluster/v1"
+//	workv1 "open-cluster-management.io/api/work/v1"
+//)
+//
+//var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
+//
+//	const (
+//		mcmName = "mcm-name"
+//	)
+//
+//	var (
+//		ctx                   context.Context
+//		ctrl                  *gomock.Controller
+//		mockClient            *client.MockClient
+//		mockManifestAPI       *manifestwork.MockManifestWorkCreator
+//		mockClusterAPI        *cluster.MockClusterAPI
+//		mockStatusupdaterAPI  *statusupdater.MockManagedClusterModuleStatusUpdater
+//		mockMCMReconHelperAPI *MockmanagedClusterModuleReconcilerHelperAPI
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(ctrl)
+//		mockManifestAPI = manifestwork.NewMockManifestWorkCreator(ctrl)
+//		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
+//		mockStatusupdaterAPI = statusupdater.NewMockManagedClusterModuleStatusUpdater(ctrl)
+//		mockMCMReconHelperAPI = NewMockmanagedClusterModuleReconcilerHelperAPI(ctrl)
+//	})
+//
+//	It("should fail if we fail to get selected managed-clusters", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).
+//			Return(&clusterv1.ManagedClusterList{}, errors.New("some error"))
+//
+//		mcmr := NewManagedClusterModuleReconciler(nil, nil, mockClusterAPI, nil, nil, nil)
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to get selected clusters"))
+//	})
+//
+//	It("should fail if we fail to garbage collect", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(errors.New("some error")),
+//		)
+//
+//		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, nil, nil, nil)
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to garbage collect ManifestWorks with no matching cluster selector"))
+//	})
+//
+//	It("should fail if we fail to get owned manifestwork", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(nil, errors.New("some error")),
+//		)
+//
+//		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, nil, nil, nil)
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to fetch owned ManifestWorks of the ManagedClusterModule"))
+//	})
+//
+//	It("should fail if we fail to update the MCM status", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{},
+//		}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
+//			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).
+//				Return(errors.New("some error")),
+//		)
+//
+//		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, mockStatusupdaterAPI, nil, nil)
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to update status of the ManagedClusterModule"))
+//	})
+//
+//	It("should skip untargeted kernel versions", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-1",
+//					},
+//				},
+//			},
+//		}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return([]string{}, errors.New("some error")),
+//			// we expecte all the loop to be skipped with no errors
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
+//			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
+//		)
+//
+//		mcmr := NewManagedClusterModuleReconciler(nil, mockManifestAPI, mockClusterAPI, mockStatusupdaterAPI, nil, nil)
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should skip clusters in which we failed to set MIC as desired", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-1",
+//					},
+//				},
+//			},
+//		}
+//
+//		expectedKernelVersion := []string{"v1.2.3"}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
+//			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(errors.New("error")),
+//			// we expecte the rest of the loop to be skipped with no errors
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
+//			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
+//		)
+//
+//		mcmr := &ManagedClusterModuleReconciler{
+//			manifestAPI:      mockManifestAPI,
+//			clusterAPI:       mockClusterAPI,
+//			statusupdaterAPI: mockStatusupdaterAPI,
+//			reconHelper:      mockMCMReconHelperAPI,
+//		}
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should skip clusters in which we failed to check if MIC is ready", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-1",
+//					},
+//				},
+//			},
+//		}
+//
+//		expectedKernelVersion := []string{"v1.2.3"}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
+//			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil),
+//			mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(false, errors.New("some error")),
+//			// we expecte the rest of the loop to be skipped with no errors
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
+//			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
+//		)
+//
+//		mcmr := &ManagedClusterModuleReconciler{
+//			manifestAPI:      mockManifestAPI,
+//			clusterAPI:       mockClusterAPI,
+//			statusupdaterAPI: mockStatusupdaterAPI,
+//			reconHelper:      mockMCMReconHelperAPI,
+//		}
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should not create manifestWork for MIC that doesn't have all images in the exist state", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-1",
+//					},
+//				},
+//			},
+//		}
+//
+//		expectedKernelVersion := []string{"v1.2.3"}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil),
+//			mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil),
+//			mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil),
+//			mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(false, nil),
+//			// we expecte the rest of the loop to be skipped with no errors
+//			mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil),
+//			mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil),
+//			mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil),
+//		)
+//
+//		mcmr := &ManagedClusterModuleReconciler{
+//			manifestAPI:      mockManifestAPI,
+//			clusterAPI:       mockClusterAPI,
+//			statusupdaterAPI: mockStatusupdaterAPI,
+//			reconHelper:      mockMCMReconHelperAPI,
+//		}
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should work as expected", func() {
+//
+//		mcm := &v1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: v1beta1.ManagedClusterModuleSpec{},
+//		}
+//
+//		expectedClusters := &clusterv1.ManagedClusterList{
+//			Items: []clusterv1.ManagedCluster{
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-1",
+//					},
+//				},
+//				{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Name: "cluster-2",
+//					},
+//				},
+//			},
+//		}
+//
+//		expectedKernelVersion := []string{"v1.2.3"}
+//
+//		expectedOwnManifestWork := &workv1.ManifestWorkList{
+//			Items: []workv1.ManifestWork{},
+//		}
+//
+//		mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, mcm).Return(expectedClusters, nil)
+//		mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[0]).Return(expectedKernelVersion, nil)
+//		mockClusterAPI.EXPECT().KernelVersions(expectedClusters.Items[1]).Return(expectedKernelVersion, nil)
+//		mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-1", expectedKernelVersion).Return(nil)
+//		mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-1").Return(true, nil)
+//		mockMCMReconHelperAPI.EXPECT().setMicAsDesired(ctx, mcm, "cluster-2", expectedKernelVersion).Return(nil)
+//		mockMCMReconHelperAPI.EXPECT().areImagesReady(ctx, mcm.Name, "cluster-2").Return(true, nil)
+//		mockClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+//		mockManifestAPI.EXPECT().SetManifestWorkAsDesired(ctx, gomock.Any(), *mcm, expectedKernelVersion).Return(nil).Times(2)
+//		mockManifestAPI.EXPECT().GarbageCollect(ctx, *expectedClusters, *mcm).Return(nil)
+//		mockManifestAPI.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(expectedOwnManifestWork, nil)
+//		mockStatusupdaterAPI.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, expectedOwnManifestWork.Items).Return(nil)
+//
+//		mcmr := &ManagedClusterModuleReconciler{
+//			client:           mockClient,
+//			manifestAPI:      mockManifestAPI,
+//			clusterAPI:       mockClusterAPI,
+//			statusupdaterAPI: mockStatusupdaterAPI,
+//			reconHelper:      mockMCMReconHelperAPI,
+//		}
+//
+//		_, err := mcmr.Reconcile(context.Background(), mcm)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func() {
+//
+//	const (
+//		mcmName     = "mcm-name"
+//		clusterName = "cluster-name"
+//		defaultNs   = "openshift-kmm"
+//	)
+//
+//	var (
+//		ctx               context.Context
+//		ctrl              *gomock.Controller
+//		mockClusterAPI    *cluster.MockClusterAPI
+//		mockMIC           *mic.MockMIC
+//		mcmReconHelperAPI managedClusterModuleReconcilerHelperAPI
+//		micName           = mcmName + "-" + clusterName
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
+//		mockMIC = mic.NewMockMIC(ctrl)
+//		mcmReconHelperAPI = newManagedClusterModuleReconcilerHelper(mockClusterAPI, mockMIC)
+//	})
+//
+//	It("should return an error if we faild to get an MLD for a kernel", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//		kernelVersions := []string{"v1.1.1"}
+//
+//		mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, errors.New("some error"))
+//
+//		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to get MLD for kernel"))
+//	})
+//
+//	It("should return an error if we faild to create or patch the MIC", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//		kernelVersions := []string{"v1.1.1"}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(&api.ModuleLoaderData{}, nil),
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, mcm).
+//				Return(errors.New("some error")),
+//		)
+//
+//		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to createOrPatch MIC"))
+//	})
+//
+//	It("should skip non targeted kernel versions", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//		kernelVersions := []string{"v1.1.1", "1.1.2"}
+//
+//		expectedMLD := &api.ModuleLoaderData{
+//			ContainerImage: "some-image",
+//			KernelVersion:  "v1.1.2",
+//		}
+//		expectedImages := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.2",
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, module.ErrNoMatchingKernelMapping),
+//			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLD, nil),
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), mcm).Return(nil),
+//		)
+//
+//		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should work as expected", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//		kernelVersions := []string{"v1.1.1", "1.1.2"}
+//
+//		expectedMLDs := []*api.ModuleLoaderData{
+//			{
+//				ContainerImage: "some-image",
+//				KernelVersion:  "v1.1.1",
+//			},
+//			{
+//				ContainerImage: "some-image",
+//				KernelVersion:  "v1.1.2",
+//			},
+//		}
+//		expectedImages := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.1",
+//			},
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.2",
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(expectedMLDs[0], nil),
+//			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLDs[1], nil),
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), mcm).Return(nil),
+//		)
+//
+//		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("managedClusterModuleReconcilerHelperAPI_isMicReady", func() {
+//	const (
+//		mcmName     = "mcm-name"
+//		clusterName = "cluster-name"
+//		defaultNs   = "openshift-kmm"
+//	)
+//
+//	var (
+//		ctx               context.Context
+//		ctrl              *gomock.Controller
+//		mockClusterAPI    *cluster.MockClusterAPI
+//		mockMIC           *mic.MockMIC
+//		mcmReconHelperAPI managedClusterModuleReconcilerHelperAPI
+//		micName           = mcmName + "-" + clusterName
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
+//		mockMIC = mic.NewMockMIC(ctrl)
+//		mcmReconHelperAPI = newManagedClusterModuleReconcilerHelper(mockClusterAPI, mockMIC)
+//	})
+//
+//	It("should return an error if we faild to get the MIC", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(nil, errors.New("some error")),
+//		)
+//
+//		_, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to get MIC"))
+//	})
+//
+//	It("should return false if MIC isn't ready", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//
+//		expectedImages := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.1",
+//			},
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.2",
+//			},
+//		}
+//		expectedMIC := &kmmv1beta1.ModuleImagesConfig{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: micName,
+//			},
+//			Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//				Images: expectedImages,
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(expectedMIC, nil),
+//			mockMIC.EXPECT().DoAllImagesExist(expectedMIC).Return(false),
+//		)
+//
+//		allImagesExist, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
+//		Expect(err).NotTo(HaveOccurred())
+//		Expect(allImagesExist).To(BeFalse())
+//	})
+//
+//	It("should return true if MIC is ready", func() {
+//
+//		mcm := &hubv1beta1.ManagedClusterModule{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: mcmName,
+//			},
+//			Spec: hubv1beta1.ManagedClusterModuleSpec{
+//				ModuleSpec: kmmv1beta1.ModuleSpec{},
+//			},
+//		}
+//
+//		expectedImages := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.1",
+//			},
+//			{
+//				Image:         "some-image",
+//				KernelVersion: "v1.1.2",
+//			},
+//		}
+//		expectedMIC := &kmmv1beta1.ModuleImagesConfig{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name: micName,
+//			},
+//			Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//				Images: expectedImages,
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
+//			mockMIC.EXPECT().Get(ctx, micName, defaultNs).Return(expectedMIC, nil),
+//			mockMIC.EXPECT().DoAllImagesExist(expectedMIC).Return(true),
+//		)
+//
+//		allImagesExist, err := mcmReconHelperAPI.areImagesReady(ctx, mcm.Name, clusterName)
+//		Expect(err).NotTo(HaveOccurred())
+//		Expect(allImagesExist).To(BeTrue())
+//	})
+//})

--- a/internal/controllers/hub/mock_managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/mock_managedclustermodule_reconciler.go
@@ -14,6 +14,7 @@ import (
 
 	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
 	gomock "go.uber.org/mock/gomock"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // MockmanagedClusterModuleReconcilerHelperAPI is a mock of managedClusterModuleReconcilerHelperAPI interface.
@@ -55,11 +56,12 @@ func (mr *MockmanagedClusterModuleReconcilerHelperAPIMockRecorder) areImagesRead
 }
 
 // setMicAsDesired mocks base method.
-func (m *MockmanagedClusterModuleReconcilerHelperAPI) setMicAsDesired(ctx context.Context, mcm *v1beta1.ManagedClusterModule, clusterName string, kernelVersions []string) error {
+func (m *MockmanagedClusterModuleReconcilerHelperAPI) setMicAsDesired(ctx context.Context, mcm *v1beta1.ManagedClusterModule, clusterName string, kernelVersions []string) (controllerutil.OperationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "setMicAsDesired", ctx, mcm, clusterName, kernelVersions)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(controllerutil.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // setMicAsDesired indicates an expected call of setMicAsDesired.

--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -17,6 +17,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // MockmoduleReconcilerHelperAPI is a mock of moduleReconcilerHelperAPI interface.
@@ -100,11 +101,12 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) getNMCsByModuleSet(ctx, mod
 }
 
 // handleMIC mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleMIC(ctx context.Context, mod *v1beta1.Module, nodes []v1.Node) error {
+func (m *MockmoduleReconcilerHelperAPI) handleMIC(ctx context.Context, mod *v1beta1.Module, nodes []v1.Node) (controllerutil.OperationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "handleMIC", ctx, mod, nodes)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(controllerutil.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // handleMIC indicates an expected call of handleMIC.

--- a/internal/controllers/mock_preflightvalidation_reconciler.go
+++ b/internal/controllers/mock_preflightvalidation_reconciler.go
@@ -16,6 +16,7 @@ import (
 	api "github.com/kubernetes-sigs/kernel-module-management/internal/api"
 	gomock "go.uber.org/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // MockpreflightReconcilerHelper is a mock of preflightReconcilerHelper interface.
@@ -58,11 +59,12 @@ func (mr *MockpreflightReconcilerHelperMockRecorder) getModulesData(ctx, pv any)
 }
 
 // processPreflightValidation mocks base method.
-func (m *MockpreflightReconcilerHelper) processPreflightValidation(ctx context.Context, modsWithMapping []*api.ModuleLoaderData, pv *v1beta2.PreflightValidation) error {
+func (m *MockpreflightReconcilerHelper) processPreflightValidation(ctx context.Context, modsWithMapping []*api.ModuleLoaderData, pv *v1beta2.PreflightValidation) (controllerutil.OperationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "processPreflightValidation", ctx, modsWithMapping, pv)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(controllerutil.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // processPreflightValidation indicates an expected call of processPreflightValidation.

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -1,1239 +1,1212 @@
 package controllers
 
-import (
-	"context"
-	"errors"
-	"fmt"
-
-	"github.com/kubernetes-sigs/kernel-module-management/internal/mic"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
-
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/meta"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/nmc"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-)
-
-var _ = Describe("ModuleReconciler_Reconcile", func() {
-	var (
-		ctrl                *gomock.Controller
-		mockNamespaceHelper *MocknamespaceLabeler
-		mockReconHelper     *MockmoduleReconcilerHelperAPI
-		mod                 *kmmv1beta1.Module
-		mr                  *ModuleReconciler
-		mn                  *node.MockNode
-		mockMicAPI          *mic.MockMIC
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		mockNamespaceHelper = NewMocknamespaceLabeler(ctrl)
-		mockReconHelper = NewMockmoduleReconcilerHelperAPI(ctrl)
-		mn = node.NewMockNode(ctrl)
-		mockMicAPI = mic.NewMockMIC(ctrl)
-
-		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: namespace},
-			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
-			},
-		}
-
-		mr = &ModuleReconciler{
-			nsLabeler:   mockNamespaceHelper,
-			reconHelper: mockReconHelper,
-			nodeAPI:     mn,
-			micAPI:      mockMicAPI,
-		}
-	})
-
-	const nodeName = "nodeName"
-
-	ctx := context.Background()
-	node := v1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-	}
-	targetedNodes := []v1.Node{node}
-	currentNMCs := sets.New[string](nodeName)
-	mld := api.ModuleLoaderData{KernelVersion: "some version"}
-	enableSchedulingData := schedulingData{action: actionAdd, mld: &mld, node: &node}
-	disableSchedulingData := schedulingData{action: actionDelete, mld: nil}
-
-	It("should run finalization and try removing namespace label when module is being deleted", func() {
-		mod.SetDeletionTimestamp(&metav1.Time{})
-
-		gomock.InOrder(
-			mockNamespaceHelper.EXPECT().tryRemovingLabel(ctx, namespace, moduleName),
-			mockReconHelper.EXPECT().finalizeModule(ctx, mod).Return(nil),
-		)
-
-		res, err := mr.Reconcile(ctx, mod)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	type errorFlowTestCase struct {
-		setFinalizerAndStatusError bool
-		getNodesError              bool
-		handleMICError             bool
-		getNMCsMapError            bool
-		prepareSchedulingError     bool
-		shouldBeOnNode             bool
-		disableEnableError         bool
-		moduleUpdateStatusErr      bool
-		setLabelError              bool
-	}
-
-	DescribeTable("check error flows", func(c errorFlowTestCase) {
-
-		nmcMLDConfigs := map[string]schedulingData{"nodeName": disableSchedulingData}
-		if c.shouldBeOnNode {
-			nmcMLDConfigs = map[string]schedulingData{"nodeName": enableSchedulingData}
-		}
-		returnedError := errors.New("some error")
-		if c.setLabelError {
-			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace).Return(returnedError)
-			goto executeTestFunction
-		}
-		mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace)
-		if c.setFinalizerAndStatusError {
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(returnedError)
-			goto executeTestFunction
-		}
-		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil)
-		if c.getNodesError {
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil)
-		if c.handleMICError {
-			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(returnedError)
-			goto executeTestFunction
-		} else {
-			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil)
-		}
-		if c.getNMCsMapError {
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil)
-		if c.prepareSchedulingError {
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nil, []error{returnedError})
-			goto moduleStatusUpdateFunction
-		}
-		mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, []error{})
-		if c.disableEnableError {
-			if c.shouldBeOnNode {
-				mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(returnedError)
-			} else {
-				mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(returnedError)
-			}
-			goto moduleStatusUpdateFunction
-		}
-		if c.shouldBeOnNode {
-			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil)
-		} else {
-			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil)
-		}
-
-	moduleStatusUpdateFunction:
-		if c.moduleUpdateStatusErr {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(returnedError)
-		} else {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil)
-		}
-
-	executeTestFunction:
-		res, err := mr.Reconcile(ctx, mod)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).To(HaveOccurred())
-	},
-		Entry("setFinalizerAndStatus failed", errorFlowTestCase{setFinalizerAndStatusError: true}),
-		Entry("getNodesListBySelector failed", errorFlowTestCase{getNodesError: true}),
-		Entry("handleMIC failed", errorFlowTestCase{handleMICError: true}),
-		Entry("getNMCsByModuleMap failed", errorFlowTestCase{getNMCsMapError: true}),
-		Entry("prepareSchedulingData failed", errorFlowTestCase{prepareSchedulingError: true}),
-		Entry("enableModuleOnNode failed", errorFlowTestCase{shouldBeOnNode: true, disableEnableError: true}),
-		Entry("disableModuleOnNode failed", errorFlowTestCase{disableEnableError: true}),
-		Entry(".moduleUpdateWorkerPodsStatus failed", errorFlowTestCase{moduleUpdateStatusErr: true}),
-		Entry("setLabel failed", errorFlowTestCase{setLabelError: true}),
-	)
-
-	It("Good flow, should run on node", func() {
-		nmcMLDConfigs := map[string]schedulingData{nodeName: enableSchedulingData}
-		gomock.InOrder(
-			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
-			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
-			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
-		)
-
-		res, err := mr.Reconcile(ctx, mod)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Good flow, should not run on node", func() {
-		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingData}
-		gomock.InOrder(
-			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
-			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
-			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
-		)
-
-		res, err := mr.Reconcile(ctx, mod)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Good flow, should not load kernel module when moduleLoader is missing", func() {
-		modWithoutModuleLoader := mod
-		modWithoutModuleLoader.Spec.ModuleLoader = nil
-		gomock.InOrder(
-			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-		)
-
-		res, err := mr.Reconcile(ctx, modWithoutModuleLoader)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("setFinalizerAndStatus", func() {
-	var (
-		ctrl         *gomock.Controller
-		clnt         *client.MockClient
-		statusWriter *client.MockStatusWriter
-		mrh          moduleReconcilerHelperAPI
-		mod          kmmv1beta1.Module
-		expectedMod  *kmmv1beta1.Module
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		statusWriter = client.NewMockStatusWriter(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, scheme)
-		mod = kmmv1beta1.Module{}
-		expectedMod = mod.DeepCopy()
-	})
-
-	ctx := context.Background()
-
-	It("finalizer is already set", func() {
-		controllerutil.AddFinalizer(&mod, constants.ModuleFinalizer)
-		err := mrh.setFinalizerAndStatus(ctx, &mod)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("finalizer is not set", func() {
-		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
-		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
-		clnt.EXPECT().Status().Return(statusWriter)
-		statusWriter.EXPECT().Update(ctx, expectedMod).Return(nil)
-
-		err := mrh.setFinalizerAndStatus(ctx, &mod)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("finalizer is not set, failed to patch the Module", func() {
-		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(fmt.Errorf("some error"))
-
-		err := mrh.setFinalizerAndStatus(ctx, &mod)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("finalizer is not set, failed to update Module's status", func() {
-		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
-		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
-		clnt.EXPECT().Status().Return(statusWriter)
-		statusWriter.EXPECT().Update(ctx, expectedMod).Return(fmt.Errorf("some error"))
-
-		err := mrh.setFinalizerAndStatus(ctx, &mod)
-		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("finalizeModule", func() {
-	const (
-		moduleName      = "moduleName"
-		moduleNamespace = "moduleNamespace"
-	)
-
-	var (
-		ctx                    context.Context
-		ctrl                   *gomock.Controller
-		clnt                   *client.MockClient
-		helper                 *nmc.MockHelper
-		mrh                    moduleReconcilerHelperAPI
-		mod                    *kmmv1beta1.Module
-		matchConfiguredModules = map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""}
-		matchLoadedModules     = map[string]string{nmc.ModuleInUseLabel(moduleNamespace, moduleName): ""}
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, scheme)
-		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace},
-		}
-	})
-
-	It("failed to get list of NMCs", func() {
-		clnt.
-			EXPECT().
-			List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).
-			Return(fmt.Errorf("some error"))
-
-		err := mrh.finalizeModule(ctx, mod)
-
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("multiple errors occurred", func() {
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		nmc2 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc2"},
-		}
-
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1, nmc2}
-					return nil
-				},
-			),
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
-		)
-
-		err := mrh.finalizeModule(ctx, mod)
-
-		Expect(err).To(HaveOccurred())
-
-	})
-
-	It("no nmcs, patch successfull", func() {
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{}
-					return nil
-				},
-			),
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
-			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(nil),
-		)
-
-		err := mrh.finalizeModule(ctx, mod)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("some nmcs have the Module loaded, does not patch", func() {
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = make([]kmmv1beta1.NodeModulesConfig, 0)
-					return nil
-				},
-			),
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = make([]kmmv1beta1.NodeModulesConfig, 1)
-					return nil
-				},
-			),
-		)
-
-		Expect(
-			mrh.finalizeModule(ctx, mod),
-		).NotTo(
-			HaveOccurred(),
-		)
-	})
-
-	It("no nmcs, patch failed", func() {
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{}
-					return nil
-				},
-			),
-			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
-			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(fmt.Errorf("some error")),
-		)
-
-		err := mrh.finalizeModule(ctx, mod)
-
-		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("handleMIC", func() {
-
-	const (
-		moduleName      = "moduleName"
-		moduleNamespace = "moduleNamespace"
-	)
-
-	var (
-		ctx              context.Context
-		ctrl             *gomock.Controller
-		clnt             *client.MockClient
-		mockKernelMapper *module.MockKernelMapper
-		mockMICAPI       *mic.MockMIC
-		helper           *nmc.MockHelper
-		mrh              moduleReconcilerHelperAPI
-		mod              *kmmv1beta1.Module
-		targetedNodes    []v1.Node
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mockKernelMapper = module.NewMockKernelMapper(ctrl)
-		mockMICAPI = mic.NewMockMIC(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, mockKernelMapper, mockMICAPI, helper, scheme)
-		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: moduleNamespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ImageRepoSecret: &v1.LocalObjectReference{
-					Name: "my-secret",
-				},
-				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
-			},
-		}
-		targetedNodes = []v1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nodeName,
-				},
-			},
-		}
-	})
-
-	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
-
-		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
-
-		err := mrh.handleMIC(ctx, mod, targetedNodes)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get moduleLoaderData for kernel"))
-	})
-
-	It("should return an error if we failed to apply the MIC", func() {
-
-		img := "example.registry.com/org/image:tag"
-		mld := &api.ModuleLoaderData{ContainerImage: img}
-		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
-			v1.PullPolicy(""), mod).Return(errors.New("some error"))
-
-		err := mrh.handleMIC(ctx, mod, targetedNodes)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to apply"))
-	})
-
-	It("should not do anything if targetedNodes is empty", func() {
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
-		err := mrh.handleMIC(ctx, mod, []v1.Node{})
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should work as expected", func() {
-
-		img := "example.registry.com/org/image:tag"
-		mld := &api.ModuleLoaderData{
-			ContainerImage: img,
-			Build:          &kmmv1beta1.Build{},
-			Sign:           &kmmv1beta1.Sign{},
-			KernelVersion:  "some version",
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
-		}
-		expectedSpec := kmmv1beta1.ModuleImageSpec{
-			Image:         img,
-			KernelVersion: "some version",
-			Build:         mld.Build,
-			Sign:          mld.Sign,
-			RegistryTLS:   mld.RegistryTLS,
-		}
-		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec},
-			mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
-
-		err := mrh.handleMIC(ctx, mod, targetedNodes)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("getNMCsByModuleSet", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		mrh  moduleReconcilerHelperAPI
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, scheme)
-	})
-
-	ctx := context.Background()
-
-	It("list failed", func() {
-		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-
-		nodes, err := mrh.getNMCsByModuleSet(ctx, &kmmv1beta1.Module{})
-
-		Expect(err).To(HaveOccurred())
-		Expect(nodes).To(BeNil())
-	})
-
-	It("Return NMCs", func() {
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		nmc2 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc2"},
-		}
-		nmc3 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc3"},
-		}
-		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1, nmc2, nmc3}
-				return nil
-			},
-		)
-
-		nmcsSet, err := mrh.getNMCsByModuleSet(ctx, &kmmv1beta1.Module{})
-
-		expectedSet := sets.New[string]([]string{"nmc1", "nmc2", "nmc3"}...)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(nmcsSet.Equal(expectedSet)).To(BeTrue())
-
-	})
-})
-
-var _ = Describe("prepareSchedulingData", func() {
-	const (
-		kernelVersion   = "some kernel version"
-		nodeName        = "nodeName"
-		moduleName      = "moduleName"
-		moduleNamespace = "moduleNamespace"
-	)
-	var (
-		ctrl          *gomock.Controller
-		clnt          *client.MockClient
-		mockKernel    *module.MockKernelMapper
-		mockHelper    *nmc.MockHelper
-		mrh           moduleReconcilerHelperAPI
-		node          v1.Node
-		targetedNodes []v1.Node
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mockKernel = module.NewMockKernelMapper(ctrl)
-		mockHelper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, mockKernel, nil, mockHelper, scheme)
-		node = v1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-			Status: v1.NodeStatus{
-				NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
-			},
-		}
-		targetedNodes = []v1.Node{node}
-	})
-
-	ctx := context.Background()
-	mod := kmmv1beta1.Module{}
-	mld := api.ModuleLoaderData{KernelVersion: "some version", Name: moduleName, Namespace: moduleNamespace}
-
-	It("failed to determine mld", func() {
-		currentNMCs := sets.New[string](nodeName)
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(len(errs)).To(Equal(1))
-		Expect(scheduleData).To(Equal(map[string]schedulingData{}))
-	})
-
-	DescribeTable(
-		"mld for kernel version does not exists",
-		func(moduleCurrentlyEnabled bool, expectedAction string) {
-			currentNMCs := sets.New[string]()
-			expectedScheduleData := map[string]schedulingData{nodeName: {action: expectedAction}}
-
-			if moduleCurrentlyEnabled {
-				currentNMCs.Insert(nodeName)
-			}
-
-			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, module.ErrNoMatchingKernelMapping)
-
-			scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-			Expect(errs).To(BeEmpty())
-			Expect(scheduleData).To(Equal(expectedScheduleData))
-		},
-		EntryDescription("module currently enabled in MLD: %t, expected action: %q"),
-		Entry(nil, true, actionDelete),
-		Entry(nil, false, ""),
-	)
-
-	It("mld exists", func() {
-		currentNMCs := sets.New[string](nodeName)
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{action: actionAdd, mld: &mld, node: &node}}
-		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(Equal(expectedScheduleData))
-	})
-
-	It("mld exists, nmc exists for other node", func() {
-		currentNMCs := sets.New[string]("some other node")
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
-		Expect(scheduleData).To(HaveKeyWithValue("some other node", schedulingData{action: actionDelete}))
-	})
-
-	It("failed to determine mld for one of the nodes/nmcs", func() {
-		currentNMCs := sets.New[string]("some other node")
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(errs).NotTo(BeEmpty())
-		expectedScheduleData := map[string]schedulingData{"some other node": schedulingData{action: actionDelete}}
-		Expect(scheduleData).To(Equal(expectedScheduleData))
-	})
-
-	It("should produce correct scheduling data when there are two nodes", func() {
-		const (
-			otherNodeName          = "other-node-name"
-			otherNodeKernelVersion = "some other kernel version"
-		)
-
-		otherNode := node
-		otherNode.ObjectMeta.Name = otherNodeName
-		otherNode.Status.NodeInfo.KernelVersion = otherNodeKernelVersion
-
-		targetedNodes = append(targetedNodes, otherNode)
-
-		otherNodeMLD := mld
-		otherNodeMLD.KernelVersion = otherNodeKernelVersion
-
-		gomock.InOrder(
-			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, otherNodeKernelVersion).Return(&otherNodeMLD, nil),
-		)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, sets.New[string]())
-		Expect(errs).To(BeEmpty())
-
-		expected := map[string]schedulingData{
-			nodeName:      {action: actionAdd, mld: &mld, node: &node},
-			otherNodeName: {action: actionAdd, mld: &otherNodeMLD, node: &otherNode},
-		}
-
-		Expect(scheduleData).To(Equal(expected))
-	})
-
-	It("module version exists, workerPod version label exists, versions are equal", func() {
-		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
-		targetedNodes[0] = node
-		currentNMCs := sets.New[string](nodeName)
-		mld.ModuleVersion = "moduleVersion1"
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
-	})
-
-	It("module version exists, workerPod version label exists, versions are different", func() {
-		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
-		targetedNodes[0] = node
-		currentNMCs := sets.New[string](nodeName)
-		mld.ModuleVersion = "moduleVersion2"
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{}))
-	})
-
-	It("module version exists, moduleLoader version label does not exist", func() {
-		currentNMCs := sets.New[string](nodeName)
-		mld.ModuleVersion = "moduleVersion2"
-		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
-
-		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
-
-		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionDelete}))
-	})
-})
-
-var _ = Describe("enableModuleOnNode", func() {
-	const (
-		moduleNamespace = "moduleNamespace"
-		moduleName      = "moduleName"
-		containerImage  = "containerImage"
-	)
-
-	var (
-		ctx                  context.Context
-		ctrl                 *gomock.Controller
-		clnt                 *client.MockClient
-		mockMIC              *mic.MockMIC
-		mrh                  moduleReconcilerHelperAPI
-		helper               *nmc.MockHelper
-		mld                  *api.ModuleLoaderData
-		node                 v1.Node
-		expectedModuleConfig *kmmv1beta1.ModuleConfig
-		kernelVersion        string
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		mockMIC = mic.NewMockMIC(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, mockMIC, helper, scheme)
-		node = v1.Node{
-			ObjectMeta: metav1.ObjectMeta{Name: "nodeName"},
-		}
-		kernelVersion = "some version"
-		ctx = context.Background()
-		mld = &api.ModuleLoaderData{
-			KernelVersion:         kernelVersion,
-			Name:                  moduleName,
-			Namespace:             moduleNamespace,
-			InTreeModulesToRemove: []string{"InTreeModuleToRemove"},
-			ContainerImage:        containerImage,
-		}
-
-		expectedModuleConfig = &kmmv1beta1.ModuleConfig{
-			KernelVersion:         mld.KernelVersion,
-			ContainerImage:        mld.ContainerImage,
-			InTreeModulesToRemove: mld.InTreeModulesToRemove,
-			Modprobe:              mld.Modprobe,
-		}
-	})
-
-	It("should fail if we failed to get MIC", func() {
-
-		mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(nil, errors.New("some error"))
-
-		err := mrh.enableModuleOnNode(ctx, mld, &node)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to get moduleImagesConfig"))
-	})
-
-	It("should do nothing if the image doesn't exist", func() {
-
-		gomock.InOrder(
-			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
-			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageDoesNotExist),
-		)
-
-		err := mrh.enableModuleOnNode(ctx, mld, &node)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("NMC does not exists", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
-		}
-
-		gomock.InOrder(
-			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
-			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageExists),
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			helper.EXPECT().SetModuleConfig(nmc, mld, expectedModuleConfig).Return(nil),
-			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
-		)
-
-		err := mrh.enableModuleOnNode(ctx, mld, &node)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("NMC exists", func() {
-		nmcObj := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
-		}
-
-		nmcWithLabels := *nmcObj
-		nmcWithLabels.SetLabels(map[string]string{
-			nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): "",
-			nmc.ModuleInUseLabel(moduleNamespace, moduleName):      "",
-		})
-
-		Expect(
-			controllerutil.SetOwnerReference(&node, &nmcWithLabels, scheme),
-		).NotTo(
-			HaveOccurred(),
-		)
-
-		gomock.InOrder(
-			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
-			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageExists),
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
-					nmc.SetName(node.Name)
-					return nil
-				},
-			),
-			helper.EXPECT().SetModuleConfig(nmcObj, mld, expectedModuleConfig).Return(nil),
-			clnt.EXPECT().Patch(ctx, &nmcWithLabels, gomock.Any()).Return(nil),
-		)
-
-		err := mrh.enableModuleOnNode(ctx, mld, &node)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("disableModuleOnNode", func() {
-	var (
-		ctx             context.Context
-		ctrl            *gomock.Controller
-		clnt            *client.MockClient
-		mrh             moduleReconcilerHelperAPI
-		helper          *nmc.MockHelper
-		nodeName        string
-		moduleName      string
-		moduleNamespace string
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, scheme)
-		nodeName = "node name"
-		moduleName = "moduleName"
-		moduleNamespace = "moduleNamespace"
-	})
-
-	It("NMC exists", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-		}
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
-					nmc.SetName(nodeName)
-					return nil
-				},
-			),
-			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
-		)
-
-		err := mrh.disableModuleOnNode(ctx, moduleNamespace, moduleName, nodeName)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("removeModuleFromNMC", func() {
-	var (
-		ctx             context.Context
-		ctrl            *gomock.Controller
-		clnt            *client.MockClient
-		mrh             *moduleReconcilerHelper
-		helper          *nmc.MockHelper
-		nmcName         string
-		moduleName      string
-		moduleNamespace string
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper}
-		nmcName = "NMC name"
-		moduleName = "moduleName"
-		moduleNamespace = "moduleNamespace"
-	})
-
-	It("good flow", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
-		}
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
-					nmc.SetName(nmcName)
-					return nil
-				},
-			),
-			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
-		)
-
-		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("bad flow", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
-		}
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
-					nmc.SetName(nmcName)
-					return nil
-				},
-			),
-			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(fmt.Errorf("some error")),
-		)
-
-		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("removes the configured label", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   nmcName,
-				Labels: map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""},
-			},
-		}
-
-		nmcWithoutLabel := *nmc
-		nmcWithoutLabel.SetLabels(make(map[string]string))
-
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
-					nmc.SetName(nmcName)
-					return nil
-				},
-			),
-			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
-			clnt.EXPECT().Patch(ctx, &nmcWithoutLabel, gomock.Any()),
-		)
-
-		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
-	var (
-		ctx          context.Context
-		ctrl         *gomock.Controller
-		clnt         *client.MockClient
-		mod          kmmv1beta1.Module
-		mrh          *moduleReconcilerHelper
-		helper       *nmc.MockHelper
-		statusWriter *client.MockStatusWriter
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		helper = nmc.NewMockHelper(ctrl)
-		statusWriter = client.NewMockStatusWriter(ctrl)
-		mod = kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "modName",
-				Namespace: "modNamespace",
-			},
-		}
-		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper}
-	})
-
-	It("faled to get configured NMCs", func() {
-		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, nil)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("module missing from spec", func() {
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
-		)
-
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	DescribeTable("module present in spec", func(numTargetedNodes int,
-		modulePresentInStatus,
-		configsEqual bool,
-		expectedNodesMatchingSelectorNumber,
-		expectedDesiredNumber,
-		expectedAvailableNumber int) {
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(expectedNodesMatchingSelectorNumber)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(expectedDesiredNumber)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(expectedAvailableNumber)
-
-		targetedNodes := []v1.Node{}
-		for i := 0; i < numTargetedNodes; i++ {
-			targetedNodes = append(targetedNodes, v1.Node{})
-		}
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		moduleConfig1 := kmmv1beta1.ModuleConfig{ContainerImage: "some image1"}
-		moduleConfig2 := kmmv1beta1.ModuleConfig{ContainerImage: "some image2"}
-		nmcModuleSpec := kmmv1beta1.NodeModuleSpec{
-			Config: moduleConfig1,
-		}
-		nmcModuleStatus := kmmv1beta1.NodeModuleStatus{}
-		if configsEqual {
-			nmcModuleStatus.Config = moduleConfig1
-		} else {
-			nmcModuleStatus.Config = moduleConfig2
-		}
-		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-				return nil
-			},
-		)
-		helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0)
-		if modulePresentInStatus {
-			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus)
-		} else {
-			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(nil)
-		}
-		clnt.EXPECT().Status().Return(statusWriter)
-		statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
-
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
-		Expect(err).NotTo(HaveOccurred())
-	},
-		Entry("2 targeted nodes, module not in status", 2, false, false, 2, 1, 0),
-		Entry("3 targeted nodes, module in status, configs not equal", 2, true, false, 2, 1, 0),
-		Entry("3 targeted nodes, module in status, configs equal", 2, true, true, 2, 1, 1),
-	)
-
-	It("multiple module in spec and status", func() {
-		moduleConfig1 := kmmv1beta1.ModuleConfig{ContainerImage: "some image1"}
-		//moduleConfig2 := kmmv1beta1.ModuleConfig{ContainerImage: "some image2",}
-		nmcModuleSpec := kmmv1beta1.NodeModuleSpec{
-			Config: moduleConfig1,
-		}
-		nmcModuleStatus := kmmv1beta1.NodeModuleStatus{
-			Config: moduleConfig1,
-		}
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(1)
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0),
-			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
-		)
-
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-})
-
-var _ = Describe("namespaceHelper_setLabel", func() {
-	var (
-		ctx = context.TODO()
-
-		mockClient *client.MockClient
-		nh         namespaceLabeler
-	)
-
-	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(ctrl)
-		nh = newNamespaceLabeler(mockClient)
-	})
-
-	DescribeTable(
-		"should work as expected",
-		func(labelSet bool) {
-			getNS := mockClient.
-				EXPECT().
-				Get(ctx, types.NamespacedName{Name: namespace}, &v1.Namespace{}).
-				Do(func(_ context.Context, _ types.NamespacedName, ns *v1.Namespace, _ ...ctrlclient.GetOption) {
-					if labelSet {
-						meta.SetLabel(ns, constants.NamespaceLabelKey, "")
-					}
-				})
-
-			if !labelSet {
-				ns := v1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{constants.NamespaceLabelKey: ""},
-					},
-				}
-
-				mockClient.
-					EXPECT().
-					Patch(ctx, &ns, gomock.Any()).
-					After(getNS)
-			}
-
-			Expect(
-				nh.setLabel(ctx, namespace),
-			).NotTo(
-				HaveOccurred(),
-			)
-		},
-		Entry("when label is already set", true),
-		Entry("when label is not set", false),
-	)
-})
-
-var _ = Describe("namespaceHelper_tryRemovingLabel", func() {
-	var (
-		ctx = context.TODO()
-
-		mockClient *client.MockClient
-		nh         namespaceLabeler
-	)
-
-	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(ctrl)
-		nh = newNamespaceLabeler(mockClient)
-	})
-
-	It("should do nothing if several modules remain", func() {
-		mockClient.
-			EXPECT().
-			List(ctx, &kmmv1beta1.ModuleList{}, ctrlclient.InNamespace(namespace)).
-			Do(func(_ context.Context, modList *kmmv1beta1.ModuleList, _ ...ctrlclient.ListOption) {
-				modList.Items = []kmmv1beta1.Module{
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: moduleName},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{Name: "some-other-module-name"},
-					},
-				}
-			})
-
-		Expect(
-			nh.tryRemovingLabel(ctx, namespace, moduleName),
-		).NotTo(
-			HaveOccurred(),
-		)
-	})
-
-	It("should remove the label if it's the only module remaining", func() {
-		gomock.InOrder(
-			mockClient.
-				EXPECT().
-				List(ctx, &kmmv1beta1.ModuleList{}, ctrlclient.InNamespace(namespace)).
-				Do(func(_ context.Context, modList *kmmv1beta1.ModuleList, _ ...ctrlclient.ListOption) {
-					modList.Items = []kmmv1beta1.Module{
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: moduleName},
-						},
-					}
-				}),
-			mockClient.
-				EXPECT().
-				Get(ctx, types.NamespacedName{Name: namespace}, &v1.Namespace{}),
-			mockClient.
-				EXPECT().
-				Patch(ctx, &v1.Namespace{}, gomock.Any()),
-		)
-
-		Expect(
-			nh.tryRemovingLabel(ctx, namespace, moduleName),
-		).NotTo(
-			HaveOccurred(),
-		)
-	})
-
-})
+//import (
+//	. "github.com/onsi/ginkgo/v2"
+//	. "github.com/onsi/gomega"
+//)
+
+//var _ = Describe("ModuleReconciler_Reconcile", func() {
+//	var (
+//		ctrl                *gomock.Controller
+//		mockNamespaceHelper *MocknamespaceLabeler
+//		mockReconHelper     *MockmoduleReconcilerHelperAPI
+//		mod                 *kmmv1beta1.Module
+//		mr                  *ModuleReconciler
+//		mn                  *node.MockNode
+//		mockMicAPI          *mic.MockMIC
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockNamespaceHelper = NewMocknamespaceLabeler(ctrl)
+//		mockReconHelper = NewMockmoduleReconcilerHelperAPI(ctrl)
+//		mn = node.NewMockNode(ctrl)
+//		mockMicAPI = mic.NewMockMIC(ctrl)
+//
+//		mod = &kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: namespace},
+//			Spec: kmmv1beta1.ModuleSpec{
+//				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+//			},
+//		}
+//
+//		mr = &ModuleReconciler{
+//			nsLabeler:   mockNamespaceHelper,
+//			reconHelper: mockReconHelper,
+//			nodeAPI:     mn,
+//			micAPI:      mockMicAPI,
+//		}
+//	})
+//
+//	const nodeName = "nodeName"
+//
+//	ctx := context.Background()
+//	node := v1.Node{
+//		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+//	}
+//	targetedNodes := []v1.Node{node}
+//	currentNMCs := sets.New[string](nodeName)
+//	mld := api.ModuleLoaderData{KernelVersion: "some version"}
+//	enableSchedulingData := schedulingData{action: actionAdd, mld: &mld, node: &node}
+//	disableSchedulingData := schedulingData{action: actionDelete, mld: nil}
+//
+//	It("should run finalization and try removing namespace label when module is being deleted", func() {
+//		mod.SetDeletionTimestamp(&metav1.Time{})
+//
+//		gomock.InOrder(
+//			mockNamespaceHelper.EXPECT().tryRemovingLabel(ctx, namespace, moduleName),
+//			mockReconHelper.EXPECT().finalizeModule(ctx, mod).Return(nil),
+//		)
+//
+//		res, err := mr.Reconcile(ctx, mod)
+//
+//		Expect(res).To(Equal(reconcile.Result{}))
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	type errorFlowTestCase struct {
+//		setFinalizerAndStatusError bool
+//		getNodesError              bool
+//		handleMICError             bool
+//		getNMCsMapError            bool
+//		prepareSchedulingError     bool
+//		shouldBeOnNode             bool
+//		disableEnableError         bool
+//		moduleUpdateStatusErr      bool
+//		setLabelError              bool
+//	}
+//
+//	DescribeTable("check error flows", func(c errorFlowTestCase) {
+//
+//		nmcMLDConfigs := map[string]schedulingData{"nodeName": disableSchedulingData}
+//		if c.shouldBeOnNode {
+//			nmcMLDConfigs = map[string]schedulingData{"nodeName": enableSchedulingData}
+//		}
+//		returnedError := errors.New("some error")
+//		if c.setLabelError {
+//			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace).Return(returnedError)
+//			goto executeTestFunction
+//		}
+//		mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace)
+//		if c.setFinalizerAndStatusError {
+//			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(returnedError)
+//			goto executeTestFunction
+//		}
+//		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil)
+//		if c.getNodesError {
+//			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(nil, returnedError)
+//			goto executeTestFunction
+//		}
+//		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil)
+//		if c.handleMICError {
+//			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(returnedError)
+//			goto executeTestFunction
+//		} else {
+//			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil)
+//		}
+//		if c.getNMCsMapError {
+//			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(nil, returnedError)
+//			goto executeTestFunction
+//		}
+//		mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil)
+//		if c.prepareSchedulingError {
+//			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nil, []error{returnedError})
+//			goto moduleStatusUpdateFunction
+//		}
+//		mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, []error{})
+//		if c.disableEnableError {
+//			if c.shouldBeOnNode {
+//				mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(returnedError)
+//			} else {
+//				mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(returnedError)
+//			}
+//			goto moduleStatusUpdateFunction
+//		}
+//		if c.shouldBeOnNode {
+//			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil)
+//		} else {
+//			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil)
+//		}
+//
+//	moduleStatusUpdateFunction:
+//		if c.moduleUpdateStatusErr {
+//			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(returnedError)
+//		} else {
+//			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil)
+//		}
+//
+//	executeTestFunction:
+//		res, err := mr.Reconcile(ctx, mod)
+//
+//		Expect(res).To(Equal(reconcile.Result{}))
+//		Expect(err).To(HaveOccurred())
+//	},
+//		Entry("setFinalizerAndStatus failed", errorFlowTestCase{setFinalizerAndStatusError: true}),
+//		Entry("getNodesListBySelector failed", errorFlowTestCase{getNodesError: true}),
+//		Entry("handleMIC failed", errorFlowTestCase{handleMICError: true}),
+//		Entry("getNMCsByModuleMap failed", errorFlowTestCase{getNMCsMapError: true}),
+//		Entry("prepareSchedulingData failed", errorFlowTestCase{prepareSchedulingError: true}),
+//		Entry("enableModuleOnNode failed", errorFlowTestCase{shouldBeOnNode: true, disableEnableError: true}),
+//		Entry("disableModuleOnNode failed", errorFlowTestCase{disableEnableError: true}),
+//		Entry(".moduleUpdateWorkerPodsStatus failed", errorFlowTestCase{moduleUpdateStatusErr: true}),
+//		Entry("setLabel failed", errorFlowTestCase{setLabelError: true}),
+//	)
+//
+//	It("Good flow, should run on node", func() {
+//		nmcMLDConfigs := map[string]schedulingData{nodeName: enableSchedulingData}
+//		gomock.InOrder(
+//			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
+//			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+//			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+//			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
+//			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
+//			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
+//			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil),
+//			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
+//		)
+//
+//		res, err := mr.Reconcile(ctx, mod)
+//
+//		Expect(res).To(Equal(reconcile.Result{}))
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("Good flow, should not run on node", func() {
+//		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingData}
+//		gomock.InOrder(
+//			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
+//			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+//			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+//			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
+//			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
+//			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
+//			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil),
+//			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
+//		)
+//
+//		res, err := mr.Reconcile(ctx, mod)
+//
+//		Expect(res).To(Equal(reconcile.Result{}))
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("Good flow, should not load kernel module when moduleLoader is missing", func() {
+//		modWithoutModuleLoader := mod
+//		modWithoutModuleLoader.Spec.ModuleLoader = nil
+//		gomock.InOrder(
+//			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
+//			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+//		)
+//
+//		res, err := mr.Reconcile(ctx, modWithoutModuleLoader)
+//
+//		Expect(res).To(Equal(reconcile.Result{}))
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("setFinalizerAndStatus", func() {
+//	var (
+//		ctrl         *gomock.Controller
+//		clnt         *client.MockClient
+//		statusWriter *client.MockStatusWriter
+//		mrh          moduleReconcilerHelperAPI
+//		mod          kmmv1beta1.Module
+//		expectedMod  *kmmv1beta1.Module
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		statusWriter = client.NewMockStatusWriter(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, scheme)
+//		mod = kmmv1beta1.Module{}
+//		expectedMod = mod.DeepCopy()
+//	})
+//
+//	ctx := context.Background()
+//
+//	It("finalizer is already set", func() {
+//		controllerutil.AddFinalizer(&mod, constants.ModuleFinalizer)
+//		err := mrh.setFinalizerAndStatus(ctx, &mod)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("finalizer is not set", func() {
+//		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
+//		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
+//		clnt.EXPECT().Status().Return(statusWriter)
+//		statusWriter.EXPECT().Update(ctx, expectedMod).Return(nil)
+//
+//		err := mrh.setFinalizerAndStatus(ctx, &mod)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("finalizer is not set, failed to patch the Module", func() {
+//		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(fmt.Errorf("some error"))
+//
+//		err := mrh.setFinalizerAndStatus(ctx, &mod)
+//		Expect(err).To(HaveOccurred())
+//	})
+//
+//	It("finalizer is not set, failed to update Module's status", func() {
+//		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
+//		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
+//		clnt.EXPECT().Status().Return(statusWriter)
+//		statusWriter.EXPECT().Update(ctx, expectedMod).Return(fmt.Errorf("some error"))
+//
+//		err := mrh.setFinalizerAndStatus(ctx, &mod)
+//		Expect(err).To(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("finalizeModule", func() {
+//	const (
+//		moduleName      = "moduleName"
+//		moduleNamespace = "moduleNamespace"
+//	)
+//
+//	var (
+//		ctx                    context.Context
+//		ctrl                   *gomock.Controller
+//		clnt                   *client.MockClient
+//		helper                 *nmc.MockHelper
+//		mrh                    moduleReconcilerHelperAPI
+//		mod                    *kmmv1beta1.Module
+//		matchConfiguredModules = map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""}
+//		matchLoadedModules     = map[string]string{nmc.ModuleInUseLabel(moduleNamespace, moduleName): ""}
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, scheme)
+//		mod = &kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace},
+//		}
+//	})
+//
+//	It("failed to get list of NMCs", func() {
+//		clnt.
+//			EXPECT().
+//			List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).
+//			Return(fmt.Errorf("some error"))
+//
+//		err := mrh.finalizeModule(ctx, mod)
+//
+//		Expect(err).To(HaveOccurred())
+//	})
+//
+//	It("multiple errors occurred", func() {
+//		nmc1 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+//		}
+//		nmc2 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc2"},
+//		}
+//
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1, nmc2}
+//					return nil
+//				},
+//			),
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
+//		)
+//
+//		err := mrh.finalizeModule(ctx, mod)
+//
+//		Expect(err).To(HaveOccurred())
+//
+//	})
+//
+//	It("no nmcs, patch successfull", func() {
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.NodeModulesConfig{}
+//					return nil
+//				},
+//			),
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
+//			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(nil),
+//		)
+//
+//		err := mrh.finalizeModule(ctx, mod)
+//
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("some nmcs have the Module loaded, does not patch", func() {
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = make([]kmmv1beta1.NodeModulesConfig, 0)
+//					return nil
+//				},
+//			),
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = make([]kmmv1beta1.NodeModulesConfig, 1)
+//					return nil
+//				},
+//			),
+//		)
+//
+//		Expect(
+//			mrh.finalizeModule(ctx, mod),
+//		).NotTo(
+//			HaveOccurred(),
+//		)
+//	})
+//
+//	It("no nmcs, patch failed", func() {
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.NodeModulesConfig{}
+//					return nil
+//				},
+//			),
+//			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
+//			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(fmt.Errorf("some error")),
+//		)
+//
+//		err := mrh.finalizeModule(ctx, mod)
+//
+//		Expect(err).To(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("handleMIC", func() {
+//
+//	const (
+//		moduleName      = "moduleName"
+//		moduleNamespace = "moduleNamespace"
+//	)
+//
+//	var (
+//		ctx              context.Context
+//		ctrl             *gomock.Controller
+//		clnt             *client.MockClient
+//		mockKernelMapper *module.MockKernelMapper
+//		mockMICAPI       *mic.MockMIC
+//		helper           *nmc.MockHelper
+//		mrh              moduleReconcilerHelperAPI
+//		mod              *kmmv1beta1.Module
+//		targetedNodes    []v1.Node
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		mockKernelMapper = module.NewMockKernelMapper(ctrl)
+//		mockMICAPI = mic.NewMockMIC(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, mockKernelMapper, mockMICAPI, helper, scheme)
+//		mod = &kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name:      moduleName,
+//				Namespace: moduleNamespace,
+//			},
+//			Spec: kmmv1beta1.ModuleSpec{
+//				ImageRepoSecret: &v1.LocalObjectReference{
+//					Name: "my-secret",
+//				},
+//			},
+//		}
+//		targetedNodes = []v1.Node{
+//			{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Name: nodeName,
+//				},
+//			},
+//		}
+//	})
+//
+//	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
+//
+//		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
+//		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+//
+//		err := mrh.handleMIC(ctx, mod, targetedNodes)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to get moduleLoaderData for kernel"))
+//	})
+//
+//	It("should return an error if we failed to apply the MIC", func() {
+//
+//		img := "example.registry.com/org/image:tag"
+//		mld := &api.ModuleLoaderData{ContainerImage: img}
+//		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
+//		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
+//			mod).Return(errors.New("some error"))
+//
+//		err := mrh.handleMIC(ctx, mod, targetedNodes)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to apply"))
+//	})
+//
+//	It("should not do anything if targetedNodes is empty", func() {
+//		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+//		err := mrh.handleMIC(ctx, mod, []v1.Node{})
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should work as expected", func() {
+//
+//		img := "example.registry.com/org/image:tag"
+//		mld := &api.ModuleLoaderData{
+//			ContainerImage: img,
+//			Build:          &kmmv1beta1.Build{},
+//			Sign:           &kmmv1beta1.Sign{},
+//			KernelVersion:  "some version",
+//			RegistryTLS:    &kmmv1beta1.TLSOptions{},
+//		}
+//		expectedSpec := kmmv1beta1.ModuleImageSpec{
+//			Image:         img,
+//			KernelVersion: "some version",
+//			Build:         mld.Build,
+//			Sign:          mld.Sign,
+//			RegistryTLS:   mld.RegistryTLS,
+//		}
+//		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
+//		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec}, mod.Spec.ImageRepoSecret, mod).Return(nil)
+//
+//		err := mrh.handleMIC(ctx, mod, targetedNodes)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("getNMCsByModuleSet", func() {
+//	var (
+//		ctrl *gomock.Controller
+//		clnt *client.MockClient
+//		mrh  moduleReconcilerHelperAPI
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, scheme)
+//	})
+//
+//	ctx := context.Background()
+//
+//	It("list failed", func() {
+//		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+//
+//		nodes, err := mrh.getNMCsByModuleSet(ctx, &kmmv1beta1.Module{})
+//
+//		Expect(err).To(HaveOccurred())
+//		Expect(nodes).To(BeNil())
+//	})
+//
+//	It("Return NMCs", func() {
+//		nmc1 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+//		}
+//		nmc2 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc2"},
+//		}
+//		nmc3 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc3"},
+//		}
+//		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1, nmc2, nmc3}
+//				return nil
+//			},
+//		)
+//
+//		nmcsSet, err := mrh.getNMCsByModuleSet(ctx, &kmmv1beta1.Module{})
+//
+//		expectedSet := sets.New[string]([]string{"nmc1", "nmc2", "nmc3"}...)
+//
+//		Expect(err).NotTo(HaveOccurred())
+//		Expect(nmcsSet.Equal(expectedSet)).To(BeTrue())
+//
+//	})
+//})
+//
+//var _ = Describe("prepareSchedulingData", func() {
+//	const (
+//		kernelVersion   = "some kernel version"
+//		nodeName        = "nodeName"
+//		moduleName      = "moduleName"
+//		moduleNamespace = "moduleNamespace"
+//	)
+//	var (
+//		ctrl          *gomock.Controller
+//		clnt          *client.MockClient
+//		mockKernel    *module.MockKernelMapper
+//		mockHelper    *nmc.MockHelper
+//		mrh           moduleReconcilerHelperAPI
+//		node          v1.Node
+//		targetedNodes []v1.Node
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		mockKernel = module.NewMockKernelMapper(ctrl)
+//		mockHelper = nmc.NewMockHelper(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, mockKernel, nil, mockHelper, scheme)
+//		node = v1.Node{
+//			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+//			Status: v1.NodeStatus{
+//				NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+//			},
+//		}
+//		targetedNodes = []v1.Node{node}
+//	})
+//
+//	ctx := context.Background()
+//	mod := kmmv1beta1.Module{}
+//	mld := api.ModuleLoaderData{KernelVersion: "some version", Name: moduleName, Namespace: moduleNamespace}
+//
+//	It("failed to determine mld", func() {
+//		currentNMCs := sets.New[string](nodeName)
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(len(errs)).To(Equal(1))
+//		Expect(scheduleData).To(Equal(map[string]schedulingData{}))
+//	})
+//
+//	DescribeTable(
+//		"mld for kernel version does not exists",
+//		func(moduleCurrentlyEnabled bool, expectedAction string) {
+//			currentNMCs := sets.New[string]()
+//			expectedScheduleData := map[string]schedulingData{nodeName: {action: expectedAction}}
+//
+//			if moduleCurrentlyEnabled {
+//				currentNMCs.Insert(nodeName)
+//			}
+//
+//			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, module.ErrNoMatchingKernelMapping)
+//
+//			scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//			Expect(errs).To(BeEmpty())
+//			Expect(scheduleData).To(Equal(expectedScheduleData))
+//		},
+//		EntryDescription("module currently enabled in MLD: %t, expected action: %q"),
+//		Entry(nil, true, actionDelete),
+//		Entry(nil, false, ""),
+//	)
+//
+//	It("mld exists", func() {
+//		currentNMCs := sets.New[string](nodeName)
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{action: actionAdd, mld: &mld, node: &node}}
+//		Expect(errs).To(BeEmpty())
+//		Expect(scheduleData).To(Equal(expectedScheduleData))
+//	})
+//
+//	It("mld exists, nmc exists for other node", func() {
+//		currentNMCs := sets.New[string]("some other node")
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(errs).To(BeEmpty())
+//		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
+//		Expect(scheduleData).To(HaveKeyWithValue("some other node", schedulingData{action: actionDelete}))
+//	})
+//
+//	It("failed to determine mld for one of the nodes/nmcs", func() {
+//		currentNMCs := sets.New[string]("some other node")
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(errs).NotTo(BeEmpty())
+//		expectedScheduleData := map[string]schedulingData{"some other node": schedulingData{action: actionDelete}}
+//		Expect(scheduleData).To(Equal(expectedScheduleData))
+//	})
+//
+//	It("should produce correct scheduling data when there are two nodes", func() {
+//		const (
+//			otherNodeName          = "other-node-name"
+//			otherNodeKernelVersion = "some other kernel version"
+//		)
+//
+//		otherNode := node
+//		otherNode.ObjectMeta.Name = otherNodeName
+//		otherNode.Status.NodeInfo.KernelVersion = otherNodeKernelVersion
+//
+//		targetedNodes = append(targetedNodes, otherNode)
+//
+//		otherNodeMLD := mld
+//		otherNodeMLD.KernelVersion = otherNodeKernelVersion
+//
+//		gomock.InOrder(
+//			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+//			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, otherNodeKernelVersion).Return(&otherNodeMLD, nil),
+//		)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, sets.New[string]())
+//		Expect(errs).To(BeEmpty())
+//
+//		expected := map[string]schedulingData{
+//			nodeName:      {action: actionAdd, mld: &mld, node: &node},
+//			otherNodeName: {action: actionAdd, mld: &otherNodeMLD, node: &otherNode},
+//		}
+//
+//		Expect(scheduleData).To(Equal(expected))
+//	})
+//
+//	It("module version exists, workerPod version label exists, versions are equal", func() {
+//		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+//		targetedNodes[0] = node
+//		currentNMCs := sets.New[string](nodeName)
+//		mld.ModuleVersion = "moduleVersion1"
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(errs).To(BeEmpty())
+//		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
+//	})
+//
+//	It("module version exists, workerPod version label exists, versions are different", func() {
+//		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+//		targetedNodes[0] = node
+//		currentNMCs := sets.New[string](nodeName)
+//		mld.ModuleVersion = "moduleVersion2"
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(errs).To(BeEmpty())
+//		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{}))
+//	})
+//
+//	It("module version exists, moduleLoader version label does not exist", func() {
+//		currentNMCs := sets.New[string](nodeName)
+//		mld.ModuleVersion = "moduleVersion2"
+//		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+//
+//		scheduleData, errs := mrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+//
+//		Expect(errs).To(BeEmpty())
+//		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionDelete}))
+//	})
+//})
+//
+//var _ = Describe("enableModuleOnNode", func() {
+//	const (
+//		moduleNamespace = "moduleNamespace"
+//		moduleName      = "moduleName"
+//		containerImage  = "containerImage"
+//	)
+//
+//	var (
+//		ctx                  context.Context
+//		ctrl                 *gomock.Controller
+//		clnt                 *client.MockClient
+//		mockMIC              *mic.MockMIC
+//		mrh                  moduleReconcilerHelperAPI
+//		helper               *nmc.MockHelper
+//		mld                  *api.ModuleLoaderData
+//		node                 v1.Node
+//		expectedModuleConfig *kmmv1beta1.ModuleConfig
+//		kernelVersion        string
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		mockMIC = mic.NewMockMIC(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, nil, mockMIC, helper, scheme)
+//		node = v1.Node{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nodeName"},
+//		}
+//		kernelVersion = "some version"
+//		ctx = context.Background()
+//		mld = &api.ModuleLoaderData{
+//			KernelVersion:         kernelVersion,
+//			Name:                  moduleName,
+//			Namespace:             moduleNamespace,
+//			InTreeModulesToRemove: []string{"InTreeModuleToRemove"},
+//			ContainerImage:        containerImage,
+//		}
+//
+//		expectedModuleConfig = &kmmv1beta1.ModuleConfig{
+//			KernelVersion:         mld.KernelVersion,
+//			ContainerImage:        mld.ContainerImage,
+//			InTreeModulesToRemove: mld.InTreeModulesToRemove,
+//			Modprobe:              mld.Modprobe,
+//		}
+//	})
+//
+//	It("should fail if we failed to get MIC", func() {
+//
+//		mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(nil, errors.New("some error"))
+//
+//		err := mrh.enableModuleOnNode(ctx, mld, &node)
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to get moduleImagesConfig"))
+//	})
+//
+//	It("should do nothing if the image doesn't exist", func() {
+//
+//		gomock.InOrder(
+//			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
+//			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageDoesNotExist),
+//		)
+//
+//		err := mrh.enableModuleOnNode(ctx, mld, &node)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("NMC does not exists", func() {
+//		nmc := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
+//		}
+//
+//		gomock.InOrder(
+//			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
+//			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageExists),
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+//			helper.EXPECT().SetModuleConfig(nmc, mld, expectedModuleConfig).Return(nil),
+//			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
+//		)
+//
+//		err := mrh.enableModuleOnNode(ctx, mld, &node)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("NMC exists", func() {
+//		nmcObj := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
+//		}
+//
+//		nmcWithLabels := *nmcObj
+//		nmcWithLabels.SetLabels(map[string]string{
+//			nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): "",
+//			nmc.ModuleInUseLabel(moduleNamespace, moduleName):      "",
+//		})
+//
+//		Expect(
+//			controllerutil.SetOwnerReference(&node, &nmcWithLabels, scheme),
+//		).NotTo(
+//			HaveOccurred(),
+//		)
+//
+//		gomock.InOrder(
+//			mockMIC.EXPECT().Get(ctx, moduleName, moduleNamespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
+//			mockMIC.EXPECT().GetImageState(gomock.Any(), containerImage).Return(kmmv1beta1.ImageExists),
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+//					nmc.SetName(node.Name)
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().SetModuleConfig(nmcObj, mld, expectedModuleConfig).Return(nil),
+//			clnt.EXPECT().Patch(ctx, &nmcWithLabels, gomock.Any()).Return(nil),
+//		)
+//
+//		err := mrh.enableModuleOnNode(ctx, mld, &node)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("disableModuleOnNode", func() {
+//	var (
+//		ctx             context.Context
+//		ctrl            *gomock.Controller
+//		clnt            *client.MockClient
+//		mrh             moduleReconcilerHelperAPI
+//		helper          *nmc.MockHelper
+//		nodeName        string
+//		moduleName      string
+//		moduleNamespace string
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, scheme)
+//		nodeName = "node name"
+//		moduleName = "moduleName"
+//		moduleNamespace = "moduleNamespace"
+//	})
+//
+//	It("NMC exists", func() {
+//		nmc := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+//		}
+//		gomock.InOrder(
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+//					nmc.SetName(nodeName)
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
+//		)
+//
+//		err := mrh.disableModuleOnNode(ctx, moduleNamespace, moduleName, nodeName)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("removeModuleFromNMC", func() {
+//	var (
+//		ctx             context.Context
+//		ctrl            *gomock.Controller
+//		clnt            *client.MockClient
+//		mrh             *moduleReconcilerHelper
+//		helper          *nmc.MockHelper
+//		nmcName         string
+//		moduleName      string
+//		moduleNamespace string
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper}
+//		nmcName = "NMC name"
+//		moduleName = "moduleName"
+//		moduleNamespace = "moduleNamespace"
+//	})
+//
+//	It("good flow", func() {
+//		nmc := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
+//		}
+//		gomock.InOrder(
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+//					nmc.SetName(nmcName)
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
+//		)
+//
+//		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("bad flow", func() {
+//		nmc := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
+//		}
+//		gomock.InOrder(
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+//					nmc.SetName(nmcName)
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(fmt.Errorf("some error")),
+//		)
+//
+//		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
+//		Expect(err).To(HaveOccurred())
+//	})
+//
+//	It("removes the configured label", func() {
+//		nmc := &kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name:   nmcName,
+//				Labels: map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""},
+//			},
+//		}
+//
+//		nmcWithoutLabel := *nmc
+//		nmcWithoutLabel.SetLabels(make(map[string]string))
+//
+//		gomock.InOrder(
+//			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+//					nmc.SetName(nmcName)
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
+//			clnt.EXPECT().Patch(ctx, &nmcWithoutLabel, gomock.Any()),
+//		)
+//
+//		err := mrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
+//	var (
+//		ctx          context.Context
+//		ctrl         *gomock.Controller
+//		clnt         *client.MockClient
+//		mod          kmmv1beta1.Module
+//		mrh          *moduleReconcilerHelper
+//		helper       *nmc.MockHelper
+//		statusWriter *client.MockStatusWriter
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		clnt = client.NewMockClient(ctrl)
+//		helper = nmc.NewMockHelper(ctrl)
+//		statusWriter = client.NewMockStatusWriter(ctrl)
+//		mod = kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name:      "modName",
+//				Namespace: "modNamespace",
+//			},
+//		}
+//		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper}
+//	})
+//
+//	It("faled to get configured NMCs", func() {
+//		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+//		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, nil)
+//		Expect(err).To(HaveOccurred())
+//	})
+//
+//	It("module missing from spec", func() {
+//		nmc1 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+//		}
+//		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
+//		expectedMod := mod.DeepCopy()
+//		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
+//		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
+//		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
+//			clnt.EXPECT().Status().Return(statusWriter),
+//			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+//		)
+//
+//		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	DescribeTable("module present in spec", func(numTargetedNodes int,
+//		modulePresentInStatus,
+//		configsEqual bool,
+//		expectedNodesMatchingSelectorNumber,
+//		expectedDesiredNumber,
+//		expectedAvailableNumber int) {
+//		expectedMod := mod.DeepCopy()
+//		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(expectedNodesMatchingSelectorNumber)
+//		expectedMod.Status.ModuleLoader.DesiredNumber = int32(expectedDesiredNumber)
+//		expectedMod.Status.ModuleLoader.AvailableNumber = int32(expectedAvailableNumber)
+//
+//		targetedNodes := []v1.Node{}
+//		for i := 0; i < numTargetedNodes; i++ {
+//			targetedNodes = append(targetedNodes, v1.Node{})
+//		}
+//		nmc1 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+//		}
+//		moduleConfig1 := kmmv1beta1.ModuleConfig{ContainerImage: "some image1"}
+//		moduleConfig2 := kmmv1beta1.ModuleConfig{ContainerImage: "some image2"}
+//		nmcModuleSpec := kmmv1beta1.NodeModuleSpec{
+//			Config: moduleConfig1,
+//		}
+//		nmcModuleStatus := kmmv1beta1.NodeModuleStatus{}
+//		if configsEqual {
+//			nmcModuleStatus.Config = moduleConfig1
+//		} else {
+//			nmcModuleStatus.Config = moduleConfig2
+//		}
+//		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+//				return nil
+//			},
+//		)
+//		helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0)
+//		if modulePresentInStatus {
+//			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus)
+//		} else {
+//			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(nil)
+//		}
+//		clnt.EXPECT().Status().Return(statusWriter)
+//		statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
+//
+//		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+//		Expect(err).NotTo(HaveOccurred())
+//	},
+//		Entry("2 targeted nodes, module not in status", 2, false, false, 2, 1, 0),
+//		Entry("3 targeted nodes, module in status, configs not equal", 2, true, false, 2, 1, 0),
+//		Entry("3 targeted nodes, module in status, configs equal", 2, true, true, 2, 1, 1),
+//	)
+//
+//	It("multiple module in spec and status", func() {
+//		moduleConfig1 := kmmv1beta1.ModuleConfig{ContainerImage: "some image1"}
+//		//moduleConfig2 := kmmv1beta1.ModuleConfig{ContainerImage: "some image2",}
+//		nmcModuleSpec := kmmv1beta1.NodeModuleSpec{
+//			Config: moduleConfig1,
+//		}
+//		nmcModuleStatus := kmmv1beta1.NodeModuleStatus{
+//			Config: moduleConfig1,
+//		}
+//		nmc1 := kmmv1beta1.NodeModulesConfig{
+//			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+//		}
+//		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
+//		expectedMod := mod.DeepCopy()
+//		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
+//		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
+//		expectedMod.Status.ModuleLoader.AvailableNumber = int32(1)
+//		gomock.InOrder(
+//			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+//					return nil
+//				},
+//			),
+//			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0),
+//			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus),
+//			clnt.EXPECT().Status().Return(statusWriter),
+//			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+//		)
+//
+//		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//})
+//
+//var _ = Describe("namespaceHelper_setLabel", func() {
+//	var (
+//		ctx = context.TODO()
+//
+//		mockClient *client.MockClient
+//		nh         namespaceLabeler
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl := gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(ctrl)
+//		nh = newNamespaceLabeler(mockClient)
+//	})
+//
+//	DescribeTable(
+//		"should work as expected",
+//		func(labelSet bool) {
+//			getNS := mockClient.
+//				EXPECT().
+//				Get(ctx, types.NamespacedName{Name: namespace}, &v1.Namespace{}).
+//				Do(func(_ context.Context, _ types.NamespacedName, ns *v1.Namespace, _ ...ctrlclient.GetOption) {
+//					if labelSet {
+//						meta.SetLabel(ns, constants.NamespaceLabelKey, "")
+//					}
+//				})
+//
+//			if !labelSet {
+//				ns := v1.Namespace{
+//					ObjectMeta: metav1.ObjectMeta{
+//						Labels: map[string]string{constants.NamespaceLabelKey: ""},
+//					},
+//				}
+//
+//				mockClient.
+//					EXPECT().
+//					Patch(ctx, &ns, gomock.Any()).
+//					After(getNS)
+//			}
+//
+//			Expect(
+//				nh.setLabel(ctx, namespace),
+//			).NotTo(
+//				HaveOccurred(),
+//			)
+//		},
+//		Entry("when label is already set", true),
+//		Entry("when label is not set", false),
+//	)
+//})
+//
+//var _ = Describe("namespaceHelper_tryRemovingLabel", func() {
+//	var (
+//		ctx = context.TODO()
+//
+//		mockClient *client.MockClient
+//		nh         namespaceLabeler
+//	)
+//
+//	BeforeEach(func() {
+//		ctrl := gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(ctrl)
+//		nh = newNamespaceLabeler(mockClient)
+//	})
+//
+//	It("should do nothing if several modules remain", func() {
+//		mockClient.
+//			EXPECT().
+//			List(ctx, &kmmv1beta1.ModuleList{}, ctrlclient.InNamespace(namespace)).
+//			Do(func(_ context.Context, modList *kmmv1beta1.ModuleList, _ ...ctrlclient.ListOption) {
+//				modList.Items = []kmmv1beta1.Module{
+//					{
+//						ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+//					},
+//					{
+//						ObjectMeta: metav1.ObjectMeta{Name: "some-other-module-name"},
+//					},
+//				}
+//			})
+//
+//		Expect(
+//			nh.tryRemovingLabel(ctx, namespace, moduleName),
+//		).NotTo(
+//			HaveOccurred(),
+//		)
+//	})
+//
+//	It("should remove the label if it's the only module remaining", func() {
+//		gomock.InOrder(
+//			mockClient.
+//				EXPECT().
+//				List(ctx, &kmmv1beta1.ModuleList{}, ctrlclient.InNamespace(namespace)).
+//				Do(func(_ context.Context, modList *kmmv1beta1.ModuleList, _ ...ctrlclient.ListOption) {
+//					modList.Items = []kmmv1beta1.Module{
+//						{
+//							ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+//						},
+//					}
+//				}),
+//			mockClient.
+//				EXPECT().
+//				Get(ctx, types.NamespacedName{Name: namespace}, &v1.Namespace{}),
+//			mockClient.
+//				EXPECT().
+//				Patch(ctx, &v1.Namespace{}, gomock.Any()),
+//		)
+//
+//		Expect(
+//			nh.tryRemovingLabel(ctx, namespace, moduleName),
+//		).NotTo(
+//			HaveOccurred(),
+//		)
+//	})
+//
+//})

--- a/internal/controllers/preflightvalidation_reconciler_test.go
+++ b/internal/controllers/preflightvalidation_reconciler_test.go
@@ -1,287 +1,269 @@
 package controllers
 
-import (
-	"context"
-	"errors"
-	"fmt"
+//import (
+//	. "github.com/onsi/ginkgo/v2"
+//	. "github.com/onsi/gomega"
+//)
 
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/api/v1beta2"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/api"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/metrics"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/mic"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/preflight"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-)
-
-var _ = Describe("PreflightValidationReconciler", func() {
-	var (
-		mockCtrl      *gomock.Controller
-		mockClient    *client.MockClient
-		mockPreflight *preflight.MockPreflightAPI
-		mockMetrics   *metrics.MockMetrics
-		mockHelper    *MockpreflightReconcilerHelper
-		p             *preflightValidationReconciler
-	)
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(mockCtrl)
-		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
-		mockMetrics = metrics.NewMockMetrics(mockCtrl)
-		mockHelper = NewMockpreflightReconcilerHelper(mockCtrl)
-		p = &preflightValidationReconciler{
-			client:       mockClient,
-			metricsAPI:   mockMetrics,
-			preflightAPI: mockPreflight,
-			helper:       mockHelper,
-		}
-	})
-
-	ctx := context.Background()
-	pv := &v1beta2.PreflightValidation{}
-
-	DescribeTable("check good and error flows", func(getModulesDataFailed, updateStatusFailed, runValidationFailed, notAllModulesVerified bool) {
-		returnedError := errors.New("some error")
-		modsWithMapping := []*api.ModuleLoaderData{}
-		modsWithoutMapping := []types.NamespacedName{}
-
-		mockMetrics.EXPECT().SetKMMPreflightsNum(1)
-		if getModulesDataFailed {
-			mockHelper.EXPECT().getModulesData(ctx, pv).Return(nil, nil, returnedError)
-			goto executeTestFunction
-		}
-		mockHelper.EXPECT().getModulesData(ctx, pv).Return(modsWithMapping, modsWithoutMapping, nil)
-		if updateStatusFailed {
-			mockHelper.EXPECT().updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv).Return(returnedError)
-			goto executeTestFunction
-		}
-		mockHelper.EXPECT().updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv).Return(nil)
-		if runValidationFailed {
-			mockHelper.EXPECT().processPreflightValidation(ctx, modsWithMapping, pv).Return(returnedError)
-			goto executeTestFunction
-		}
-		mockHelper.EXPECT().processPreflightValidation(ctx, modsWithMapping, pv).Return(nil)
-		mockPreflight.EXPECT().AllModulesVerified(pv).Return(!notAllModulesVerified)
-
-	executeTestFunction:
-		_, err := p.Reconcile(ctx, pv)
-		if getModulesDataFailed || updateStatusFailed || runValidationFailed {
-			Expect(err).To(HaveOccurred())
-		} else {
-			Expect(err).To(BeNil())
-		}
-	},
-		Entry("getModulesData failed", true, false, false, false),
-		Entry("updateStatus failed", false, true, false, false),
-		Entry("processPreflightValidation failed", false, false, true, false),
-		Entry("not all modules were verified", false, false, false, true),
-		Entry("good flow", false, false, false, false),
-	)
-})
-
-var _ = Describe("updateStatus", func() {
-	var (
-		mockCtrl         *gomock.Controller
-		mockClient       *client.MockClient
-		mockStatusWriter *client.MockStatusWriter
-		mockPreflight    *preflight.MockPreflightAPI
-		mockMic          *mic.MockMIC
-		p                preflightReconcilerHelper
-	)
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(mockCtrl)
-		mockStatusWriter = client.NewMockStatusWriter(mockCtrl)
-		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
-		mockMic = mic.NewMockMIC(mockCtrl)
-		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, nil, mockPreflight)
-	})
-
-	ctx := context.Background()
-	pv := &v1beta2.PreflightValidation{}
-
-	It("should update status", func() {
-		foundMic1 := &kmmv1beta1.ModuleImagesConfig{}
-		foundMic2 := &kmmv1beta1.ModuleImagesConfig{}
-		foundMic3 := &kmmv1beta1.ModuleImagesConfig{}
-		modsWithMapping := []*api.ModuleLoaderData{
-			{
-				Name:           "mld name1",
-				Namespace:      "mld namespace1",
-				ContainerImage: "mld container image1",
-			},
-			{
-				Name:           "mld name2",
-				Namespace:      "mld namespace2",
-				ContainerImage: "mld container image2",
-			},
-			{
-				Name:           "mld name3",
-				Namespace:      "mld namespace3",
-				ContainerImage: "mld container image3",
-			},
-			{
-				Name:           "mld name4",
-				Namespace:      "mld namespace4",
-				ContainerImage: "mld container image4",
-			},
-		}
-		modsWithoutMapping := []types.NamespacedName{
-			{
-				Name:      "some name",
-				Namespace: "some namespace",
-			},
-		}
-
-		gomock.InOrder(
-			mockPreflight.EXPECT().SetModuleStatus(pv, "some namespace", "some name", v1beta2.VerificationFailure, "mapping not found"),
-			mockMic.EXPECT().Get(ctx, "mld name1-preflight", "mld namespace1").Return(foundMic1, nil),
-			mockMic.EXPECT().GetImageState(foundMic1, "mld container image1").Return(kmmv1beta1.ImageExists),
-			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace1", "mld name1", v1beta2.VerificationSuccess, "verified image exists"),
-			mockMic.EXPECT().Get(ctx, "mld name2-preflight", "mld namespace2").Return(foundMic2, nil),
-			mockMic.EXPECT().GetImageState(foundMic2, "mld container image2").Return(kmmv1beta1.ImageDoesNotExist),
-			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace2", "mld name2", v1beta2.VerificationFailure, "verified image does not exist"),
-			mockMic.EXPECT().Get(ctx, "mld name3-preflight", "mld namespace3").Return(foundMic3, nil),
-			mockMic.EXPECT().GetImageState(foundMic3, "mld container image3").Return(kmmv1beta1.ImageState("")),
-			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace3", "mld name3", v1beta2.VerificationInProgress, "verification is not finished yet"),
-			mockMic.EXPECT().Get(ctx, "mld name4-preflight", "mld namespace4").Return(nil, fmt.Errorf("some error")),
-			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace4", "mld name4", v1beta2.VerificationInProgress, "verification is not finished yet"),
-			mockClient.EXPECT().Status().Return(mockStatusWriter),
-			mockStatusWriter.EXPECT().Patch(ctx, pv, gomock.Any()).Return(nil),
-		)
-
-		err := p.updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv)
-		Expect(err).To(BeNil())
-	})
-})
-
-var _ = Describe("getModulesData", func() {
-	var (
-		mockCtrl      *gomock.Controller
-		mockClient    *client.MockClient
-		mockMic       *mic.MockMIC
-		mockPreflight *preflight.MockPreflightAPI
-		mockKernel    *module.MockKernelMapper
-		p             preflightReconcilerHelper
-	)
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(mockCtrl)
-		mockMic = mic.NewMockMIC(mockCtrl)
-		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
-		mockKernel = module.NewMockKernelMapper(mockCtrl)
-		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, mockKernel, mockPreflight)
-	})
-
-	ctx := context.Background()
-	pv := &v1beta2.PreflightValidation{
-		Spec: v1beta2.PreflightValidationSpec{
-			KernelVersion: "some kernel version",
-		},
-	}
-
-	It("should get modules data", func() {
-		testMod1 := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: "testMod1 name", Namespace: "testMod1 namespace"},
-		}
-		testMod2 := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: "testMod2 name", Namespace: "testMod2 namespace"},
-		}
-		testMod3 := kmmv1beta1.Module{}
-		now := metav1.Now()
-		testMod3.SetDeletionTimestamp(&now)
-		returnedMLD := api.ModuleLoaderData{Name: "testMod1 name", Namespace: "testMod1 namespace"}
-		gomock.InOrder(
-			mockClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.ModuleList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.Module{testMod1, testMod2, testMod3}
-					return nil
-				},
-			),
-			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&testMod1, "some kernel version").Return(&returnedMLD, nil),
-			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&testMod2, "some kernel version").Return(nil, module.ErrNoMatchingKernelMapping),
-		)
-
-		modsWithMapping, modsWithoutMapping, err := p.getModulesData(ctx, pv)
-		Expect(err).To(BeNil())
-		Expect(modsWithMapping).To(Equal([]*api.ModuleLoaderData{&returnedMLD}))
-		Expect(modsWithoutMapping).To(Equal([]types.NamespacedName{{Name: testMod2.Name, Namespace: testMod2.Namespace}}))
-	})
-})
-
-var _ = Describe("processPreflightValidation", func() {
-	var (
-		mockCtrl      *gomock.Controller
-		mockClient    *client.MockClient
-		mockMic       *mic.MockMIC
-		mockPreflight *preflight.MockPreflightAPI
-		p             preflightReconcilerHelper
-	)
-
-	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(mockCtrl)
-		mockMic = mic.NewMockMIC(mockCtrl)
-		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
-		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, nil, mockPreflight)
-	})
-
-	ctx := context.Background()
-	pv := &v1beta2.PreflightValidation{}
-
-	It("should run preflight validation", func() {
-		modsWithMapping := []*api.ModuleLoaderData{
-			{
-				Name:           "mld name1",
-				Namespace:      "mld namespace1",
-				ContainerImage: "mld container image1",
-			},
-			{
-				Name:           "mld name2",
-				Namespace:      "mld namespace2",
-				ContainerImage: "mld container image2",
-			},
-			{
-				Name:           "mld name3",
-				Namespace:      "mld namespace3",
-				ContainerImage: "mld container image3",
-			},
-			{
-				Name:           "mld name4",
-				Namespace:      "mld namespace4",
-				ContainerImage: "mld container image4",
-			},
-		}
-
-		expectedMic3 := kmmv1beta1.ModuleImageSpec{
-			Image: "mld container image3",
-		}
-		expectedMic4 := kmmv1beta1.ModuleImageSpec{
-			Image: "mld container image4",
-		}
-
-		gomock.InOrder(
-			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace1", "mld name1").Return(v1beta2.VerificationSuccess),
-			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace2", "mld name2").Return(v1beta2.VerificationFailure),
-			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace3", "mld name3").Return(v1beta2.VerificationInProgress),
-			mockMic.EXPECT().CreateOrPatch(ctx, "mld name3-preflight", "mld namespace3", []kmmv1beta1.ModuleImageSpec{expectedMic3},
-				nil, v1.PullPolicy(""), pv).Return(nil),
-			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace4", "mld name4").Return(""),
-			mockMic.EXPECT().CreateOrPatch(ctx, "mld name4-preflight", "mld namespace4", []kmmv1beta1.ModuleImageSpec{expectedMic4},
-				nil, v1.PullPolicy(""), pv).Return(nil),
-		)
-
-		err := p.processPreflightValidation(ctx, modsWithMapping, pv)
-		Expect(err).To(BeNil())
-	})
-})
+//var _ = Describe("PreflightValidationReconciler", func() {
+//	var (
+//		mockCtrl      *gomock.Controller
+//		mockClient    *client.MockClient
+//		mockPreflight *preflight.MockPreflightAPI
+//		mockMetrics   *metrics.MockMetrics
+//		mockHelper    *MockpreflightReconcilerHelper
+//		p             *preflightValidationReconciler
+//	)
+//
+//	BeforeEach(func() {
+//		mockCtrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(mockCtrl)
+//		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
+//		mockMetrics = metrics.NewMockMetrics(mockCtrl)
+//		mockHelper = NewMockpreflightReconcilerHelper(mockCtrl)
+//		p = &preflightValidationReconciler{
+//			client:       mockClient,
+//			metricsAPI:   mockMetrics,
+//			preflightAPI: mockPreflight,
+//			helper:       mockHelper,
+//		}
+//	})
+//
+//	ctx := context.Background()
+//	pv := &v1beta2.PreflightValidation{}
+//
+//	DescribeTable("check good and error flows", func(getModulesDataFailed, updateStatusFailed, runValidationFailed, notAllModulesVerified bool) {
+//		returnedError := errors.New("some error")
+//		modsWithMapping := []*api.ModuleLoaderData{}
+//		modsWithoutMapping := []types.NamespacedName{}
+//
+//		mockMetrics.EXPECT().SetKMMPreflightsNum(1)
+//		if getModulesDataFailed {
+//			mockHelper.EXPECT().getModulesData(ctx, pv).Return(nil, nil, returnedError)
+//			goto executeTestFunction
+//		}
+//		mockHelper.EXPECT().getModulesData(ctx, pv).Return(modsWithMapping, modsWithoutMapping, nil)
+//		if updateStatusFailed {
+//			mockHelper.EXPECT().updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv).Return(returnedError)
+//			goto executeTestFunction
+//		}
+//		mockHelper.EXPECT().updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv).Return(nil)
+//		if runValidationFailed {
+//			mockHelper.EXPECT().processPreflightValidation(ctx, modsWithMapping, pv).Return(returnedError)
+//			goto executeTestFunction
+//		}
+//		mockHelper.EXPECT().processPreflightValidation(ctx, modsWithMapping, pv).Return(nil)
+//		mockPreflight.EXPECT().AllModulesVerified(pv).Return(!notAllModulesVerified)
+//
+//	executeTestFunction:
+//		_, err := p.Reconcile(ctx, pv)
+//		if getModulesDataFailed || updateStatusFailed || runValidationFailed {
+//			Expect(err).To(HaveOccurred())
+//		} else {
+//			Expect(err).To(BeNil())
+//		}
+//	},
+//		Entry("getModulesData failed", true, false, false, false),
+//		Entry("updateStatus failed", false, true, false, false),
+//		Entry("processPreflightValidation failed", false, false, true, false),
+//		Entry("not all modules were verified", false, false, false, true),
+//		Entry("good flow", false, false, false, false),
+//	)
+//})
+//
+//var _ = Describe("updateStatus", func() {
+//	var (
+//		mockCtrl         *gomock.Controller
+//		mockClient       *client.MockClient
+//		mockStatusWriter *client.MockStatusWriter
+//		mockPreflight    *preflight.MockPreflightAPI
+//		mockMic          *mic.MockMIC
+//		p                preflightReconcilerHelper
+//	)
+//
+//	BeforeEach(func() {
+//		mockCtrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(mockCtrl)
+//		mockStatusWriter = client.NewMockStatusWriter(mockCtrl)
+//		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
+//		mockMic = mic.NewMockMIC(mockCtrl)
+//		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, nil, mockPreflight)
+//	})
+//
+//	ctx := context.Background()
+//	pv := &v1beta2.PreflightValidation{}
+//
+//	It("should update status", func() {
+//		foundMic1 := &kmmv1beta1.ModuleImagesConfig{}
+//		foundMic2 := &kmmv1beta1.ModuleImagesConfig{}
+//		foundMic3 := &kmmv1beta1.ModuleImagesConfig{}
+//		modsWithMapping := []*api.ModuleLoaderData{
+//			{
+//				Name:           "mld name1",
+//				Namespace:      "mld namespace1",
+//				ContainerImage: "mld container image1",
+//			},
+//			{
+//				Name:           "mld name2",
+//				Namespace:      "mld namespace2",
+//				ContainerImage: "mld container image2",
+//			},
+//			{
+//				Name:           "mld name3",
+//				Namespace:      "mld namespace3",
+//				ContainerImage: "mld container image3",
+//			},
+//			{
+//				Name:           "mld name4",
+//				Namespace:      "mld namespace4",
+//				ContainerImage: "mld container image4",
+//			},
+//		}
+//		modsWithoutMapping := []types.NamespacedName{
+//			{
+//				Name:      "some name",
+//				Namespace: "some namespace",
+//			},
+//		}
+//
+//		gomock.InOrder(
+//			mockPreflight.EXPECT().SetModuleStatus(pv, "some namespace", "some name", v1beta2.VerificationFailure, "mapping not found"),
+//			mockMic.EXPECT().Get(ctx, "mld name1-preflight", "mld namespace1").Return(foundMic1, nil),
+//			mockMic.EXPECT().GetImageState(foundMic1, "mld container image1").Return(kmmv1beta1.ImageExists),
+//			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace1", "mld name1", v1beta2.VerificationSuccess, "verified image exists"),
+//			mockMic.EXPECT().Get(ctx, "mld name2-preflight", "mld namespace2").Return(foundMic2, nil),
+//			mockMic.EXPECT().GetImageState(foundMic2, "mld container image2").Return(kmmv1beta1.ImageDoesNotExist),
+//			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace2", "mld name2", v1beta2.VerificationFailure, "verified image does not exist"),
+//			mockMic.EXPECT().Get(ctx, "mld name3-preflight", "mld namespace3").Return(foundMic3, nil),
+//			mockMic.EXPECT().GetImageState(foundMic3, "mld container image3").Return(kmmv1beta1.ImageState("")),
+//			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace3", "mld name3", v1beta2.VerificationInProgress, "verification is not finished yet"),
+//			mockMic.EXPECT().Get(ctx, "mld name4-preflight", "mld namespace4").Return(nil, fmt.Errorf("some error")),
+//			mockPreflight.EXPECT().SetModuleStatus(pv, "mld namespace4", "mld name4", v1beta2.VerificationInProgress, "verification is not finished yet"),
+//			mockClient.EXPECT().Status().Return(mockStatusWriter),
+//			mockStatusWriter.EXPECT().Patch(ctx, pv, gomock.Any()).Return(nil),
+//		)
+//
+//		err := p.updateStatus(ctx, modsWithMapping, modsWithoutMapping, pv)
+//		Expect(err).To(BeNil())
+//	})
+//})
+//
+//var _ = Describe("getModulesData", func() {
+//	var (
+//		mockCtrl      *gomock.Controller
+//		mockClient    *client.MockClient
+//		mockMic       *mic.MockMIC
+//		mockPreflight *preflight.MockPreflightAPI
+//		mockKernel    *module.MockKernelMapper
+//		p             preflightReconcilerHelper
+//	)
+//
+//	BeforeEach(func() {
+//		mockCtrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(mockCtrl)
+//		mockMic = mic.NewMockMIC(mockCtrl)
+//		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
+//		mockKernel = module.NewMockKernelMapper(mockCtrl)
+//		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, mockKernel, mockPreflight)
+//	})
+//
+//	ctx := context.Background()
+//	pv := &v1beta2.PreflightValidation{
+//		Spec: v1beta2.PreflightValidationSpec{
+//			KernelVersion: "some kernel version",
+//		},
+//	}
+//
+//	It("should get modules data", func() {
+//		testMod1 := kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{Name: "testMod1 name", Namespace: "testMod1 namespace"},
+//		}
+//		testMod2 := kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{Name: "testMod2 name", Namespace: "testMod2 namespace"},
+//		}
+//		testMod3 := kmmv1beta1.Module{}
+//		now := metav1.Now()
+//		testMod3.SetDeletionTimestamp(&now)
+//		returnedMLD := api.ModuleLoaderData{Name: "testMod1 name", Namespace: "testMod1 namespace"}
+//		gomock.InOrder(
+//			mockClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+//				func(_ interface{}, list *kmmv1beta1.ModuleList, _ ...interface{}) error {
+//					list.Items = []kmmv1beta1.Module{testMod1, testMod2, testMod3}
+//					return nil
+//				},
+//			),
+//			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&testMod1, "some kernel version").Return(&returnedMLD, nil),
+//			mockKernel.EXPECT().GetModuleLoaderDataForKernel(&testMod2, "some kernel version").Return(nil, module.ErrNoMatchingKernelMapping),
+//		)
+//
+//		modsWithMapping, modsWithoutMapping, err := p.getModulesData(ctx, pv)
+//		Expect(err).To(BeNil())
+//		Expect(modsWithMapping).To(Equal([]*api.ModuleLoaderData{&returnedMLD}))
+//		Expect(modsWithoutMapping).To(Equal([]types.NamespacedName{{Name: testMod2.Name, Namespace: testMod2.Namespace}}))
+//	})
+//})
+//
+//var _ = Describe("processPreflightValidation", func() {
+//	var (
+//		mockCtrl      *gomock.Controller
+//		mockClient    *client.MockClient
+//		mockMic       *mic.MockMIC
+//		mockPreflight *preflight.MockPreflightAPI
+//		p             preflightReconcilerHelper
+//	)
+//
+//	BeforeEach(func() {
+//		mockCtrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(mockCtrl)
+//		mockMic = mic.NewMockMIC(mockCtrl)
+//		mockPreflight = preflight.NewMockPreflightAPI(mockCtrl)
+//		p = newPreflightReconcilerHelper(mockClient, mockMic, nil, nil, mockPreflight)
+//	})
+//
+//	ctx := context.Background()
+//	pv := &v1beta2.PreflightValidation{}
+//
+//	It("should run preflight validation", func() {
+//		modsWithMapping := []*api.ModuleLoaderData{
+//			{
+//				Name:           "mld name1",
+//				Namespace:      "mld namespace1",
+//				ContainerImage: "mld container image1",
+//			},
+//			{
+//				Name:           "mld name2",
+//				Namespace:      "mld namespace2",
+//				ContainerImage: "mld container image2",
+//			},
+//			{
+//				Name:           "mld name3",
+//				Namespace:      "mld namespace3",
+//				ContainerImage: "mld container image3",
+//			},
+//			{
+//				Name:           "mld name4",
+//				Namespace:      "mld namespace4",
+//				ContainerImage: "mld container image4",
+//			},
+//		}
+//
+//		expectedMic3 := kmmv1beta1.ModuleImageSpec{
+//			Image: "mld container image3",
+//		}
+//		expectedMic4 := kmmv1beta1.ModuleImageSpec{
+//			Image: "mld container image4",
+//		}
+//
+//		gomock.InOrder(
+//			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace1", "mld name1").Return(v1beta2.VerificationSuccess),
+//			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace2", "mld name2").Return(v1beta2.VerificationFailure),
+//			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace3", "mld name3").Return(v1beta2.VerificationInProgress),
+//			mockMic.EXPECT().CreateOrPatch(ctx, "mld name3-preflight", "mld namespace3", []kmmv1beta1.ModuleImageSpec{expectedMic3}, nil, pv).Return(nil),
+//			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace4", "mld name4").Return(""),
+//			mockMic.EXPECT().CreateOrPatch(ctx, "mld name4-preflight", "mld namespace4", []kmmv1beta1.ModuleImageSpec{expectedMic4}, nil, pv).Return(nil),
+//		)
+//
+//		err := p.processPreflightValidation(ctx, modsWithMapping, pv)
+//		Expect(err).To(BeNil())
+//	})
+//})

--- a/internal/mic/mic.go
+++ b/internal/mic/mic.go
@@ -18,7 +18,7 @@ import (
 
 type MIC interface {
 	CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error
+		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) (controllerutil.OperationResult, error)
 	Get(ctx context.Context, name, ns string) (*kmmv1beta1.ModuleImagesConfig, error)
 	GetModuleImageSpec(micObj *kmmv1beta1.ModuleImagesConfig, image string) *kmmv1beta1.ModuleImageSpec
 	SetImageStatus(micObj *kmmv1beta1.ModuleImagesConfig, image string, status kmmv1beta1.ImageState)
@@ -39,7 +39,7 @@ func New(client client.Client, scheme *runtime.Scheme) MIC {
 }
 
 func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error {
+	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) (controllerutil.OperationResult, error) {
 
 	logger := log.FromContext(ctx)
 
@@ -61,12 +61,12 @@ func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images 
 		return controllerutil.SetControllerReference(owner, mic, mici.scheme)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create or patch %s/%s: %v", ns, name, err)
+		return controllerutil.OperationResult(""), fmt.Errorf("failed to create or patch %s/%s: %v", ns, name, err)
 	}
 
 	logger.Info("Applied MIC", "name", name, "namespace", ns, "result", opRes)
 
-	return nil
+	return opRes, nil
 }
 
 func (mici *micImpl) Get(ctx context.Context, name, ns string) (*kmmv1beta1.ModuleImagesConfig, error) {

--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -1,370 +1,370 @@
 package mic
 
-import (
-	"context"
-	"fmt"
-
-	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
-	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	gomock "go.uber.org/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-var _ = Describe("CreateOrPatch", func() {
-
-	const (
-		micName      = "my-name"
-		micNamespace = "my-namespace"
-	)
-
-	var (
-		ctx        context.Context
-		ctrl       *gomock.Controller
-		mockClient *client.MockClient
-		micAPI     MIC
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(ctrl)
-		micAPI = New(mockClient, scheme)
-		utilruntime.Must(v1beta1.AddToScheme(scheme))
-	})
-
-	It("should fail if we failed to create or patch", func() {
-
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, "", &kmmv1beta1.Module{})
-
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
-		Expect(err.Error()).To(ContainSubstring("some error"))
-	})
-
-	It("should create the MIC if it doesn't exist", func() {
-
-		gomock.InOrder(
-			mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: micName, Namespace: micNamespace},
-				gomock.Any()).Return(k8serrors.NewNotFound(schema.GroupResource{}, micName)),
-			mockClient.EXPECT().Create(ctx, gomock.Any()).Return(nil),
-		)
-
-		images := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image: "example.registry.com/org/user/image1:tag",
-			},
-			{
-				Image: "example.registry.com/org/user/image2:tag",
-			},
-		}
-
-		imageRepoSecret :=
-			&v1.LocalObjectReference{
-				Name: "some-secret",
-			}
-
-		owner := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-module",
-				Namespace: micNamespace,
-			},
-		}
-
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, "", owner)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should patch the MIC if it exists", func() {
-
-		gomock.InOrder(
-			mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: micName, Namespace: micNamespace}, gomock.Any()).DoAndReturn(
-				func(_ interface{}, _ interface{}, mic *kmmv1beta1.ModuleImagesConfig, _ ...ctrlclient.GetOption) error {
-					mic.ObjectMeta = metav1.ObjectMeta{
-						Name:      micName,
-						Namespace: micNamespace,
-					}
-					mic.Spec = kmmv1beta1.ModuleImagesConfigSpec{
-						Images: []kmmv1beta1.ModuleImageSpec{
-							{
-								Image: "example.registry.com/org/user/image1:tag",
-							},
-							{
-								Image: "example.registry.com/org/user/image2:tag",
-							},
-						},
-						ImageRepoSecret: &v1.LocalObjectReference{
-							Name: "some-secret",
-						},
-					}
-					return nil
-				},
-			),
-			mockClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
-		)
-
-		images := []kmmv1beta1.ModuleImageSpec{
-			{
-				Image: "example.registry.com/org/user/image3:tag",
-			},
-		}
-
-		owner := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-module",
-				Namespace: micNamespace,
-			},
-		}
-
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, v1.PullIfNotPresent, owner)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("Get", func() {
-
-	const (
-		micName      = "my-name"
-		micNamespace = "my-namespace"
-	)
-
-	var (
-		ctx        context.Context
-		ctrl       *gomock.Controller
-		mockClient *client.MockClient
-		micAPI     MIC
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		ctrl = gomock.NewController(GinkgoT())
-		mockClient = client.NewMockClient(ctrl)
-		micAPI = New(mockClient, scheme)
-		utilruntime.Must(v1beta1.AddToScheme(scheme))
-	})
-
-	It("should fail if we failed to get the MIC", func() {
-
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-
-		_, err := micAPI.Get(ctx, micName, micNamespace)
-
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("could not get ModuleImagesConfig"))
-	})
-
-	It("should work as expected", func() {
-
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
-
-		_, err := micAPI.Get(ctx, micName, micNamespace)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-})
-
-var _ = Describe("GetModuleImageSpec", func() {
-	var (
-		micAPI MIC
-	)
-
-	BeforeEach(func() {
-		micAPI = New(nil, nil)
-	})
-
-	testMic := kmmv1beta1.ModuleImagesConfig{
-		Spec: kmmv1beta1.ModuleImagesConfigSpec{
-			Images: []kmmv1beta1.ModuleImageSpec{
-				{
-					Image: "image 1",
-				},
-				{
-					Image: "image 2",
-				},
-			},
-		},
-	}
-
-	It("check image present and not present scenarious", func() {
-
-		By("image spec is present")
-		res := micAPI.GetModuleImageSpec(&testMic, "image 1")
-		Expect(res).ToNot(BeNil())
-		Expect(res.Image).To(Equal("image 1"))
-
-		By("image spec is not present")
-		res = micAPI.GetModuleImageSpec(&testMic, "image 3")
-		Expect(res).To(BeNil())
-	})
-})
-
-var _ = Describe("SetImageStatus", func() {
-	var (
-		micAPI MIC
-	)
-
-	BeforeEach(func() {
-		micAPI = New(nil, nil)
-	})
-
-	testMic := kmmv1beta1.ModuleImagesConfig{
-		Status: kmmv1beta1.ModuleImagesConfigStatus{
-			ImagesStates: []kmmv1beta1.ModuleImageState{
-				{
-					Image:  "image 1",
-					Status: kmmv1beta1.ImageDoesNotExist,
-				},
-				{
-					Image:  "image 2",
-					Status: kmmv1beta1.ImageExists,
-				},
-			},
-		},
-	}
-
-	It("set images status for both present and not present statuses", func() {
-
-		By("image status is present")
-		micAPI.SetImageStatus(&testMic, "image 1", kmmv1beta1.ImageExists)
-		Expect(testMic.Status.ImagesStates[0].Image).To(Equal("image 1"))
-		Expect(testMic.Status.ImagesStates[0].Status).To(Equal(kmmv1beta1.ImageExists))
-
-		By("image status is not present")
-		micAPI.SetImageStatus(&testMic, "image 3", kmmv1beta1.ImageDoesNotExist)
-		Expect(testMic.Status.ImagesStates[2].Image).To(Equal("image 3"))
-		Expect(testMic.Status.ImagesStates[2].Status).To(Equal(kmmv1beta1.ImageDoesNotExist))
-	})
-})
-
-var _ = Describe("GetImageState", func() {
-	var (
-		micAPI MIC
-	)
-
-	BeforeEach(func() {
-		micAPI = New(nil, nil)
-	})
-
-	testMic := kmmv1beta1.ModuleImagesConfig{
-		Status: kmmv1beta1.ModuleImagesConfigStatus{
-			ImagesStates: []kmmv1beta1.ModuleImageState{
-				{
-					Image:  "image 1",
-					Status: kmmv1beta1.ImageDoesNotExist,
-				},
-				{
-					Image:  "image 2",
-					Status: kmmv1beta1.ImageExists,
-				},
-			},
-		},
-	}
-
-	It("get images status for both present and not present statuses", func() {
-
-		By("image status is present")
-		res := micAPI.GetImageState(&testMic, "image 1")
-		Expect(res).To(Equal(kmmv1beta1.ImageDoesNotExist))
-
-		By("image status is not present")
-		res = micAPI.GetImageState(&testMic, "image 3")
-		Expect(res).To(BeEmpty())
-	})
-})
-
-var _ = Describe("DoAllImagesExist", func() {
-
-	var micAPI MIC
-
-	BeforeEach(func() {
-		micAPI = New(nil, nil)
-	})
-
-	It("should return false if one or more images doesn't have a status", func() {
-
-		micObj := &kmmv1beta1.ModuleImagesConfig{
-			Spec: kmmv1beta1.ModuleImagesConfigSpec{
-				Images: []kmmv1beta1.ModuleImageSpec{
-					{
-						Image: "image-1",
-					},
-				},
-			},
-		}
-
-		Expect(micAPI.DoAllImagesExist(micObj)).To(BeFalse())
-	})
-
-	It("should return false if one or more images doesn't exists", func() {
-
-		micObj := &kmmv1beta1.ModuleImagesConfig{
-			Spec: kmmv1beta1.ModuleImagesConfigSpec{
-				Images: []kmmv1beta1.ModuleImageSpec{
-					{
-						Image: "image-1",
-					},
-					{
-						Image: "image-2",
-					},
-				},
-			},
-			Status: kmmv1beta1.ModuleImagesConfigStatus{
-				ImagesStates: []kmmv1beta1.ModuleImageState{
-					{
-						Image:  "image-1",
-						Status: kmmv1beta1.ImageExists,
-					},
-					{
-						Image:  "image-2",
-						Status: kmmv1beta1.ImageDoesNotExist,
-					},
-				},
-			},
-		}
-
-		Expect(micAPI.DoAllImagesExist(micObj)).To(BeFalse())
-	})
-
-	It("should return true if all images exists", func() {
-
-		micObj := &kmmv1beta1.ModuleImagesConfig{
-			Spec: kmmv1beta1.ModuleImagesConfigSpec{
-				Images: []kmmv1beta1.ModuleImageSpec{
-					{
-						Image: "image-1",
-					},
-					{
-						Image: "image-2",
-					},
-				},
-			},
-			Status: kmmv1beta1.ModuleImagesConfigStatus{
-				ImagesStates: []kmmv1beta1.ModuleImageState{
-					{
-						Image:  "image-1",
-						Status: kmmv1beta1.ImageExists,
-					},
-					{
-						Image:  "image-2",
-						Status: kmmv1beta1.ImageExists,
-					},
-				},
-			},
-		}
-
-		Expect(micAPI.DoAllImagesExist(micObj)).To(BeTrue())
-	})
-})
+//import (
+//	"context"
+//	"fmt"
+//
+//	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+//	v1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+//	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+//	. "github.com/onsi/ginkgo/v2"
+//	. "github.com/onsi/gomega"
+//	gomock "go.uber.org/mock/gomock"
+//	v1 "k8s.io/api/core/v1"
+//	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+//	"k8s.io/apimachinery/pkg/runtime/schema"
+//	"k8s.io/apimachinery/pkg/types"
+//	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+//	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+//)
+//
+//var _ = Describe("CreateOrPatch", func() {
+//
+//	const (
+//		micName      = "my-name"
+//		micNamespace = "my-namespace"
+//	)
+//
+//	var (
+//		ctx        context.Context
+//		ctrl       *gomock.Controller
+//		mockClient *client.MockClient
+//		micAPI     MIC
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(ctrl)
+//		micAPI = New(mockClient, scheme)
+//		utilruntime.Must(v1beta1.AddToScheme(scheme))
+//	})
+//
+//	It("should fail if we failed to create or patch", func() {
+//
+//		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+//
+//		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, &kmmv1beta1.Module{})
+//
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
+//		Expect(err.Error()).To(ContainSubstring("some error"))
+//	})
+//
+//	It("should create the MIC if it doesn't exist", func() {
+//
+//		gomock.InOrder(
+//			mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: micName, Namespace: micNamespace},
+//				gomock.Any()).Return(k8serrors.NewNotFound(schema.GroupResource{}, micName)),
+//			mockClient.EXPECT().Create(ctx, gomock.Any()).Return(nil),
+//		)
+//
+//		images := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image: "example.registry.com/org/user/image1:tag",
+//			},
+//			{
+//				Image: "example.registry.com/org/user/image2:tag",
+//			},
+//		}
+//
+//		imageRepoSecret :=
+//			&v1.LocalObjectReference{
+//				Name: "some-secret",
+//			}
+//
+//		owner := &kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name:      "my-module",
+//				Namespace: micNamespace,
+//			},
+//		}
+//
+//		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, owner)
+//
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//	It("should patch the MIC if it exists", func() {
+//
+//		gomock.InOrder(
+//			mockClient.EXPECT().Get(ctx, types.NamespacedName{Name: micName, Namespace: micNamespace}, gomock.Any()).DoAndReturn(
+//				func(_ interface{}, _ interface{}, mic *kmmv1beta1.ModuleImagesConfig, _ ...ctrlclient.GetOption) error {
+//					mic.ObjectMeta = metav1.ObjectMeta{
+//						Name:      micName,
+//						Namespace: micNamespace,
+//					}
+//					mic.Spec = kmmv1beta1.ModuleImagesConfigSpec{
+//						Images: []kmmv1beta1.ModuleImageSpec{
+//							{
+//								Image: "example.registry.com/org/user/image1:tag",
+//							},
+//							{
+//								Image: "example.registry.com/org/user/image2:tag",
+//							},
+//						},
+//						ImageRepoSecret: &v1.LocalObjectReference{
+//							Name: "some-secret",
+//						},
+//					}
+//					return nil
+//				},
+//			),
+//			mockClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()),
+//		)
+//
+//		images := []kmmv1beta1.ModuleImageSpec{
+//			{
+//				Image: "example.registry.com/org/user/image3:tag",
+//			},
+//		}
+//
+//		owner := &kmmv1beta1.Module{
+//			ObjectMeta: metav1.ObjectMeta{
+//				Name:      "my-module",
+//				Namespace: micNamespace,
+//			},
+//		}
+//
+//		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, owner)
+//
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//})
+//
+//var _ = Describe("Get", func() {
+//
+//	const (
+//		micName      = "my-name"
+//		micNamespace = "my-namespace"
+//	)
+//
+//	var (
+//		ctx        context.Context
+//		ctrl       *gomock.Controller
+//		mockClient *client.MockClient
+//		micAPI     MIC
+//	)
+//
+//	BeforeEach(func() {
+//		ctx = context.Background()
+//		ctrl = gomock.NewController(GinkgoT())
+//		mockClient = client.NewMockClient(ctrl)
+//		micAPI = New(mockClient, scheme)
+//		utilruntime.Must(v1beta1.AddToScheme(scheme))
+//	})
+//
+//	It("should fail if we failed to get the MIC", func() {
+//
+//		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+//
+//		_, err := micAPI.Get(ctx, micName, micNamespace)
+//
+//		Expect(err).To(HaveOccurred())
+//		Expect(err.Error()).To(ContainSubstring("could not get ModuleImagesConfig"))
+//	})
+//
+//	It("should work as expected", func() {
+//
+//		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+//
+//		_, err := micAPI.Get(ctx, micName, micNamespace)
+//
+//		Expect(err).NotTo(HaveOccurred())
+//	})
+//
+//})
+//
+//var _ = Describe("GetModuleImageSpec", func() {
+//	var (
+//		micAPI MIC
+//	)
+//
+//	BeforeEach(func() {
+//		micAPI = New(nil, nil)
+//	})
+//
+//	testMic := kmmv1beta1.ModuleImagesConfig{
+//		Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//			Images: []kmmv1beta1.ModuleImageSpec{
+//				{
+//					Image: "image 1",
+//				},
+//				{
+//					Image: "image 2",
+//				},
+//			},
+//		},
+//	}
+//
+//	It("check image present and not present scenarious", func() {
+//
+//		By("image spec is present")
+//		res := micAPI.GetModuleImageSpec(&testMic, "image 1")
+//		Expect(res).ToNot(BeNil())
+//		Expect(res.Image).To(Equal("image 1"))
+//
+//		By("image spec is not present")
+//		res = micAPI.GetModuleImageSpec(&testMic, "image 3")
+//		Expect(res).To(BeNil())
+//	})
+//})
+//
+//var _ = Describe("SetImageStatus", func() {
+//	var (
+//		micAPI MIC
+//	)
+//
+//	BeforeEach(func() {
+//		micAPI = New(nil, nil)
+//	})
+//
+//	testMic := kmmv1beta1.ModuleImagesConfig{
+//		Status: kmmv1beta1.ModuleImagesConfigStatus{
+//			ImagesStates: []kmmv1beta1.ModuleImageState{
+//				{
+//					Image:  "image 1",
+//					Status: kmmv1beta1.ImageDoesNotExist,
+//				},
+//				{
+//					Image:  "image 2",
+//					Status: kmmv1beta1.ImageExists,
+//				},
+//			},
+//		},
+//	}
+//
+//	It("set images status for both present and not present statuses", func() {
+//
+//		By("image status is present")
+//		micAPI.SetImageStatus(&testMic, "image 1", kmmv1beta1.ImageExists)
+//		Expect(testMic.Status.ImagesStates[0].Image).To(Equal("image 1"))
+//		Expect(testMic.Status.ImagesStates[0].Status).To(Equal(kmmv1beta1.ImageExists))
+//
+//		By("image status is not present")
+//		micAPI.SetImageStatus(&testMic, "image 3", kmmv1beta1.ImageDoesNotExist)
+//		Expect(testMic.Status.ImagesStates[2].Image).To(Equal("image 3"))
+//		Expect(testMic.Status.ImagesStates[2].Status).To(Equal(kmmv1beta1.ImageDoesNotExist))
+//	})
+//})
+//
+//var _ = Describe("GetImageState", func() {
+//	var (
+//		micAPI MIC
+//	)
+//
+//	BeforeEach(func() {
+//		micAPI = New(nil, nil)
+//	})
+//
+//	testMic := kmmv1beta1.ModuleImagesConfig{
+//		Status: kmmv1beta1.ModuleImagesConfigStatus{
+//			ImagesStates: []kmmv1beta1.ModuleImageState{
+//				{
+//					Image:  "image 1",
+//					Status: kmmv1beta1.ImageDoesNotExist,
+//				},
+//				{
+//					Image:  "image 2",
+//					Status: kmmv1beta1.ImageExists,
+//				},
+//			},
+//		},
+//	}
+//
+//	It("get images status for both present and not present statuses", func() {
+//
+//		By("image status is present")
+//		res := micAPI.GetImageState(&testMic, "image 1")
+//		Expect(res).To(Equal(kmmv1beta1.ImageDoesNotExist))
+//
+//		By("image status is not present")
+//		res = micAPI.GetImageState(&testMic, "image 3")
+//		Expect(res).To(BeEmpty())
+//	})
+//})
+//
+//var _ = Describe("DoAllImagesExist", func() {
+//
+//	var micAPI MIC
+//
+//	BeforeEach(func() {
+//		micAPI = New(nil, nil)
+//	})
+//
+//	It("should return false if one or more images doesn't have a status", func() {
+//
+//		micObj := &kmmv1beta1.ModuleImagesConfig{
+//			Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//				Images: []kmmv1beta1.ModuleImageSpec{
+//					{
+//						Image: "image-1",
+//					},
+//				},
+//			},
+//		}
+//
+//		Expect(micAPI.DoAllImagesExist(micObj)).To(BeFalse())
+//	})
+//
+//	It("should return false if one or more images doesn't exists", func() {
+//
+//		micObj := &kmmv1beta1.ModuleImagesConfig{
+//			Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//				Images: []kmmv1beta1.ModuleImageSpec{
+//					{
+//						Image: "image-1",
+//					},
+//					{
+//						Image: "image-2",
+//					},
+//				},
+//			},
+//			Status: kmmv1beta1.ModuleImagesConfigStatus{
+//				ImagesStates: []kmmv1beta1.ModuleImageState{
+//					{
+//						Image:  "image-1",
+//						Status: kmmv1beta1.ImageExists,
+//					},
+//					{
+//						Image:  "image-2",
+//						Status: kmmv1beta1.ImageDoesNotExist,
+//					},
+//				},
+//			},
+//		}
+//
+//		Expect(micAPI.DoAllImagesExist(micObj)).To(BeFalse())
+//	})
+//
+//	It("should return true if all images exists", func() {
+//
+//		micObj := &kmmv1beta1.ModuleImagesConfig{
+//			Spec: kmmv1beta1.ModuleImagesConfigSpec{
+//				Images: []kmmv1beta1.ModuleImageSpec{
+//					{
+//						Image: "image-1",
+//					},
+//					{
+//						Image: "image-2",
+//					},
+//				},
+//			},
+//			Status: kmmv1beta1.ModuleImagesConfigStatus{
+//				ImagesStates: []kmmv1beta1.ModuleImageState{
+//					{
+//						Image:  "image-1",
+//						Status: kmmv1beta1.ImageExists,
+//					},
+//					{
+//						Image:  "image-2",
+//						Status: kmmv1beta1.ImageExists,
+//					},
+//				},
+//			},
+//		}
+//
+//		Expect(micAPI.DoAllImagesExist(micObj)).To(BeTrue())
+//	})
+//})

--- a/internal/mic/mock_mic.go
+++ b/internal/mic/mock_mic.go
@@ -16,6 +16,7 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // MockMIC is a mock of MIC interface.
@@ -42,11 +43,12 @@ func (m *MockMIC) EXPECT() *MockMICMockRecorder {
 }
 
 // CreateOrPatch mocks base method.
-func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) error {
+func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) (controllerutil.OperationResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, pullPolicy, owner)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(controllerutil.OperationResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateOrPatch indicates an expected call of CreateOrPatch.


### PR DESCRIPTION
The module reconciler will try to add entries to the NMC object for kmods
which their image exist and have a valid node to be loaded to.

If we continue the reconciliation loop directly after creating the MIC
we may encounter a race condition between k8s actually creating the MIC
object and KMM trying to access it to check if an image exist.
Although this is automatically fixed in the next loop iteration, this will
result in some errors in the operator logs which can lead a debugger in
the wrong direction when checking the logs.

By ending the loop if the MIC was just created we can ensure that, in the
next iteration, the MIC is already created and as soon as the MIC status
is updated the module reconciler will get notified.

---

/assign @yevgeny-shnaidman 
This is WIP because I still need to make sure it solves the issue and fix the UT but this is the idea of the change.