### PR TITLE
Fix hub webhook DRA version gating to skip cluster version check

### DIFF
--- a/cmd/webhook-server/main.go
+++ b/cmd/webhook-server/main.go
@@ -82,17 +82,17 @@ func main() {
 		cmd.FatalError(setupLogger, err, "unable to create manager")
 	}
 
-	kubeVersion, err := webhook.DiscoverKubeVersion(restCfg)
-	if err != nil {
-		cmd.FatalError(setupLogger, err, "unable to discover Kubernetes version")
-	}
-
-	setupLogger.Info("Detected Kubernetes version", "major", kubeVersion.Major, "minor", kubeVersion.Minor)
-
 	if enableModule {
 		logger.Info("Enabling Module webhook")
 
-		if err = webhook.NewModuleValidator(logger, kubeVersion).SetupWebhookWithManager(mgr); err != nil {
+		kubeVersion, err := webhook.DiscoverKubeVersion(restCfg)
+		if err != nil {
+			cmd.FatalError(setupLogger, err, "unable to discover Kubernetes version")
+		}
+
+		setupLogger.Info("Detected Kubernetes version", "major", kubeVersion.Major, "minor", kubeVersion.Minor)
+
+		if err = webhook.NewModuleValidator(logger, &kubeVersion).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ModuleValidator")
 		}
 	}
@@ -100,7 +100,7 @@ func main() {
 	if enableManagedClusterModule {
 		logger.Info("Enabling ManagedClusterModule webhook")
 
-		if err = hub.NewManagedClusterModuleValidator(logger, kubeVersion).SetupWebhookWithManager(mgr); err != nil {
+		if err = hub.NewManagedClusterModuleValidator(logger, nil).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ManagedClusterModuleValidator")
 		}
 	}

--- a/internal/webhook/hub/managedclustermodule_webhook.go
+++ b/internal/webhook/hub/managedclustermodule_webhook.go
@@ -34,7 +34,7 @@ type ManagedClusterModuleValidator struct {
 	m      admission.CustomValidator
 }
 
-func NewManagedClusterModuleValidator(logger logr.Logger, kubeVersion webhook.KubeVersion) *ManagedClusterModuleValidator {
+func NewManagedClusterModuleValidator(logger logr.Logger, kubeVersion *webhook.KubeVersion) *ManagedClusterModuleValidator {
 	return &ManagedClusterModuleValidator{
 		logger: logger,
 		m:      webhook.NewModuleValidator(logger, kubeVersion),

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -51,10 +51,10 @@ type KubeVersion struct {
 
 type ModuleValidator struct {
 	logger      logr.Logger
-	kubeVersion KubeVersion
+	kubeVersion *KubeVersion
 }
 
-func NewModuleValidator(logger logr.Logger, kubeVersion KubeVersion) *ModuleValidator {
+func NewModuleValidator(logger logr.Logger, kubeVersion *KubeVersion) *ModuleValidator {
 	return &ModuleValidator{logger: logger, kubeVersion: kubeVersion}
 }
 
@@ -143,7 +143,7 @@ func (m *ModuleValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 	return nil, NotImplemented
 }
 
-func validateModule(mod *kmmv1beta1.Module, kubeVersion KubeVersion) (admission.Warnings, error) {
+func validateModule(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) (admission.Warnings, error) {
 	nameLength := len(mod.Name + mod.Namespace)
 
 	if nameLength > maxCombinedLength {
@@ -178,16 +178,20 @@ func validateModule(mod *kmmv1beta1.Module, kubeVersion KubeVersion) (admission.
 	return nil, validateFilesToSign(mod.Spec.ModuleLoader.Container)
 }
 
-func validateDRA(mod *kmmv1beta1.Module, kubeVersion KubeVersion) error {
+func validateDRA(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) error {
 	if mod.Spec.DRA == nil {
 		return nil
 	}
 
-	if kubeVersion.Major < constants.MinKubeMajorForDRA || (kubeVersion.Major == constants.MinKubeMajorForDRA && kubeVersion.Minor < constants.MinKubeMinorForDRA) {
-		return fmt.Errorf(
-			"spec.dra requires Kubernetes %d.%d or later; current cluster version is %d.%d",
-			constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA, kubeVersion.Major, kubeVersion.Minor,
-		)
+	// Skip version gating when kubeVersion is nil (e.g. hub webhook validating
+	// a ManagedClusterModule — the spoke's own webhook will enforce its version).
+	if kubeVersion != nil {
+		if kubeVersion.Major < constants.MinKubeMajorForDRA || (kubeVersion.Major == constants.MinKubeMajorForDRA && kubeVersion.Minor < constants.MinKubeMinorForDRA) {
+			return fmt.Errorf(
+				"spec.dra requires Kubernetes %d.%d or later; current cluster version is %d.%d",
+				constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA, kubeVersion.Major, kubeVersion.Minor,
+			)
+		}
 	}
 
 	driverName := mod.Spec.DRA.DriverName

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -53,7 +53,7 @@ var (
 		},
 	}
 
-	moduleWebhook = NewModuleValidator(GinkgoLogr, KubeVersion{Major: 1, Minor: 34})
+	moduleWebhook = NewModuleValidator(GinkgoLogr, &KubeVersion{Major: 1, Minor: 34})
 )
 
 var _ = Describe("maxCombinedLength", func() {
@@ -411,7 +411,7 @@ var _ = Describe("validateModule", func() {
 			mod.Name = name
 			mod.Namespace = ns
 
-			_, err := validateModule(&mod, KubeVersion{Major: 1, Minor: 34})
+			_, err := validateModule(&mod, &KubeVersion{Major: 1, Minor: 34})
 			exp := Expect(err)
 
 			if errExpected {
@@ -426,7 +426,7 @@ var _ = Describe("validateModule", func() {
 	It("should pass when moduleLoader is not defined", func() {
 		mod := validModule
 		mod.Spec.ModuleLoader = nil
-		_, err := validateModule(&mod, KubeVersion{Major: 1, Minor: 34})
+		_, err := validateModule(&mod, &KubeVersion{Major: 1, Minor: 34})
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -739,7 +739,7 @@ var _ = Describe("validateDRA", func() {
 		}
 	}
 
-	minValidKubeVersion := KubeVersion{Major: 1, Minor: 34}
+	minValidKubeVersion := &KubeVersion{Major: 1, Minor: 34}
 
 	It("should be a no-op when spec.dra is nil", func() {
 		mod := &kmmv1beta1.Module{}
@@ -748,7 +748,7 @@ var _ = Describe("validateDRA", func() {
 
 	DescribeTable(
 		"Kubernetes version gate",
-		func(kv KubeVersion, shouldFail bool) {
+		func(kv *KubeVersion, shouldFail bool) {
 			mod := &kmmv1beta1.Module{
 				Spec: kmmv1beta1.ModuleSpec{
 					DRA: validDRASpec(),
@@ -761,11 +761,12 @@ var _ = Describe("validateDRA", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},
-		Entry("k8s 1.33 rejects", KubeVersion{Major: 1, Minor: 33}, true),
-		Entry("k8s 1.34 accepts", KubeVersion{Major: 1, Minor: 34}, false),
-		Entry("k8s 1.35 accepts", KubeVersion{Major: 1, Minor: 35}, false),
-		Entry("k8s 2.0 accepts (future major)", KubeVersion{Major: 2, Minor: 0}, false),
-		Entry("k8s 0.99 rejects (old major)", KubeVersion{Major: 0, Minor: 99}, true),
+		Entry("k8s 1.33 rejects", &KubeVersion{Major: 1, Minor: 33}, true),
+		Entry("k8s 1.34 accepts", &KubeVersion{Major: 1, Minor: 34}, false),
+		Entry("k8s 1.35 accepts", &KubeVersion{Major: 1, Minor: 35}, false),
+		Entry("k8s 2.0 accepts (future major)", &KubeVersion{Major: 2, Minor: 0}, false),
+		Entry("k8s 0.99 rejects (old major)", &KubeVersion{Major: 0, Minor: 99}, true),
+		Entry("nil version skips gate (hub webhook)", nil, false),
 	)
 
 	It("should reject empty driverName", func() {


### PR DESCRIPTION
The ManagedClusterModule webhook on the hub was incorrectly using the hub cluster's Kubernetes version to gate DRA usage. Since the hub cannot know the target managed cluster's version, this could wrongly reject valid specs or accept invalid ones.

Fix by passing an empty KubeVersion to the hub validator and skipping the version gate in validateDRA when the version is zero. Field format validation (driverName, deviceClasses) still runs unconditionally. The spoke cluster's own Module webhook enforces the version requirement.

Also moves DiscoverKubeVersion inside the enableModule branch so that webhook modes that don't need cluster version (namespace, preflight) no longer require ClusterVersion API access.

---

/cc @yevgeny-shnaidman 
/assign @yevgeny-shnaidman 