### PR TITLE
Introducing DockerfileOCIArtifact field to Module CRD.

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -53,6 +53,11 @@ type Build struct {
 	DockerfileConfigMap *v1.LocalObjectReference `json:"dockerfileConfigMap"`
 
 	// +optional
+	// DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+	// used to build the kernel module container image.
+	DockerfileOCIArtifact string `json:"dockerfileOCIArtifact"`
+
+	// +optional
 	// BaseImageRegistryTLS contains settings determining how to access registries of the base images in the build-process' Dockerfile.
 	BaseImageRegistryTLS TLSOptions `json:"baseImageRegistryTLS,omitempty"`
 

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2521,6 +2521,11 @@ spec:
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              dockerfileOCIArtifact:
+                                description: |-
+                                  DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                                  used to build the kernel module container image.
+                                type: string
                               kanikoParams:
                                 description: KanikoParams is used to customize the
                                   building process of the image.
@@ -2648,6 +2653,11 @@ spec:
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    dockerfileOCIArtifact:
+                                      description: |-
+                                        DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                                        used to build the kernel module container image.
+                                      type: string
                                     kanikoParams:
                                       description: KanikoParams is used to customize
                                         the building process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -118,6 +118,11 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        dockerfileOCIArtifact:
+                          description: |-
+                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                            used to build the kernel module container image.
+                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -118,6 +118,11 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        dockerfileOCIArtifact:
+                          description: |-
+                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                            used to build the kernel module container image.
+                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2502,6 +2502,11 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          dockerfileOCIArtifact:
+                            description: |-
+                              DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                              used to build the kernel module container image.
+                            type: string
                           kanikoParams:
                             description: KanikoParams is used to customize the building
                               process of the image.
@@ -2626,6 +2631,11 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                dockerfileOCIArtifact:
+                                  description: |-
+                                    DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                                    used to build the kernel module container image.
+                                  type: string
                                 kanikoParams:
                                   description: KanikoParams is used to customize the
                                     building process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -118,6 +118,11 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        dockerfileOCIArtifact:
+                          description: |-
+                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                            used to build the kernel module container image.
+                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -118,6 +118,11 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        dockerfileOCIArtifact:
+                          description: |-
+                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                            used to build the kernel module container image.
+                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2502,6 +2502,11 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          dockerfileOCIArtifact:
+                            description: |-
+                              DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                              used to build the kernel module container image.
+                            type: string
                           kanikoParams:
                             description: KanikoParams is used to customize the building
                               process of the image.
@@ -2626,6 +2631,11 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                dockerfileOCIArtifact:
+                                  description: |-
+                                    DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
+                                    used to build the kernel module container image.
+                                  type: string
                                 kanikoParams:
                                   description: KanikoParams is used to customize the
                                     building process of the image.


### PR DESCRIPTION
As part of transitioning our builds to Shipwright using OCIArtifacts instead of pods running the Kaniko container, we need to allow users to specify the registry and artifact that contain the Dockerfile used for building the kernel module image.
The `dockerfileOCIArtifact` field will remain optional for now, until the migration to Shipwright is complete.

---

/cc @ybettan @yevgeny-shnaidman