### PR TITLE
Reverting Module CRD change from using OCIArtifacts to DockerfileConfigMap

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -53,11 +53,6 @@ type Build struct {
 	DockerfileConfigMap *v1.LocalObjectReference `json:"dockerfileConfigMap"`
 
 	// +optional
-	// DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-	// used to build the kernel module container image.
-	DockerfileOCIArtifact string `json:"dockerfileOCIArtifact"`
-
-	// +optional
 	// BaseImageRegistryTLS contains settings determining how to access registries of the base images in the build-process' Dockerfile.
 	BaseImageRegistryTLS TLSOptions `json:"baseImageRegistryTLS,omitempty"`
 

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2521,11 +2521,6 @@ spec:
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
-                              dockerfileOCIArtifact:
-                                description: |-
-                                  DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                                  used to build the kernel module container image.
-                                type: string
                               kanikoParams:
                                 description: KanikoParams is used to customize the
                                   building process of the image.
@@ -2653,11 +2648,6 @@ spec:
                                           type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
-                                    dockerfileOCIArtifact:
-                                      description: |-
-                                        DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                                        used to build the kernel module container image.
-                                      type: string
                                     kanikoParams:
                                       description: KanikoParams is used to customize
                                         the building process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -118,11 +118,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        dockerfileOCIArtifact:
-                          description: |-
-                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                            used to build the kernel module container image.
-                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -118,11 +118,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        dockerfileOCIArtifact:
-                          description: |-
-                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                            used to build the kernel module container image.
-                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2502,11 +2502,6 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
-                          dockerfileOCIArtifact:
-                            description: |-
-                              DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                              used to build the kernel module container image.
-                            type: string
                           kanikoParams:
                             description: KanikoParams is used to customize the building
                               process of the image.
@@ -2631,11 +2626,6 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
-                                dockerfileOCIArtifact:
-                                  description: |-
-                                    DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                                    used to build the kernel module container image.
-                                  type: string
                                 kanikoParams:
                                   description: KanikoParams is used to customize the
                                     building process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -118,11 +118,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        dockerfileOCIArtifact:
-                          description: |-
-                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                            used to build the kernel module container image.
-                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -118,11 +118,6 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
-                        dockerfileOCIArtifact:
-                          description: |-
-                            DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                            used to build the kernel module container image.
-                          type: string
                         kanikoParams:
                           description: KanikoParams is used to customize the building
                             process of the image.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2502,11 +2502,6 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
-                          dockerfileOCIArtifact:
-                            description: |-
-                              DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                              used to build the kernel module container image.
-                            type: string
                           kanikoParams:
                             description: KanikoParams is used to customize the building
                               process of the image.
@@ -2631,11 +2626,6 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
-                                dockerfileOCIArtifact:
-                                  description: |-
-                                    DockerfileOCIArtifact specifies an OCI artifact that contains the dockerfile
-                                    used to build the kernel module container image.
-                                  type: string
                                 kanikoParams:
                                   description: KanikoParams is used to customize the
                                     building process of the image.


### PR DESCRIPTION
Because we will not use OCIArtifacts with Shipwright for build and sign, we can revert KMM to use configmap to store the dockerfile.

---

Relevant pr - https://github.com/kubernetes-sigs/kernel-module-management/pull/1154

---

@ybettan @yevgeny-shnaidman