### PR TITLE
Replace deprecated golang.org/x/net/context with stdlib context

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/go-logr/logr"
-	"golang.org/x/net/context"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,12 +5,12 @@ import (
 	"os"
 	"time"
 
+	"context"
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/config/mock_config.go
+++ b/internal/config/mock_config.go
@@ -9,10 +9,10 @@
 package config
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
-	context "golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	client "sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
The golang.org/x/net/context package has been deprecated in favor of the standard library context package.
It is recommended in the docs to use the standard library instead.

Reference [here](https://pkg.go.dev/golang.org/x/net/context)

---

/cc @yevgeny-shnaidman @ybettan 