### PR TITLE
Add DRA webhook validation with Kubernetes version gating

### DIFF
--- a/cmd/webhook-server/main.go
+++ b/cmd/webhook-server/main.go
@@ -75,15 +75,24 @@ func main() {
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)
 	options.LeaderElection = false
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create manager")
 	}
 
+	kubeVersion, err := webhook.DiscoverKubeVersion(restCfg)
+	if err != nil {
+		cmd.FatalError(setupLogger, err, "unable to discover Kubernetes version")
+	}
+
+	setupLogger.Info("Detected Kubernetes version", "major", kubeVersion.Major, "minor", kubeVersion.Minor)
+
 	if enableModule {
 		logger.Info("Enabling Module webhook")
 
-		if err = webhook.NewModuleValidator(logger).SetupWebhookWithManager(mgr); err != nil {
+		if err = webhook.NewModuleValidator(logger, kubeVersion).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ModuleValidator")
 		}
 	}
@@ -91,7 +100,7 @@ func main() {
 	if enableManagedClusterModule {
 		logger.Info("Enabling ManagedClusterModule webhook")
 
-		if err = hub.NewManagedClusterModuleValidator(logger).SetupWebhookWithManager(mgr); err != nil {
+		if err = hub.NewManagedClusterModuleValidator(logger, kubeVersion).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ManagedClusterModuleValidator")
 		}
 	}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -29,4 +29,7 @@ const (
 	DRARoleLabelValue          = "dra"
 
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
+
+	MinKubeMajorForDRA = 1
+	MinKubeMinorForDRA = 34
 )

--- a/internal/webhook/hub/managedclustermodule_webhook.go
+++ b/internal/webhook/hub/managedclustermodule_webhook.go
@@ -34,10 +34,10 @@ type ManagedClusterModuleValidator struct {
 	m      admission.CustomValidator
 }
 
-func NewManagedClusterModuleValidator(logger logr.Logger) *ManagedClusterModuleValidator {
+func NewManagedClusterModuleValidator(logger logr.Logger, kubeVersion webhook.KubeVersion) *ManagedClusterModuleValidator {
 	return &ManagedClusterModuleValidator{
 		logger: logger,
-		m:      webhook.NewModuleValidator(logger),
+		m:      webhook.NewModuleValidator(logger, kubeVersion),
 	}
 }
 

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -20,15 +20,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"regexp"
-	"strings"
 
 	"github.com/go-logr/logr"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -36,12 +41,54 @@ import (
 // maxCombinedLength is the maximum combined length of Module name and namespace when the version field is set.
 const maxCombinedLength = 40
 
-type ModuleValidator struct {
-	logger logr.Logger
+var kubeVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// KubeVersion holds the parsed major and minor version of a Kubernetes cluster.
+type KubeVersion struct {
+	Major int
+	Minor int
 }
 
-func NewModuleValidator(logger logr.Logger) *ModuleValidator {
-	return &ModuleValidator{logger: logger}
+type ModuleValidator struct {
+	logger      logr.Logger
+	kubeVersion KubeVersion
+}
+
+func NewModuleValidator(logger logr.Logger, kubeVersion KubeVersion) *ModuleValidator {
+	return &ModuleValidator{logger: logger, kubeVersion: kubeVersion}
+}
+
+// DiscoverKubeVersion queries the Kubernetes API server and returns its version.
+func DiscoverKubeVersion(cfg *rest.Config) (KubeVersion, error) {
+	discClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("failed to create discovery client: %v", err)
+	}
+
+	serverVersion, err := discClient.ServerVersion()
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("failed to query Kubernetes server version: %v", err)
+	}
+
+	return parseKubeVersion(serverVersion.GitVersion)
+}
+
+// parseKubeVersion extracts the major and minor version from a Kubernetes
+// GitVersion string such as "v1.34.0" or "v1.34.0+k3s1".
+func parseKubeVersion(gitVersion string) (KubeVersion, error) {
+	m := kubeVersionRe.FindStringSubmatch(gitVersion)
+	if m == nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes version from %q", gitVersion)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes major version from %q: %v", gitVersion, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes minor version from %q: %v", gitVersion, err)
+	}
+	return KubeVersion{Major: major, Minor: minor}, nil
 }
 
 func (m *ModuleValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -64,7 +111,7 @@ func (m *ModuleValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 
 	m.logger.Info("Validating Module creation", "name", mod.Name, "namespace", mod.Namespace)
 
-	return validateModule(mod)
+	return validateModule(mod, m.kubeVersion)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -88,7 +135,7 @@ func (m *ModuleValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		}
 	}
 
-	return validateModule(newMod)
+	return validateModule(newMod, m.kubeVersion)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -96,7 +143,7 @@ func (m *ModuleValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 	return nil, NotImplemented
 }
 
-func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
+func validateModule(mod *kmmv1beta1.Module, kubeVersion KubeVersion) (admission.Warnings, error) {
 	nameLength := len(mod.Name + mod.Namespace)
 
 	if nameLength > maxCombinedLength {
@@ -109,6 +156,10 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 
 	if err := validateTolerations(mod.Spec.Tolerations); err != nil {
 		return nil, fmt.Errorf("failed to validate Module's tolerations: %v", err)
+	}
+
+	if err := validateDRA(mod, kubeVersion); err != nil {
+		return nil, fmt.Errorf("failed to validate DRA: %v", err)
 	}
 
 	if mod.Spec.ModuleLoader == nil {
@@ -125,6 +176,46 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 	}
 
 	return nil, validateFilesToSign(mod.Spec.ModuleLoader.Container)
+}
+
+func validateDRA(mod *kmmv1beta1.Module, kubeVersion KubeVersion) error {
+	if mod.Spec.DRA == nil {
+		return nil
+	}
+
+	if kubeVersion.Major < constants.MinKubeMajorForDRA || (kubeVersion.Major == constants.MinKubeMajorForDRA && kubeVersion.Minor < constants.MinKubeMinorForDRA) {
+		return fmt.Errorf(
+			"spec.dra requires Kubernetes %d.%d or later; current cluster version is %d.%d",
+			constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA, kubeVersion.Major, kubeVersion.Minor,
+		)
+	}
+
+	driverName := mod.Spec.DRA.DriverName
+	if driverName == "" {
+		return errors.New("spec.dra.driverName is required")
+	}
+
+	if errs := validation.IsDNS1123Subdomain(driverName); len(errs) > 0 {
+		return fmt.Errorf("spec.dra.driverName %q is not a valid DNS subdomain: %s", driverName, strings.Join(errs, "; "))
+	}
+
+	seen := sets.New[string]()
+	for i, dc := range mod.Spec.DRA.DeviceClasses {
+		if dc.Name == "" {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name is required", i)
+		}
+
+		if errs := validation.IsDNS1123Subdomain(dc.Name); len(errs) > 0 {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name %q is not a valid DNS subdomain: %s", i, dc.Name, strings.Join(errs, "; "))
+		}
+
+		if seen.Has(dc.Name) {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name %q is a duplicate", i, dc.Name)
+		}
+		seen.Insert(dc.Name)
+	}
+
+	return nil
 }
 
 func validateImageFormat(img string) error {

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -53,7 +53,7 @@ var (
 		},
 	}
 
-	moduleWebhook = NewModuleValidator(GinkgoLogr)
+	moduleWebhook = NewModuleValidator(GinkgoLogr, KubeVersion{Major: 1, Minor: 34})
 )
 
 var _ = Describe("maxCombinedLength", func() {
@@ -411,7 +411,7 @@ var _ = Describe("validateModule", func() {
 			mod.Name = name
 			mod.Namespace = ns
 
-			_, err := validateModule(&mod)
+			_, err := validateModule(&mod, KubeVersion{Major: 1, Minor: 34})
 			exp := Expect(err)
 
 			if errExpected {
@@ -426,7 +426,7 @@ var _ = Describe("validateModule", func() {
 	It("should pass when moduleLoader is not defined", func() {
 		mod := validModule
 		mod.Spec.ModuleLoader = nil
-		_, err := validateModule(&mod)
+		_, err := validateModule(&mod, KubeVersion{Major: 1, Minor: 34})
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -696,5 +696,135 @@ var _ = Describe("validateTolerations", func() {
 
 		err := validateTolerations(tolerations)
 		Expect(err).To(Not(HaveOccurred()))
+	})
+})
+
+var _ = Describe("parseKubeVersion", func() {
+	DescribeTable(
+		"should parse valid version strings",
+		func(gitVersion string, expectedMajor, expectedMinor int) {
+			kv, err := parseKubeVersion(gitVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kv.Major).To(Equal(expectedMajor))
+			Expect(kv.Minor).To(Equal(expectedMinor))
+		},
+		Entry("standard version", "v1.34.0", 1, 34),
+		Entry("with build metadata", "v1.34.0+k3s1", 1, 34),
+		Entry("pre-release version", "v1.33.0-alpha.1", 1, 33),
+		Entry("higher minor", "v1.35.1", 1, 35),
+		Entry("without v prefix", "1.34.0", 1, 34),
+		Entry("hypothetical k8s 2.0", "v2.0.0", 2, 0),
+		Entry("hypothetical k8s 2.5", "v2.5.3", 2, 5),
+	)
+
+	DescribeTable(
+		"should return error for invalid strings",
+		func(gitVersion string) {
+			_, err := parseKubeVersion(gitVersion)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("empty string", ""),
+		Entry("garbage", "invalid"),
+		Entry("no minor", "v1"),
+	)
+})
+
+var _ = Describe("validateDRA", func() {
+	validDRASpec := func() *kmmv1beta1.DRASpec {
+		return &kmmv1beta1.DRASpec{
+			DriverName: "example.com",
+			Container: kmmv1beta1.CommonContainerSpec{
+				Image: "driver:latest",
+			},
+		}
+	}
+
+	minValidKubeVersion := KubeVersion{Major: 1, Minor: 34}
+
+	It("should be a no-op when spec.dra is nil", func() {
+		mod := &kmmv1beta1.Module{}
+		Expect(validateDRA(mod, minValidKubeVersion)).NotTo(HaveOccurred())
+	})
+
+	DescribeTable(
+		"Kubernetes version gate",
+		func(kv KubeVersion, shouldFail bool) {
+			mod := &kmmv1beta1.Module{
+				Spec: kmmv1beta1.ModuleSpec{
+					DRA: validDRASpec(),
+				},
+			}
+			err := validateDRA(mod, kv)
+			if shouldFail {
+				Expect(err).To(MatchError(ContainSubstring("requires Kubernetes")))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("k8s 1.33 rejects", KubeVersion{Major: 1, Minor: 33}, true),
+		Entry("k8s 1.34 accepts", KubeVersion{Major: 1, Minor: 34}, false),
+		Entry("k8s 1.35 accepts", KubeVersion{Major: 1, Minor: 35}, false),
+		Entry("k8s 2.0 accepts (future major)", KubeVersion{Major: 2, Minor: 0}, false),
+		Entry("k8s 0.99 rejects (old major)", KubeVersion{Major: 0, Minor: 99}, true),
+	)
+
+	It("should reject empty driverName", func() {
+		dra := validDRASpec()
+		dra.DriverName = ""
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).To(MatchError(ContainSubstring("driverName is required")))
+	})
+
+	It("should reject invalid driverName", func() {
+		dra := validDRASpec()
+		dra.DriverName = "INVALID_NAME!"
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).To(MatchError(ContainSubstring("not a valid DNS subdomain")))
+	})
+
+	It("should accept valid driverName", func() {
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: validDRASpec()},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).NotTo(HaveOccurred())
+	})
+
+	It("should reject duplicate deviceClasses names", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "gpu"},
+			{Name: "gpu"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).To(MatchError(ContainSubstring("duplicate")))
+	})
+
+	It("should reject invalid deviceClasses name", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "INVALID!"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).To(MatchError(ContainSubstring("not a valid DNS subdomain")))
+	})
+
+	It("should accept valid deviceClasses", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "gpu"},
+			{Name: "fpga"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidKubeVersion)).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## Summary
- Implement admission webhook validation for Modules with `spec.dra`, gating DRA usage to Kubernetes 1.34+ using a major-version-aware comparison (so future k8s 2.x+ is automatically accepted)
- Detect the cluster Kubernetes version at webhook startup via the discovery client and pass it through to validators
- Validate `driverName` format/presence and `deviceClasses` name uniqueness/format

Note: mutual exclusivity of `spec.dra` and `spec.devicePlugin` is already enforced by the CEL `XValidation` rule on `ModuleSpec` and is not duplicated in the webhook.

## Changes
- `internal/webhook/module.go`: Add `KubeVersion` struct, `ParseKubeVersion`, `DiscoverKubeVersion`, and `validateDRA` functions; thread `KubeVersion` through `ModuleValidator` and `validateModule`
- `internal/webhook/hub/managedclustermodule_webhook.go`: Pass `KubeVersion` through to `NewModuleValidator`
- `internal/constants/constants.go`: Add `MinKubeMajorForDRA` and `MinKubeMinorForDRA` constants
- `cmd/webhook-server/main.go`: Discover Kubernetes version at startup and pass to webhook validators
- `internal/webhook/module_test.go`: Add tests for `ParseKubeVersion` (including k8s 2.x), `validateDRA` (version gate boundaries, field validation)

## Test plan
- [x] Unit tests for `ParseKubeVersion` cover standard versions, build metadata, pre-release, no `v` prefix, hypothetical k8s 2.x
- [x] Unit tests for `validateDRA` cover version gate (k8s 0.99 reject, 1.33 reject, 1.34 accept, 1.35 accept, 2.0 accept), driverName validation, deviceClasses validation
- [x] All webhook tests pass
- [x] `go build ./...` compiles cleanly
- [x] Verified `DiscoverKubeVersion` against a live minikube cluster (k8s v1.35.1 → major=1, minor=35)