### PR TITLE
[WIP] Changing build and sign to use Buildah instead of Kaniko container

### DIFF
--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -17,7 +17,9 @@ data:
 
     WORKDIR /usr/src
 
-    RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+    COPY ci-build-secret .
+    
+    RUN grep super-secret-value ci-build-secret
 
     RUN git clone https://github.com/kubernetes-sigs/kernel-module-management.git
 

--- a/ci/module-kmm-ci-build-sign.yaml
+++ b/ci/module-kmm-ci-build-sign.yaml
@@ -23,9 +23,6 @@ spec:
               - name: build-secret
             dockerfileConfigMap:
               name: kmm-kmod-dockerfile
-            # Optional. If kanikoParams.tag is empty, the default value will be: 'latest'
-            kanikoParams:
-              tag: "debug"
           sign:
             certSecret:
               name: kmm-kmod-signing-cert

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -48,7 +48,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: RELATED_IMAGE_BUILD
-            value: gcr.io/kaniko-project/executor:latest
+            value: quay.io/buildah/stable:latest
           - name: RELATED_IMAGE_SIGN
             value: signer
         securityContext:

--- a/docs/mkdocs/documentation/kmod_image.md
+++ b/docs/mkdocs/documentation/kmod_image.md
@@ -72,7 +72,7 @@ The `ConfigMap` needs to be located in the same namespace as the `Module`.
 
 KMM will first check if the image name specified in the `containerImage` field exists.
 If it does, the build will be skipped.
-Otherwise, KMM will create a Pod to build your image using [kaniko](https://github.com/GoogleContainerTools/kaniko).
+Otherwise, KMM will create a Pod to build your image using [buildah](https://buildah.io/).
 
 The following build arguments are automatically set by KMM:
 

--- a/internal/buildsign/resource/templates/Dockerfile.gotmpl
+++ b/internal/buildsign/resource/templates/Dockerfile.gotmpl
@@ -3,10 +3,13 @@ FROM {{ .UnsignedImage }} as source
 
 FROM {{ .SignImage }} AS signimage
 
+COPY cert.pem cert.pem
+COPY key.pem key.pem
+
 RUN mkdir -p /tmp/signroot
 {{ range .FilesToSign }}
 COPY --from=source {{ . }} /tmp/signroot{{ . }}
-RUN /usr/local/bin/sign-file sha256 /run/secrets/key/key.pem /run/secrets/cert/cert.pem /tmp/signroot{{ . }}
+RUN /usr/local/bin/sign-file sha256 key.pem cert.pem /tmp/signroot{{ . }}
 {{- end }}
 
 FROM source

--- a/internal/buildsign/resource/templates/buildah-script.gotmpl
+++ b/internal/buildsign/resource/templates/buildah-script.gotmpl
@@ -1,0 +1,45 @@
+{{- /*gotype: github.com/kubernetes-sigs/kernel-module-management/internal/buildsign/resource.BuildahScriptData */ -}}
+export IMAGE="{{ .DestinationImg }}"
+export PUSH_IMAGE="{{ if .PushImage }}true{{ else }}false{{ end }}"
+
+{{ if .IsBuild -}}
+echo "setting up build context"
+mkdir -p /tmp/build-context
+cp /workspace/Dockerfile /tmp/build-context/
+
+for secret_dir in /run/secrets/*/; do
+    if [ -d "$secret_dir" ]; then
+        for file in "$secret_dir"*; do
+            if [ -f "$file" ]; then
+                filename=$(basename "$file")
+                cp -L "$file" "/tmp/build-context/$filename"
+            fi
+        done
+    fi
+done
+{{- else if .IsSign -}}
+echo "setting up build context with cert and key files"
+mkdir -p /tmp/build-context
+cp /workspace/Dockerfile /tmp/build-context/
+cp /run/secrets/cert/cert.pem /tmp/build-context/cert.pem
+cp /run/secrets/key/key.pem /tmp/build-context/key.pem
+{{- end }}
+
+echo "starting Buildah {{ .ActionDescription }} for $IMAGE"
+{{ .BuildCmd }} \
+  --tls-verify={{ if .TLSVerify }}true{{ else }}false{{ end }} \
+  --storage-driver=vfs \
+  -f /tmp/build-context/Dockerfile \
+  -t "$IMAGE" \
+  /tmp/build-context
+
+if [ "$PUSH_IMAGE" = "true" ]; then
+  echo "pushing {{ .PushDescription }} $IMAGE..."
+  buildah push \
+    --tls-verify={{ if .TLSVerify }}true{{ else }}false{{ end }} \
+    --storage-driver=vfs \
+    "$IMAGE" \
+    "docker://$IMAGE"
+else
+  echo "skipping push step (PUSH_IMAGE=$PUSH_IMAGE)"
+fi

--- a/internal/buildsign/resource/volumes.go
+++ b/internal/buildsign/resource/volumes.go
@@ -81,7 +81,7 @@ func makeBuildResourceVolumesAndVolumeMounts(buildConfig kmmv1beta1.Build,
 			v1.VolumeMount{
 				Name:      "secret-" + imageRepoSecret.Name,
 				ReadOnly:  true,
-				MountPath: "/kaniko/.docker",
+				MountPath: "/root/.docker",
 			},
 		)
 	}
@@ -176,12 +176,11 @@ func makeSignResourceVolumesAndVolumeMounts(signConfig *kmmv1beta1.Sign,
 			},
 		)
 
-		volumeMounts = append(
-			volumeMounts,
+		volumeMounts = append(volumeMounts,
 			v1.VolumeMount{
 				Name:      "secret-" + imageRepoSecret.Name,
 				ReadOnly:  true,
-				MountPath: "/kaniko/.docker",
+				MountPath: "/root/.docker",
 			},
 		)
 	}

--- a/internal/module/buildargoverrider.go
+++ b/internal/module/buildargoverrider.go
@@ -1,6 +1,9 @@
 package module
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -10,6 +13,7 @@ import (
 
 type BuildArgOverrider interface {
 	ApplyBuildArgOverrides(args []kmmv1beta1.BuildArg, overrides ...kmmv1beta1.BuildArg) []kmmv1beta1.BuildArg
+	FormatBuildArgs(buildArgs []kmmv1beta1.BuildArg) string
 }
 
 type buildArgOverrider struct{}
@@ -41,4 +45,12 @@ func (c *buildArgOverrider) ApplyBuildArgOverrides(args []kmmv1beta1.BuildArg, o
 	}
 
 	return args
+}
+
+func (c *buildArgOverrider) FormatBuildArgs(buildArgs []kmmv1beta1.BuildArg) string {
+	args := []string{}
+	for _, ba := range buildArgs {
+		args = append(args, "--build-arg", fmt.Sprintf("%s=%s", ba.Name, ba.Value))
+	}
+	return strings.Join(args, " ")
 }

--- a/internal/module/mock_buildargoverrider.go
+++ b/internal/module/mock_buildargoverrider.go
@@ -56,3 +56,17 @@ func (mr *MockBuildArgOverriderMockRecorder) ApplyBuildArgOverrides(args any, ov
 	varargs := append([]any{args}, overrides...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyBuildArgOverrides", reflect.TypeOf((*MockBuildArgOverrider)(nil).ApplyBuildArgOverrides), varargs...)
 }
+
+// FormatBuildArgs mocks base method.
+func (m *MockBuildArgOverrider) FormatBuildArgs(buildArgs []v1beta1.BuildArg) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FormatBuildArgs", buildArgs)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// FormatBuildArgs indicates an expected call of FormatBuildArgs.
+func (mr *MockBuildArgOverriderMockRecorder) FormatBuildArgs(buildArgs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatBuildArgs", reflect.TypeOf((*MockBuildArgOverrider)(nil).FormatBuildArgs), buildArgs)
+}


### PR DESCRIPTION
Because Kaniko is archived and thus not supported, it would be wise to change the build and sign feature to use Buildah container instead of Kaniko.
That way we can also match the build and sign d/s to behave the same.

---

/cc @ybettan @yevgeny-shnaidman 