### PR TITLE
Adjusting webhook for shipwright builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/mock v0.5.1
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/net v0.38.0
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.3
@@ -90,7 +91,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -173,6 +173,30 @@ func validateModuleLoaderContainerSpec(container kmmv1beta1.ModuleLoaderContaine
 			(km.InTreeModuleToRemove != "" && container.InTreeModulesToRemove != nil) { //nolint:staticcheck
 			return fmt.Errorf("only one type if field (InTreeModuleToRemove or InTreeModulesToRemove) can be defined in KenrelMapping or Container")
 		}
+
+		if err := validateModuleLoaderContainerBuildSpec(km.Build); err != nil {
+			return fmt.Errorf("failed to validate kernelMappings[%d].build: %v", idx, err)
+		}
+	}
+
+	return validateModuleLoaderContainerBuildSpec(container.Build)
+}
+
+func validateModuleLoaderContainerBuildSpec(build *kmmv1beta1.Build) error {
+	if build == nil {
+		return nil
+	}
+
+	if build.DockerfileOCIArtifact != "" && build.DockerfileConfigMap != nil {
+		return fmt.Errorf("only one of the Dockerfile fields: DockerfileOCIArtifact or DockerfileConfigMap can be defined")
+	}
+
+	if build.DockerfileOCIArtifact == "" && build.DockerfileConfigMap == nil {
+		return fmt.Errorf("one of the Dockerfile fields: DockerfileOCIArtifact or DockerfileConfigMap must be defined")
+	}
+
+	if build.DockerfileOCIArtifact != "" {
+		return validateImageFormat(build.DockerfileOCIArtifact)
 	}
 
 	return nil


### PR DESCRIPTION
As part of KMM transitioning to Shipwright, KMM's webhook should allow only the following scenarios:
1. DockerfileOCIArtifact is defined and not DockerfileConfigMap.
2. DockerfileConfigMap is defined and not DockerfileOCIArtifact.

---

/assign @yevgeny-shnaidman 
/cc @yevgeny-shnaidman @ybettan 
---

/hold
lets wait for #1154