### PR TITLE
Fixiמg the unschedulable node version ready label removal

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -111,6 +111,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		// skipping handling NMC spec module until node is ready
 		if !r.nodeAPI.IsNodeSchedulable(&node, mod.Tolerations) {
 			readyLabelsToRemove[utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name)] = ""
+			readyLabelsToRemove[utils.GetKernelModuleVersionReadyNodeLabel(mod.Namespace, mod.Name)] = ""
 			delete(statusMap, moduleNameKey)
 			continue
 		}

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -31,15 +31,16 @@ import (
 )
 
 const (
-	nmcName          = "nmc"
-	nsFirst          = "example-ns-1"
-	nsSecond         = "example-ns-2"
-	nameFirst        = "example-name-1"
-	nameSecond       = "example-name-2"
-	imageFirst       = "example-image-1"
-	imageSecond      = "example-image-2"
-	kmodName         = "kmm.node.kubernetes.io/test-ns.test-module.ready"
-	labelNotToRemove = "example.node.kubernetes.io/label-not-to-be-removed"
+	nmcName               = "nmc"
+	nsFirst               = "example-ns-1"
+	nsSecond              = "example-ns-2"
+	nameFirst             = "example-name-1"
+	nameSecond            = "example-name-2"
+	imageFirst            = "example-image-1"
+	imageSecond           = "example-image-2"
+	kmodReadyLabel        = "kmm.node.kubernetes.io/test-ns.test-module.ready"
+	kmodVersionReadyLabel = "kmm.node.kubernetes.io/test-ns.test-module.version.ready"
+	labelNotToRemove      = "example.node.kubernetes.io/label-not-to-be-removed"
 )
 
 var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
@@ -138,7 +139,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 		node := v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					kmodName:         "",
+					kmodReadyLabel:   "",
 					labelNotToRemove: "",
 				},
 			},
@@ -165,9 +166,10 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			),
 			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
-			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodName: ""}).DoAndReturn(
+			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodReadyLabel: "", kmodVersionReadyLabel: ""}).DoAndReturn(
 				func(_ context.Context, obj ctrlclient.Object, _, _ map[string]string) error {
-					delete(node.ObjectMeta.Labels, kmodName)
+					delete(node.ObjectMeta.Labels, kmodReadyLabel)
+					delete(node.ObjectMeta.Labels, kmodVersionReadyLabel)
 					return nil
 				},
 			),
@@ -194,8 +196,9 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 		node := v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					kmodName:         "",
-					labelNotToRemove: "",
+					kmodReadyLabel:        "",
+					kmodVersionReadyLabel: "2",
+					labelNotToRemove:      "",
 				},
 			},
 		}
@@ -221,7 +224,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			),
 			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
-			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodName: ""}).DoAndReturn(
+			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodReadyLabel: "", kmodVersionReadyLabel: ""}).DoAndReturn(
 				func(_ context.Context, obj ctrlclient.Object, _, _ map[string]string) error {
 					return fmt.Errorf("some error")
 				},


### PR DESCRIPTION
In case node becomes unschedulable (cordon, taint wihtout toleration etc'), the kmod ready version is removed. In addition, the kmod version ready label should also be removed. We do it unconditionally, since the action does not produce error even if the label does not exists on the node