### PR TITLE
Adding rbac for BuildRun resource

### DIFF
--- a/config/rbac-hub/role.yaml
+++ b/config/rbac-hub/role.yaml
@@ -87,6 +87,16 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - shipwright.io
+  resources:
+  - buildruns
+  verbs:
+  - create
+  - delete
+  - list
+  - patch
+  - watch
+- apiGroups:
   - work.open-cluster-management.io
   resources:
   - manifestworks

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -127,3 +127,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - shipwright.io
+  resources:
+  - buildruns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -67,6 +67,7 @@ type ManagedClusterModuleReconciler struct {
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=shipwright.io,resources=buildruns,verbs=list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -34,6 +34,7 @@ import (
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=shipwright.io,resources=buildruns,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;patch;watch
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;patch


### PR DESCRIPTION
As part of transitioning to Shipwright, we have to add RBAC roles for BuildRun resource as BuildRuns will be owned by KMM.
BuildRuns should have the same roles as pods because they will replace them as the default build mechanism.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @yevgeny-shnaidman 