### PR TITLE
Add DeviceClass watch to DRA reconciler

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,6 +42,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -117,3 +118,16 @@ rules:
   - nodemodulesconfigs/status
   verbs:
   - patch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -23,6 +23,7 @@ import (
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,8 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -68,6 +71,11 @@ func (r *DRAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
+		Watches(
+			&resourcev1.DeviceClass{},
+			handler.EnqueueRequestsFromMapFunc(filter.DeviceClassToModuleReconcileRequest),
+			builder.WithPredicates(filter.HasLabel(constants.ModuleNameLabel)),
+		).
 		Named(DRAReconcilerName).
 		Complete(
 			reconcile.AsReconciler[*kmmv1beta1.Module](r.client, r),

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;deletecollection;get;list;patch;watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
@@ -51,6 +51,7 @@ import (
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs/status,verbs=patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=preflightvalidations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=preflightvalidations/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=create;delete;deletecollection;get;list;patch;update;watch
 
 const (
 	ModuleReconcilerName = "ModuleReconciler"

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -28,6 +28,18 @@ func HasLabel(label string) predicate.Predicate {
 	})
 }
 
+func DeviceClassToModuleReconcileRequest(_ context.Context, obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	modName := labels[constants.ModuleNameLabel]
+	modNs := labels[constants.ModuleNamespaceLabel]
+	if modName == "" || modNs == "" {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: modName, Namespace: modNs}},
+	}
+}
+
 var skipDeletions predicate.Predicate = predicate.Funcs{
 	DeleteFunc: func(_ event.DeleteEvent) bool { return false },
 }


### PR DESCRIPTION
Watch DeviceClass resources so the controller reacts to external drift (e.g. manual deletion). Uses filter.HasLabel predicate to only process KMM-managed DeviceClasses. Also adds list, watch, and deletecollection RBAC verbs for the deviceclasses resource.

---

/cc @yevgeny-shnaidman 
/assign @yevgeny-shnaidman 