### PR TITLE
Adding "version.ready" label to the ordered upgrade flow

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -44,6 +44,9 @@ type ModuleItem struct {
 	//+optional
 	// tolerations define which tolerations should be added for every load/unload pod running on the node
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	//+optional
+	// Version is the version of the kernel module that should be loaded
+	Version string `json:"version,omitempty"`
 }
 
 type NodeModuleSpec struct {

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -222,6 +222,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - config
                   - name
@@ -415,6 +419,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - name
                   - namespace

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -222,6 +222,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - config
                   - name
@@ -415,6 +419,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - name
                   - namespace

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -192,10 +192,10 @@ func (mr *MocklabelPreparationHelperMockRecorder) addEqualLabels(nodeModuleReady
 }
 
 // getDeprecatedKernelModuleReadyLabels mocks base method.
-func (m *MocklabelPreparationHelper) getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string] {
+func (m *MocklabelPreparationHelper) getDeprecatedKernelModuleReadyLabels(node v1.Node) map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getDeprecatedKernelModuleReadyLabels", node)
-	ret0, _ := ret[0].(sets.Set[string])
+	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
@@ -245,6 +245,20 @@ func (m *MocklabelPreparationHelper) getStatusLabelsAndTheirConfigs(nmc *v1beta1
 func (mr *MocklabelPreparationHelperMockRecorder) getStatusLabelsAndTheirConfigs(nmc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatusLabelsAndTheirConfigs", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getStatusLabelsAndTheirConfigs), nmc)
+}
+
+// getStatusVersions mocks base method.
+func (m *MocklabelPreparationHelper) getStatusVersions(nmc *v1beta1.NodeModulesConfig) map[types.NamespacedName]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getStatusVersions", nmc)
+	ret0, _ := ret[0].(map[types.NamespacedName]string)
+	return ret0
+}
+
+// getStatusVersions indicates an expected call of getStatusVersions.
+func (mr *MocklabelPreparationHelperMockRecorder) getStatusVersions(nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatusVersions", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getStatusVersions), nmc)
 }
 
 // removeOrphanedLabels mocks base method.

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -70,6 +70,7 @@ func (h *helper) SetModuleConfig(
 	foundEntry.ImageRepoSecret = mld.ImageRepoSecret
 	foundEntry.ServiceAccountName = saName
 	foundEntry.Tolerations = mld.Tolerations
+	foundEntry.Version = mld.ModuleVersion
 
 	return nil
 }

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -98,7 +98,7 @@ func (mr *MockNodeMockRecorder) IsNodeSchedulable(node, tolerations any) *gomock
 }
 
 // UpdateLabels mocks base method.
-func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
+func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLabels", ctx, node, toBeAdded, toBeRemoved)
 	ret0, _ := ret[0].(error)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -15,7 +15,7 @@ type Node interface {
 	IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool
 	GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
-	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error
+	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error
 	IsNodeRebooted(node *v1.Node, statusBootId string) bool
 }
 
@@ -72,7 +72,7 @@ func (n *node) GetNumTargetedNodes(ctx context.Context, selector map[string]stri
 	return len(targetedNode), nil
 }
 
-func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
+func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
 	patchFrom := client.MergeFrom(node.DeepCopy())
 
 	addLabels(node, toBeAdded)
@@ -95,18 +95,18 @@ func (n *node) IsNodeRebooted(node *v1.Node, statusBootId string) bool {
 	return false
 }
 
-func addLabels(node *v1.Node, labels []string) {
-	for _, label := range labels {
+func addLabels(node *v1.Node, labels map[string]string) {
+	for label, value := range labels {
 		meta.SetLabel(
 			node,
 			label,
-			"",
+			value,
 		)
 	}
 }
 
-func removeLabels(node *v1.Node, labels []string) {
-	for _, label := range labels {
+func removeLabels(node *v1.Node, labels map[string]string) {
+	for label := range labels {
 		meta.RemoveLabel(
 			node,
 			label,

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -186,8 +186,8 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
-		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
+		loaded := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
+		unloaded := map[string]string{unloadedKernelModuleReadyNodeLabel: ""}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -202,8 +202,8 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
-		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
+		loaded := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
+		unloaded := map[string]string{unloadedKernelModuleReadyNodeLabel: ""}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
@@ -329,7 +329,7 @@ var _ = Describe("removeLabels", func() {
 	})
 
 	It("Should remove labels", func() {
-		labels := []string{firstloadedKernelModuleReadyNodeLabel}
+		labels := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
 		removeLabels(&node, labels)
 		Expect(node.Labels).ToNot(HaveKey(firstloadedKernelModuleReadyNodeLabel))
 	})

--- a/internal/pod/mock_workerpodmanager.go
+++ b/internal/pod/mock_workerpodmanager.go
@@ -97,6 +97,20 @@ func (mr *MockWorkerPodManagerMockRecorder) GetConfigAnnotation(p any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetConfigAnnotation), p)
 }
 
+// GetModuleVersionAnnotation mocks base method.
+func (m *MockWorkerPodManager) GetModuleVersionAnnotation(p *v1.Pod) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleVersionAnnotation", p)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetModuleVersionAnnotation indicates an expected call of GetModuleVersionAnnotation.
+func (mr *MockWorkerPodManagerMockRecorder) GetModuleVersionAnnotation(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleVersionAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetModuleVersionAnnotation), p)
+}
+
 // GetTolerationsAnnotation mocks base method.
 func (m *MockWorkerPodManager) GetTolerationsAnnotation(p *v1.Pod) string {
 	m.ctrl.T.Helper()

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -76,6 +76,10 @@ func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
 }
 
+func GetKernelModuleVersionReadyNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.version.ready", namespace, moduleName)
+}
+
 func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }


### PR DESCRIPTION
Currently we have only one "ready" label to signify that the kernel module is loaded successfuly. In order upgrade scenario, the user needs to know that the loaded module is actually the one with the targeted module version, in order to coordinated further actions. This PR introduces a new label: kmm.node.kubernetes.io/%s.%s.version.ready, whose value will signify the version of the currently loaded kernel module.
The changes in the code are:
1. Adding Version field both to status and spec of NMC (will be used to construct the new label)
2. Polulating the Version field of the NCM's spec during NMC update/create
3. Adding the "version" annotation to the worker pod, so that the version may be extracted for NMC's status
4. Changing the Node package API to receive maps instead of slice for labels to be added/remove. This is done since now we must also update the value of the label, and not just the key
5. Rewrite the UpdateNodeLabel function in the NMC controller to support new flow and new Node API
6. In case "ready" label is removed, we also automaticaly remove "version.ready" label. If it does not exists - nothing happens
7. In case "ready" label needs to be added, we check if the version field exists in the NMC status, and if it does, then we add the "version.ready" label with appropriate value