### PR TITLE
Register DRA reconciler with manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/metrics"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/nmc"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -62,6 +63,7 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 	utilruntime.Must(v1beta2.AddToScheme(scheme))
+	utilruntime.Must(resourcev1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -166,6 +168,10 @@ func main() {
 
 	if err = controllers.NewDevicePluginPodReconciler(client).SetupWithManager(mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DevicePluginPodReconcilerName)
+	}
+
+	if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 	}
 
 	if err = controllers.NewNodeLabelModuleVersionReconciler(client).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
## Register DRA reconciler with manager

### Summary

Wire the existing DRA reconciler into the operator manager so that DRA Modules
are actively reconciled when the manager runs in a cluster. This adds the scheme
registration, RBAC permissions, reconciler construction, and DRA module count
metric to the existing metrics sweep.

### Changes

- **cmd/manager/main.go:**
  - Add `resourcev1.AddToScheme(scheme)` for the DRA resource API
  - Construct and register `DRAReconciler` via `SetupWithManager`
- **internal/controllers/dra_reconciler.go:**
  - Add `//+kubebuilder:rbac` annotation for `resource.k8s.io/deviceclasses`
- **internal/metrics/metrics.go:**
  - Add `SetKMMDRANum` method and `kmm_dra_num` gauge
- **internal/controllers/device_plugin_reconciler.go:**
  - Count modules with `spec.dra` in the existing metrics sweep
- **config/rbac/role.yaml:**
  - Regenerated with `resource.k8s.io/deviceclasses` rule (all CRUD verbs)

### Testing

- **Unit tests:** Extended the `setKMMOMetrics` DescribeTable with a `dra` bool parameter and a new "dra" entry. All 12 entries (including "altogether") pass.
- **Integration tests:** N/A
- **Coverage:** `setKMMOMetrics` function at 100% coverage; `internal/controllers` package at 89.9%

### Acceptance Criteria

- [ ] AC-1: `resourcev1.AddToScheme(scheme)` is called in `cmd/manager/main.go`
- [ ] AC-2: `DRAReconciler` is constructed and registered via `SetupWithManager(mgr)` in `cmd/manager/main.go`
- [ ] AC-3: ClusterRole manifest includes `resource.k8s.io/deviceclasses` verbs (get, list, watch, create, update, patch, delete)
- [ ] AC-4: DRA module count is reported in existing metrics sweep
- [ ] AC-5: All unit tests pass; no duplicate reconciler registration
