### PR TITLE
Bumping `operator-sdk` and the project layout to `go.kubebuilder.io/v4`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ operator-sdk:
 		set -e ;\
 		echo "Downloading ${OPERATOR_SDK}"; \
 		mkdir -p $(dir ${OPERATOR_SDK}) ;\
-		curl -Lo ${OPERATOR_SDK} 'https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_linux_amd64'; \
+		curl -Lo ${OPERATOR_SDK} 'https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1/operator-sdk_linux_amd64'; \
 		chmod +x ${OPERATOR_SDK}; \
 	fi
 

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: sigs.x-k8s.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}


### PR DESCRIPTION
We were using an old version that was not supporting the generation or installation of bundle with `NetworkPolicies` manifests.

---

/assign @yevgeny-shnaidman 