### PR TITLE
Fixing KMM-hub's upgrade flow from 2.3.0 --> 2.4.0.

### DIFF
--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 
 	"github.com/kubernetes-sigs/kernel-module-management/internal/config"
@@ -95,7 +96,11 @@ func main() {
 
 	cfg, err := cg.GetConfig(ctx, userConfigMapName, operatorNamespace, true)
 	if err != nil {
-		cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		if errors.Is(err, config.ErrCannotUseCustomConfig) {
+			setupLogger.Error(err, "failed to get kmm config")
+		} else {
+			cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		}
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -102,7 +103,11 @@ func main() {
 
 	cfg, err := cg.GetConfig(ctx, userConfigMapName, operatorNamespace, false)
 	if err != nil {
-		cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		if errors.Is(err, config.ErrCannotUseCustomConfig) {
+			setupLogger.Error(err, "failed to get kmm config")
+		} else {
+			cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		}
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,9 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 var _ = Describe("overrideConfigFromCM", func() {
@@ -163,6 +164,7 @@ var _ = Describe("GetConfig", func() {
 			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().getClient().Return(clnt, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().overrideConfigFromCM(gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
 		)
 		_, err := cg.GetConfig(ctx, "test-cm", "test-ns", false)
@@ -175,6 +177,7 @@ var _ = Describe("GetConfig", func() {
 			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().getClient().Return(clnt, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), cm).Return(nil),
+			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().overrideConfigFromCM(gomock.Any(), gomock.Any()).Return(nil),
 		)
 		_, err := cg.GetConfig(ctx, "test-cm", "test-ns", false)


### PR DESCRIPTION
The KMM-hub controller-config configMap had an invalid entry named `metricsBindAddress` in addition to the valid entry which is `metrics.bindAddress`. This issue didn't exist in the KMM controller-config configMap.

As part of making the operators configuration persist operator upgrads, we removed the default controller-config configMaps and changed the way we read the data. The most important part was that we started to parse this data in a strict way, failing in case there is an invalid entry in the data.

When upgrading from 2.3.0 --> 2.4.0, OLM (and operator-sdk) waits for the 2.4.0 to be installed *before* removing 2.3.0, therefore, 2.4.0 was thinking KMM-hub's old controller-config configMap was actually the user's custom config for 2.4.0, and failed due to a non valid field in our old default configMap.

Once the upgrade is done, OLM will remove the configMap since it was deployed as part of 2.3.0, therefore, since our default configs and the old configMap have the same values, then KMM-hub should be configured correctly even without the need to restart the controller pod.

---

/assign @yevgeny-shnaidman 