### PR TITLE
Fixing the image references in the bundle samples.

### DIFF
--- a/config/samples/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: modulebuildsignconfig-sample
 spec:
   images:
-  - image: quay.io/myorg/my-kernel-module:latest
+  - image: <kmod container image URL>
     kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
     action: BuildImage
     build:

--- a/config/samples/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: moduleimagesconfig-sample
 spec:
   images:
-  - image: quay.io/myorg/my-kernel-module:v1.0.0
+  - image: <kmod container image URL>
     kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
   imagePullPolicy: IfNotPresent
   pushBuiltImage: false

--- a/config/samples/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/samples/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -9,7 +9,7 @@ spec:
     serviceAccountName: kmm-operator-controller
     config:
       kernelVersion: 4.18.0-372.32.1.el8_6.x86_64
-      containerImage: quay.io/myorg/my-kernel-module:latest
+      containerImage: <kmod container image URL>
       imagePullPolicy: IfNotPresent
       insecurePull: false
       modprobe:


### PR DESCRIPTION
When building the bundle locally we usually use `make bundle` but when building it in cloudbuild for publishing in operatorhub.io, we use `make bundle ... USE_IMAGEDIGESTS=true` which will eventually generate the manifests and run `operator-sdk generate bundle ... --use-image-digests`.

While the main purpose of this flag is to refer all images by digest, it also, as a side effect, pull those images to discover their digest.

Since we are using dummy images in the CSV samples, with a "real" image URL, operator-sdk treats those as actual pullable images, and tries to pull them to discover their digest.

This commit is changing the dummy images with a "place holder description" instead of a valuable URL to prevent `operator-sdk` treating those as real images.

---

/assign @TomerNewman @yevgeny-shnaidman 

[Cloudbuilds](https://console.cloud.google.com/cloud-build/builds?referrer=search&project=k8s-staging-kmm&authuser=1) are filing for ~2 months now.