### PR TITLE
Fixing documentation for building in-cluster using a Dockerfile.

### DIFF
--- a/docs/mkdocs/documentation/kmod_image.md
+++ b/docs/mkdocs/documentation/kmod_image.md
@@ -67,7 +67,7 @@ RUN depmod -b /opt ${KERNEL_FULL_VERSION}
 
 KMM is able to build kmod images in cluster.
 Build instructions must be provided using the `build` section of a kernel mapping.
-The `Dockerfile` for your container image should be copied into a `ConfigMap` object, under the `Dockerfile` key.
+The `Dockerfile` for your container image should be copied into a `ConfigMap` object, under the `dockerfile` key.
 The `ConfigMap` needs to be located in the same namespace as the `Module`.
 
 KMM will first check if the image name specified in the `containerImage` field exists.


### PR DESCRIPTION
The doc says to create a `configMap` with the `Dockerfile` key while KMM expects to see the `dockerfile` key instead which will lead to an error.

---

/assign @qbarrand 