### PR TITLE
Updating KMM's page in OperatorHub

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -34,10 +34,46 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+  controller: false
+  domain: sigs.x-k8s.io
+  group: kmm
+  kind: PreflightValidation
+  path: github.com/kubernetes-sigs/kernel-module-management/api/v1beta1
+  version: v1beta1
+- api:
+    crdVersion: v2
+    namespaced: true
   controller: true
   domain: sigs.x-k8s.io
   group: kmm
   kind: PreflightValidation
+  path: github.com/kubernetes-sigs/kernel-module-management/api/v1beta2
+  version: v1beta2
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: sigs.x-k8s.io
+  group: kmm
+  kind: ModuleBuildSignConfig
+  path: github.com/kubernetes-sigs/kernel-module-management/api/v1beta1
+  version: v1beta1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: sigs.x-k8s.io
+  group: kmm
+  kind: ModuleImagesConfig
+  path: github.com/kubernetes-sigs/kernel-module-management/api/v1beta1
+  version: v1beta1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: sigs.x-k8s.io
+  group: kmm
+  kind: NodeModulesConfig
   path: github.com/kubernetes-sigs/kernel-module-management/api/v1beta1
   version: v1beta1
 version: "3"

--- a/api/v1beta1/modulebuildsignconfig_types.go
+++ b/api/v1beta1/modulebuildsignconfig_types.go
@@ -84,7 +84,7 @@ type ModuleBuildSignConfigStatus struct {
 
 // ModuleBuildSignConfig keeps the request for images' build/sign for a KMM Module.
 // +kubebuilder:resource:path=modulebuildsignconfigs,scope=Namespaced,shortName=mbsc
-// +operator-sdk:csv:customresourcedefinitions:displayName="Module Build Sign Config"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Module Build Sign Config (internal)"
 type ModuleBuildSignConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -99,7 +99,7 @@ type ModuleImagesConfigStatus struct {
 
 // ModuleImagesConfig keeps the request for images' state for a KMM Module.
 // +kubebuilder:resource:path=moduleimagesconfigs,scope=Namespaced,shortName=mic
-// +operator-sdk:csv:customresourcedefinitions:displayName="Module Images Config"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Module Images Config (internal)"
 type ModuleImagesConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -86,7 +86,7 @@ type NodeModulesConfigStatus struct {
 
 // NodeModulesConfig keeps spec and state of the KMM modules on a node.
 // +kubebuilder:resource:path=nodemodulesconfigs,scope=Cluster,shortName=nmc
-// +operator-sdk:csv:customresourcedefinitions:displayName="Node Modules Config"
+// +operator-sdk:csv:customresourcedefinitions:displayName="Node Modules Config (internal)"
 type NodeModulesConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -55,11 +55,11 @@ type PreflightValidationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-
+// +operator-sdk:csv:customresourcedefinitions:displayName="Preflight Validation (deprecated)"
 // PreflightValidation initiates a preflight validations for all Modules on the current Kubernetes cluster.
+// Deprecated in favor of v1beta2.
 // +kubebuilder:resource:path=preflightvalidations,scope=Cluster,shortName=pfv
 // +kubebuilder:deprecatedversion
-// +operator-sdk:csv:customresourcedefinitions:displayName="Preflight Validation"
 type PreflightValidation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -20,8 +20,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: PreflightValidation initiates a preflight validations for all
-          Modules on the current Kubernetes cluster.
+        description: |-
+          PreflightValidation initiates a preflight validations for all Modules on the current Kubernetes cluster.
+          Deprecated in favor of v1beta2.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -20,8 +20,9 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: PreflightValidation initiates a preflight validations for all
-          Modules on the current Kubernetes cluster.
+        description: |-
+          PreflightValidation initiates a preflight validations for all Modules on the current Kubernetes cluster.
+          Deprecated in favor of v1beta2.
         properties:
           apiVersion:
             description: |-

--- a/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
+++ b/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
@@ -12,14 +12,39 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: ModuleBuildSignConfig keeps the request for images' build/sign
+        for a KMM Module.
+      displayName: Module Build Sign Config (internal)
+      kind: ModuleBuildSignConfig
+      name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
+    - description: ModuleImagesConfig keeps the request for images' state for a KMM
+        Module.
+      displayName: Module Images Config (internal)
+      kind: ModuleImagesConfig
+      name: moduleimagesconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
     - description: Module describes how to load a module on different kernel versions
       displayName: Module
       kind: Module
       name: modules.kmm.sigs.x-k8s.io
       version: v1beta1
+    - description: NodeModulesConfig keeps spec and state of the KMM modules on a
+        node.
+      displayName: Node Modules Config (internal)
+      kind: NodeModulesConfig
+      name: nodemodulesconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
     - description: PreflightValidation initiates a preflight validations for all Modules
         on the current Kubernetes cluster.
       displayName: Preflight Validation
+      kind: PreflightValidation
+      name: preflightvalidations.kmm.sigs.x-k8s.io
+      version: v1beta2
+    - description: |-
+        PreflightValidation initiates a preflight validations for all Modules on the current Kubernetes cluster.
+        Deprecated in favor of v1beta2.
+      displayName: Preflight Validation (deprecated)
       kind: PreflightValidation
       name: preflightvalidations.kmm.sigs.x-k8s.io
       version: v1beta1

--- a/config/samples/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -1,0 +1,13 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: ModuleBuildSignConfig
+metadata:
+  name: modulebuildsignconfig-sample
+spec:
+  images:
+  - image: quay.io/myorg/my-kernel-module:latest
+    kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
+    action: BuildImage
+    build:
+      dockerfileConfigMap:
+        name: my-dockerfile-configmap
+  pushBuiltImage: true

--- a/config/samples/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -1,0 +1,10 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: ModuleImagesConfig
+metadata:
+  name: moduleimagesconfig-sample
+spec:
+  images:
+  - image: quay.io/myorg/my-kernel-module:v1.0.0
+    kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
+  imagePullPolicy: IfNotPresent
+  pushBuiltImage: false

--- a/config/samples/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -1,0 +1,17 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: NodeModulesConfig
+metadata:
+  name: nodemodulesconfig-sample
+spec:
+  modules:
+  - name: my-kmod
+    namespace: default
+    serviceAccountName: kmm-operator-controller
+    config:
+      kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
+      containerImage: quay.io/myorg/my-kernel-module:latest
+      imagePullPolicy: IfNotPresent
+      insecurePull: false
+      modprobe:
+        moduleName: my_kmod
+        dirName: /opt

--- a/config/samples/kmm.sigs.x-k8s.io_v1beta2_preflightvalidations.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_v1beta2_preflightvalidations.yaml
@@ -1,0 +1,7 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta2
+kind: PreflightValidation
+metadata:
+  name: preflightvalidation-sample-v1beta2
+spec:
+  kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
+  pushBuiltImage: true

--- a/config/samples/kustomization.yml
+++ b/config/samples/kustomization.yml
@@ -5,4 +5,8 @@ kind: Kustomization
 resources:
   - kmm.sigs.x-k8s.io_modules.yaml
   - kmm.sigs.x-k8s.io_preflightvalidations.yaml
+  - kmm.sigs.x-k8s.io_v1beta2_preflightvalidations.yaml
+  - kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+  - kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+  - kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
When entering KMM's page in operator-hub, we can see bunch of CRDs with "Name Not Available".
This commit updates PROJECT to include those missing crds in the csv and adding each one a sample yaml.

---

KMM page [here](https://operatorhub.io/operator/kernel-module-management)
Page to test the look of the new page [here](https://operatorhub.io/preview)

---

/cc @yevgeny-shnaidman @ybettan 

---

<img width="1741" height="852" alt="Screenshot From 2025-09-09 11-32-29" src="https://github.com/user-attachments/assets/8c79345f-b1ca-40cd-a5c9-783c7d7e197a" />
