### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/collect-troubleshooting/action.yml
+++ b/.github/actions/collect-troubleshooting/action.yml
@@ -20,7 +20,7 @@ runs:
       run: kubectl support-bundle -o support-bundle.tar.gz ./support/kmm.spec.yaml
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ inputs.artifact-name }}
         path: support-bundle.tar.gz

--- a/.github/actions/create-minikube-cluster/action.yml
+++ b/.github/actions/create-minikube-cluster/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
 
     - name: Cache Minikube artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.minikube/cache
         key: ${{ runner.os }}-minikube-${{ steps.install-minikube.outputs.version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,16 +38,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - if: matrix.language == 'go'
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.25'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,4 +59,4 @@ jobs:
       run: make manager manager-hub worker
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build the image
         run: make docker-build IMG=kmm:local
@@ -23,7 +23,7 @@ jobs:
         run: docker save -o kmm_local.tar kmm:local
 
       - name: Upload the image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-image-kmm
           if-no-files-found: error
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build the image
         run: make docker-build-hub HUB_IMG=kmm-hub:local
@@ -46,7 +46,7 @@ jobs:
         run: docker save -o kmm-hub_local.tar kmm-hub:local
 
       - name: Upload the image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-image-kmm-hub
           if-no-files-found: error
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build the image
         run:  make signimage-build SIGNER_IMG=kmm-signimage:local
@@ -69,7 +69,7 @@ jobs:
         run: docker save -o kmm-signimage_local.tar kmm-signimage:local
 
       - name: Upload the image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-image-signer
           if-no-files-found: error
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build the image
         run:  make workerimage-build WORKER_IMG=kmm-worker:local
@@ -92,7 +92,7 @@ jobs:
         run: docker save -o kmm-worker_local.tar kmm-worker:local
 
       - name: Upload the image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-image-worker
           if-no-files-found: error
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build the image
         run: make webhookimage-build WEBHOOK_IMG=kmm-webhook-server:local
@@ -115,7 +115,7 @@ jobs:
         run: docker save -o kmm-webhook-server_local.tar kmm-webhook-server:local
 
       - name: Upload the image
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ci-image-webhook-server
           if-no-files-found: error
@@ -149,7 +149,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
@@ -157,7 +157,7 @@ jobs:
           start-args: --insecure-registry=host.minikube.internal:5000
 
       - name: Download container images
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -184,12 +184,12 @@ jobs:
           grep 'VERSION_ID=' /etc/os-release >> "$GITHUB_ENV"
 
       - name: Cache binaries needed by Makefile
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./bin
           key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -218,7 +218,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
@@ -226,7 +226,7 @@ jobs:
           start-args: --insecure-registry=host.minikube.internal:5000
 
       - name: Download container images
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -254,12 +254,12 @@ jobs:
           grep 'VERSION_ID=' /etc/os-release >> "$GITHUB_ENV"
 
       - name: Cache binaries needed by Makefile
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./bin
           key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -294,7 +294,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
@@ -302,7 +302,7 @@ jobs:
           start-args: --insecure-registry=host.minikube.internal:5000
 
       - name: Download container images
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -327,12 +327,12 @@ jobs:
           grep 'VERSION_ID=' /etc/os-release >> "$GITHUB_ENV"
 
       - name: Cache binaries needed by Makefile
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ./bin
           key: ${{ runner.os }}-${{ env.ID }}-${{ env.VERSION_ID }}-bin-${{ env.GO_VERSION }}-${{ hashFiles('Makefile') }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 

--- a/.github/workflows/test-codecov.yml
+++ b/.github/workflows/test-codecov.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.25'
 
@@ -26,4 +26,4 @@ jobs:
       run: make unit-test
 
     - name: Upload the coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5


### PR DESCRIPTION
The kubernetes-sigs org requires all actions to be pinned to a full length commit SHA.
this commit replaces version tags with their corresponding commit SHAs across all workflow files.

[Reference](https://github.com/kubernetes/community/commit/3bab02862e782850d6060677c1422c47424a668f)

[example](https://github.com/kubernetes-sigs/kernel-module-management/actions/runs/24652955922/job/72079628482?pr=1253) failture

---

/cc @ybettan @yevgeny-shnaidman 