### PR TITLE
fixing HashAnnotationDiffer function potential bug

### DIFF
--- a/internal/pod/workerpodmanager.go
+++ b/internal/pod/workerpodmanager.go
@@ -304,11 +304,11 @@ func (wpmi *workerPodManagerImpl) GetTolerationsAnnotation(p *v1.Pod) string {
 func (wpmi *workerPodManagerImpl) HashAnnotationDiffer(p1, p2 *v1.Pod) bool {
 
 	if p1 == nil && p2 == nil {
-		return true
+		return false
 	}
 
 	if (p1 == nil && p2 != nil) || (p1 != nil) && (p2 == nil) {
-		return false
+		return true
 	}
 
 	return p1.Annotations[hashAnnotationKey] != p2.Annotations[hashAnnotationKey]


### PR DESCRIPTION
The NMC logic ensure we call this function in such a way we never fall into one of the 2 buggy `if` sections.
That said, if the implementation were to change, we could hit this bug in real time, therefore, this method should be fixed.