### PR TITLE
Setting the cluster as a hub cluster.

### DIFF
--- a/ci/prow/operator-hub-upgrade
+++ b/ci/prow/operator-hub-upgrade
@@ -21,6 +21,20 @@ make operator-sdk
 # ready
 timeout 3m bash -c 'until [ "$(kubectl -n olm get catalogsource/operatorhubio-catalog -o jsonpath={.status.connectionState.lastObservedState})" = "READY" ]; do sleep 5; done'
 
+# Install the `clusteradm` command
+curl -LO https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/v0.7.2/install.sh
+chmod +x install.sh
+./install.sh 0.7.2
+
+# Init OCM in the cluster
+clusteradm init --wait
+kubectl wait --for=condition=Available -n open-cluster-management deployment/cluster-manager
+kubectl wait --for=condition=Available --timeout=2m -n open-cluster-management-hub \
+    deployment/cluster-manager-placement-controller \
+    deployment/cluster-manager-registration-controller \
+    deployment/cluster-manager-registration-webhook \
+    deployment/cluster-manager-work-webhook
+
 # Deploy the current bundle
 kubectl -n olm patch svc/operatorhubio-catalog --type merge -p '{"spec":{"type": "NodePort"}}'
 catalog_url=$(minikube service operatorhubio-catalog -n olm --url | cut -d"/" -f3)


### PR DESCRIPTION
We need this step in order to install the `manifestwork` and `clusterclaim` CRDs in the cluster.

Without it, `operator-sdk` will still run and manage to do the upgrade but the installed operator will constantly fail due to missing CRDs in the cluster.

This is not affecting the job correctness which is only supposed to test the upgrade but it will make thing much easier if it fails and we need to inspect the "real failing logs" and not the one generated because of missing CRDs.

---

/assign @yevgeny-shnaidman 