### PR TITLE
Add dev skills for local KMM development, e2e testing and order upgrade testing

### DIFF
--- a/.agents/skills/kmm-dev-setup/SKILL.md
+++ b/.agents/skills/kmm-dev-setup/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: kmm-dev-setup
+description: >-
+  Set up a local KMM (Kernel Module Management) dev environment from scratch.
+  Use when the user asks to create, rebuild, redeploy, or tear down a KMM
+  development environment, or when you need a running KMM instance to test changes.
+---
+# KMM Dev Environment Setup
+
+All commands below assume you are in the repository root.
+
+Follow these steps to get a working KMM instance running your current code.
+
+## Step 1: Create a multi-node Minikube cluster with a local registry
+
+Check if a cluster already exists:
+
+```bash
+minikube status
+```
+
+- If the cluster is running **and** was created with `--driver=docker --nodes=3`, skip to Step 2.
+- If the cluster exists but uses the wrong driver or node count, delete it first with `minikube delete`.
+- If no cluster exists, create one:
+
+Start the local registry (removes any leftover container first):
+
+```bash
+docker rm -f kmm-registry 2>/dev/null || true
+docker run -d -p 5000:5000 --name kmm-registry registry:2
+```
+
+Create a 3-node cluster (1 control-plane + 2 workers) using the **Docker driver**:
+
+```bash
+minikube start --nodes=3 --driver=docker --insecure-registry=host.minikube.internal:5000
+```
+
+> **Important**: Always use `--driver=docker`. The Podman driver has broken pod DNS (pods cannot resolve external names like `gcr.io`), which breaks the Kaniko build/sign pipeline.
+
+Configure CRI-O on all nodes to trust the insecure registry (the `--insecure-registry` flag alone does not configure CRI-O):
+
+```bash
+for node in minikube minikube-m02 minikube-m03; do
+  minikube ssh -n $node -- sudo bash -c '"mkdir -p /etc/containers/registries.conf.d && cat > /etc/containers/registries.conf.d/host-minikube.conf <<EOF
+[[registry]]
+location = \"host.minikube.internal:5000\"
+insecure = true
+EOF"'
+  minikube ssh -n $node -- sudo systemctl restart crio
+done
+```
+
+To destroy the cluster when done:
+
+```bash
+minikube delete
+docker rm -f kmm-registry
+```
+
+## Step 2: Build images from current code
+
+Generate a unique tag and build only the images affected by your changes:
+
+```bash
+TAG=$(date +%Y%m%d%H%M%S)
+```
+
+Build the controller image (if controller code changed):
+
+```bash
+make docker-build IMG=kmm-controller:$TAG
+```
+
+Build the webhook image (if webhook code changed):
+
+```bash
+make webhookimage-build WEBHOOK_IMG=kmm-webhook:$TAG
+```
+
+Only rebuild images whose code you actually modified. Use a **unique tag each time** you rebuild. If you reuse the same tag, the cluster nodes will use the cached image and ignore the new one.
+
+## Step 3: Load images into the cluster
+
+```bash
+minikube image load kmm-controller:$TAG
+minikube image load kmm-webhook:$TAG
+```
+
+This distributes the images to all nodes in the cluster.
+
+Verify the images are available:
+
+```bash
+minikube image list | grep kmm-controller
+```
+
+## Step 4: Deploy KMM
+
+```bash
+make deploy \
+  IMG=localhost/kmm-controller:$TAG \
+  WEBHOOK_IMG=localhost/kmm-webhook:$TAG
+```
+
+This installs cert-manager (required dependency), generates CRDs/RBAC/webhook manifests, and applies everything to the cluster via kustomize.
+
+Note: `make deploy` edits kustomization files under `config/` to set image references. These changes show up in `git status` but should not be committed.
+
+## Redeploy after code changes
+
+Set a new `TAG=$(date +%Y%m%d%H%M%S)` and repeat steps 2-4.
+
+## Tear down
+
+```bash
+make undeploy
+```
+
+This also removes cert-manager.

--- a/.agents/skills/kmm-e2e/Dockerfile.base
+++ b/.agents/skills/kmm-e2e/Dockerfile.base
@@ -1,0 +1,6 @@
+FROM alpine:latest
+ARG KERNEL_VERSION
+RUN apk add --no-cache kmod
+COPY kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
+COPY kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN depmod -b /opt

--- a/.agents/skills/kmm-e2e/SKILL.md
+++ b/.agents/skills/kmm-e2e/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: kmm-e2e
+description: >-
+  Run a manual e2e test for KMM: deploy the operator, create build/sign resources,
+  apply a Module, and verify the kernel module loads on the node. Use when the user
+  asks to run an e2e test, verify a kernel module loads, or test the full
+  build-sign-load pipeline.
+---
+# KMM E2E Test
+
+This skill walks through a manual e2e test of the KMM build-sign-load pipeline on a Minikube cluster. It builds kernel modules on the host (where headers already exist) and uses a trivial Dockerfile for the in-cluster build.
+
+All commands assume you are in the repository root. This skill directory contains:
+
+- `Dockerfile.base` — base image with both `kmm_ci_a.ko` and `kmm_ci_b.ko`
+- `module.yaml` — Module CR template; `$BASE_TAG` is substituted at apply time via `envsubst`
+
+## Step 1: Ensure a running KMM environment
+
+Use the **kmm-dev-setup** skill to ensure a Minikube cluster is running with KMM deployed from the current code. The cluster must use `--driver=docker` and have the local registry (`kmm-registry`) running.
+
+Verify both deployments are available:
+
+```bash
+kubectl wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook -n kmm-operator-system
+```
+
+## Step 2: Verify the local registry is running
+
+The **kmm-dev-setup** skill creates a `kmm-registry` container. Verify it is running:
+
+```bash
+docker ps --filter name=kmm-registry --format '{{.Names}}'
+```
+
+If it is not running, start it:
+
+```bash
+docker rm -f kmm-registry 2>/dev/null || true
+docker run -d -p 5000:5000 --name kmm-registry registry:2
+```
+
+## Step 3: Build the kernel modules locally
+
+The `.ko` files must be built for the same kernel running on the Minikube nodes. With the Docker driver, Minikube nodes share the host kernel, so building on the host produces compatible modules.
+
+Prerequisites: `gcc`, `make`, and kernel headers on the host (`/lib/modules/$(uname -r)/build` must exist).
+
+Build from inside the `ci/kmm-kmod` directory:
+
+```bash
+(cd ci/kmm-kmod && make all)
+```
+
+Verify `kmm_ci_a.ko` and `kmm_ci_b.ko` were created.
+
+## Step 4: Build images, create resources, and apply the Module
+
+This step must run as a single script because `$BASE_TAG` is used for the base image tag, the Dockerfile ConfigMap, and the Module image name.
+
+```bash
+KERNEL_VER=$(minikube ssh -- uname -r | tr -d '\r')
+export BASE_TAG=$(date +%s)
+SKILL_DIR=.agents/skills/kmm-e2e
+
+docker build --build-arg KERNEL_VERSION=$KERNEL_VER \
+  -t localhost:5000/kmm-kmod-base:$BASE_TAG -f $SKILL_DIR/Dockerfile.base ci/kmm-kmod/
+
+docker push localhost:5000/kmm-kmod-base:$BASE_TAG
+
+kubectl create secret generic build-secret \
+  --from-literal=ci-build-secret=super-secret-value \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create configmap kmm-kmod-dockerfile \
+  --from-literal=dockerfile="$(cat <<EOF
+FROM host.minikube.internal:5000/kmm-kmod-base:$BASE_TAG
+RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+EOF
+)" --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f ci/secret_kmm-kmod-signing.yaml
+
+envsubst '$BASE_TAG' < $SKILL_DIR/module.yaml | kubectl apply -f -
+```
+
+The `envsubst` substitutes only `$BASE_TAG` in the Module template — KMM handles `$MOD_NAMESPACE`, `$MOD_NAME`, and `$KERNEL_FULL_VERSION` internally at runtime.
+
+This triggers the full pipeline: **build pod -> sign pod -> worker pod**. Wait for the module to be ready:
+
+```bash
+echo "Waiting for module ready on minikube-m02..."
+until kubectl get node minikube-m02 -o jsonpath='{.metadata.labels}' 2>/dev/null | grep -q "kmm.node.kubernetes.io/default.kmm-ci.ready"; do
+  sleep 5
+done
+echo "Module ready"
+```
+
+If it takes longer than 3 minutes, check pod status and logs:
+
+```bash
+kubectl get pods -l kmm.node.kubernetes.io/module.name=kmm-ci
+kubectl logs -l kmm.node.kubernetes.io/module.name=kmm-ci --prefix
+```
+
+## Step 5: Verify the module is loaded on the target worker
+
+Check `minikube-m02` (the node selected in Step 4):
+
+```bash
+minikube ssh -n minikube-m02 -- lsmod | grep kmm_ci
+```
+
+Both `kmm_ci_a` and `kmm_ci_b` should appear. If either is missing, the test failed.
+
+## Cleanup
+
+Remove the Module (triggers module unload):
+
+```bash
+kubectl delete module --all --wait=false
+```
+
+Verify modules are unloaded:
+
+```bash
+minikube ssh -n minikube-m02 -- lsmod | grep kmm_ci  # should return nothing
+```
+
+Clean up resources:
+
+```bash
+kubectl delete secret build-secret kmm-kmod-signing-cert kmm-kmod-signing-key --ignore-not-found
+kubectl delete configmap kmm-kmod-dockerfile --ignore-not-found
+```
+
+Clean up locally-built .ko files:
+
+```bash
+(cd ci/kmm-kmod && make -C /lib/modules/$(uname -r)/build M=$(pwd) clean)
+```
+
+Optionally stop the registry:
+
+```bash
+docker rm -f kmm-registry
+```

--- a/.agents/skills/kmm-e2e/module.yaml
+++ b/.agents/skills/kmm-e2e/module.yaml
@@ -1,0 +1,37 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci
+spec:
+  moduleLoader:
+    container:
+      inTreeModulesToRemove:
+        - dummy
+      modprobe:
+        moduleName: kmm_ci_a
+        modulesLoadingOrder: [kmm_ci_a, kmm_ci_b]
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME-${BASE_TAG}:$KERNEL_FULL_VERSION
+          registryTLS:
+            insecure: true
+          build:
+            baseImageRegistryTLS:
+              insecure: true
+            secrets:
+              - name: build-secret
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+            kanikoParams:
+              tag: "debug"
+          sign:
+            certSecret:
+              name: kmm-kmod-signing-cert
+            keySecret:
+              name: kmm-kmod-signing-key
+            unsignedImageRegistryTLS:
+              insecure: true
+            filesToSign:
+              - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_?.ko
+  selector:
+    kubernetes.io/hostname: minikube-m02

--- a/.agents/skills/kmm-ordered-upgrade/Dockerfile.v1
+++ b/.agents/skills/kmm-ordered-upgrade/Dockerfile.v1
@@ -1,0 +1,5 @@
+FROM alpine:latest
+ARG KERNEL_VERSION
+RUN apk add --no-cache kmod
+COPY kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN depmod -b /opt

--- a/.agents/skills/kmm-ordered-upgrade/Dockerfile.v2
+++ b/.agents/skills/kmm-ordered-upgrade/Dockerfile.v2
@@ -1,0 +1,5 @@
+FROM alpine:latest
+ARG KERNEL_VERSION
+RUN apk add --no-cache kmod
+COPY kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN depmod -b /opt

--- a/.agents/skills/kmm-ordered-upgrade/SKILL.md
+++ b/.agents/skills/kmm-ordered-upgrade/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: kmm-ordered-upgrade
+description: >-
+  Test the KMM ordered upgrade feature end-to-end: deploy a versioned Module
+  with kmm_ci_a, upgrade to kmm_ci_b node-by-node, and verify the old module
+  is unloaded and the new one loaded on each node. Use when the user asks to
+  test ordered upgrade, module versioning, or node-by-node kmod rollout.
+---
+# KMM Ordered Upgrade E2E Test
+
+Tests the ordered upgrade flow: deploy a versioned kernel module (`kmm_ci_a`), then upgrade it node-by-node to a different module (`kmm_ci_b`) without rebooting. The swap is verified via `lsmod` — after upgrade, `kmm_ci_b` must be loaded and `kmm_ci_a` must not.
+
+All commands assume you are in the repository root. This skill directory contains supporting files:
+
+- `Dockerfile.v1` — image with `kmm_ci_a.ko` only
+- `Dockerfile.v2` — image with `kmm_ci_b.ko` only
+- `module-v1.yaml` — Module CR template (version "1", `moduleName: kmm_ci_a`)
+- `module-v2.yaml` — Module CR for v2 (version "2", `moduleName: kmm_ci_b`)
+
+## Step 1: Ensure a running KMM environment
+
+Use the **kmm-dev-setup** skill to ensure a Minikube cluster is running with KMM deployed. The cluster must use `--driver=docker` and have the local registry (`kmm-registry`) running.
+
+```bash
+kubectl wait --timeout=5m --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook -n kmm-operator-system
+docker ps --filter name=kmm-registry --format '{{.Names}}'
+```
+
+## Step 2: Build the kernel modules locally
+
+Prerequisites: `gcc`, `make`, kernel headers (`/lib/modules/$(uname -r)/build`).
+
+```bash
+(cd ci/kmm-kmod && make all)
+```
+
+Verify both `kmm_ci_a.ko` and `kmm_ci_b.ko` exist in `ci/kmm-kmod/`.
+
+## Step 3: Build and push v1 and v2 images
+
+v1 contains only `kmm_ci_a.ko`, v2 contains only `kmm_ci_b.ko`.
+
+```bash
+KERNEL_VER=$(minikube ssh -- uname -r | tr -d '\r')
+export V1_TAG="v1-$(date +%s)"
+export V2_TAG="v2-$(date +%s)"
+SKILL_DIR=.agents/skills/kmm-ordered-upgrade
+
+docker build --build-arg KERNEL_VERSION=$KERNEL_VER \
+  -t localhost:5000/kmm-kmod-base:$V1_TAG -f $SKILL_DIR/Dockerfile.v1 ci/kmm-kmod/
+
+docker build --build-arg KERNEL_VERSION=$KERNEL_VER \
+  -t localhost:5000/kmm-kmod-base:$V2_TAG -f $SKILL_DIR/Dockerfile.v2 ci/kmm-kmod/
+
+docker push localhost:5000/kmm-kmod-base:$V1_TAG
+docker push localhost:5000/kmm-kmod-base:$V2_TAG
+```
+
+Save `V1_TAG` and `V2_TAG` — they are needed in steps 4 and 6.
+
+## Step 4: Deploy the v1 Module
+
+Label workers, create build/sign resources, and apply the Module CR from `module-v1.yaml`.
+
+```bash
+kubectl label node minikube-m02 minikube-m03 kmm-test/role=worker --overwrite
+
+kubectl create secret generic build-secret \
+  --from-literal=ci-build-secret=super-secret-value \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create configmap kmm-kmod-dockerfile \
+  --from-literal=dockerfile="$(cat <<EOF
+FROM host.minikube.internal:5000/kmm-kmod-base:$V1_TAG
+RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+EOF
+)" --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl apply -f ci/secret_kmm-kmod-signing.yaml
+kubectl delete module kmm-ci --ignore-not-found
+
+envsubst '$V1_TAG' < $SKILL_DIR/module-v1.yaml | kubectl apply -f -
+```
+
+Module is created with `version: "1"` but no nodes have the version label yet — nothing loads.
+
+## Step 5: Label nodes to trigger v1 load
+
+```bash
+for NODE in minikube-m02 minikube-m03; do
+  kubectl label node $NODE kmm.node.kubernetes.io/version-module.default.kmm-ci=1
+done
+```
+
+Wait for `version.ready=1` on both nodes (build-sign-load pipeline must complete first, may take a few minutes):
+
+```bash
+for NODE in minikube-m02 minikube-m03; do
+  echo "Waiting for v1 ready on $NODE..."
+  until kubectl get node "$NODE" -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/default\.kmm-ci\.version\.ready}' 2>/dev/null | grep -q "1"; do
+    sleep 5
+  done
+  echo "$NODE: v1 ready"
+done
+```
+
+Verify `kmm_ci_a` is loaded and `kmm_ci_b` is **not**:
+
+```bash
+minikube ssh -n minikube-m02 -- lsmod | grep kmm_ci
+minikube ssh -n minikube-m03 -- lsmod | grep kmm_ci
+```
+
+Check `version.ready` shows `1`:
+
+```bash
+kubectl get nodes -l kmm-test/role=worker -L kmm.node.kubernetes.io/default.kmm-ci.version.ready
+```
+
+## Step 6: Upgrade the Module to v2
+
+Update the Dockerfile ConfigMap and apply the v2 Module CR. The `moduleName` changes from `kmm_ci_a` to `kmm_ci_b`.
+
+```bash
+kubectl create configmap kmm-kmod-dockerfile \
+  --from-literal=dockerfile="$(cat <<EOF
+FROM host.minikube.internal:5000/kmm-kmod-base:$V2_TAG
+RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+EOF
+)" --dry-run=client -o yaml | kubectl apply -f -
+
+envsubst '$V2_TAG' < $SKILL_DIR/module-v2.yaml | kubectl apply -f -
+```
+
+Nodes still run v1 — the version-module labels haven't changed yet.
+
+Verify `kmm_ci_a` is still loaded:
+
+```bash
+minikube ssh -n minikube-m02 -- lsmod | grep kmm_ci
+```
+
+## Step 7: Ordered node-by-node upgrade
+
+Upgrade one node at a time. After each label change, wait for `version.ready` to show `2`, then verify `kmm_ci_b` is loaded and `kmm_ci_a` is not.
+
+**First node:**
+
+```bash
+kubectl label node minikube-m02 kmm.node.kubernetes.io/version-module.default.kmm-ci=2 --overwrite
+
+echo "Waiting for v2 ready on minikube-m02..."
+until kubectl get node minikube-m02 -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/default\.kmm-ci\.version\.ready}' 2>/dev/null | grep -q "2"; do
+  sleep 5
+done
+```
+
+Verify the swap:
+
+```bash
+minikube ssh -n minikube-m02 -- lsmod | grep kmm_ci
+kubectl get nodes -l kmm-test/role=worker -L kmm.node.kubernetes.io/default.kmm-ci.version.ready
+```
+
+At this point minikube-m02 has v2 (`kmm_ci_b`) and minikube-m03 still has v1 (`kmm_ci_a`).
+
+**Second node:**
+
+```bash
+kubectl label node minikube-m03 kmm.node.kubernetes.io/version-module.default.kmm-ci=2 --overwrite
+
+echo "Waiting for v2 ready on minikube-m03..."
+until kubectl get node minikube-m03 -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/default\.kmm-ci\.version\.ready}' 2>/dev/null | grep -q "2"; do
+  sleep 5
+done
+```
+
+Verify:
+
+```bash
+minikube ssh -n minikube-m03 -- lsmod | grep kmm_ci
+kubectl get nodes -l kmm-test/role=worker -L kmm.node.kubernetes.io/default.kmm-ci.version.ready
+```
+
+Both nodes should now show `version.ready=2` and only `kmm_ci_b` in `lsmod`.
+
+## Cleanup
+
+```bash
+kubectl label node minikube-m02 minikube-m03 kmm.node.kubernetes.io/version-module.default.kmm-ci-
+kubectl delete module kmm-ci --ignore-not-found
+kubectl delete secret build-secret kmm-kmod-signing-cert kmm-kmod-signing-key --ignore-not-found
+kubectl delete configmap kmm-kmod-dockerfile --ignore-not-found
+kubectl label node minikube-m02 minikube-m03 kmm-test/role-
+(cd ci/kmm-kmod && make -C /lib/modules/$(uname -r)/build M=$(pwd) clean)
+```
+
+## Troubleshooting
+
+If a node gets stuck during upgrade:
+
+```bash
+kubectl get node <node> --show-labels | tr ',' '\n' | grep -E "version|kmm"
+kubectl get nodemodulesconfig <node> -o yaml
+kubectl get pods -A -l kmm.node.kubernetes.io/module.name=kmm-ci --field-selector spec.nodeName=<node>
+kubectl logs -n kmm-operator-system deployment/kmm-operator-controller --tail=100
+```

--- a/.agents/skills/kmm-ordered-upgrade/module-v1.yaml
+++ b/.agents/skills/kmm-ordered-upgrade/module-v1.yaml
@@ -1,0 +1,35 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci
+spec:
+  moduleLoader:
+    container:
+      version: "1"
+      modprobe:
+        moduleName: kmm_ci_a
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME-${V1_TAG}:$KERNEL_FULL_VERSION
+          registryTLS:
+            insecure: true
+          build:
+            baseImageRegistryTLS:
+              insecure: true
+            secrets:
+              - name: build-secret
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+            kanikoParams:
+              tag: "debug"
+          sign:
+            certSecret:
+              name: kmm-kmod-signing-cert
+            keySecret:
+              name: kmm-kmod-signing-key
+            unsignedImageRegistryTLS:
+              insecure: true
+            filesToSign:
+              - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_a.ko
+  selector:
+    kmm-test/role: worker

--- a/.agents/skills/kmm-ordered-upgrade/module-v2.yaml
+++ b/.agents/skills/kmm-ordered-upgrade/module-v2.yaml
@@ -1,0 +1,35 @@
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci
+spec:
+  moduleLoader:
+    container:
+      version: "2"
+      modprobe:
+        moduleName: kmm_ci_b
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME-${V2_TAG}:$KERNEL_FULL_VERSION
+          registryTLS:
+            insecure: true
+          build:
+            baseImageRegistryTLS:
+              insecure: true
+            secrets:
+              - name: build-secret
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+            kanikoParams:
+              tag: "debug"
+          sign:
+            certSecret:
+              name: kmm-kmod-signing-cert
+            keySecret:
+              name: kmm-kmod-signing-key
+            unsignedImageRegistryTLS:
+              insecure: true
+            filesToSign:
+              - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_b.ko
+  selector:
+    kmm-test/role: worker


### PR DESCRIPTION
Three AI-assisted skills for local development workflows:
- kmm-dev-setup: guides setting up minikube + deploying KMM from source code.
- kmm-e2e: runs the full build-sign-load pipeline.
- kmm-order-upgrade:  runs a full order upgrade local test on a multi node cluster.



---

/cc @ybettan @yevgeny-shnaidman 