### PR TITLE
Add DRA status feedback to hub-and-spoke ManifestWork

### DIFF
--- a/internal/manifestwork/manifestwork.go
+++ b/internal/manifestwork/manifestwork.go
@@ -38,6 +38,18 @@ var moduleStatusJSONPaths = []workv1.JsonPath{
 		Path: ".status.devicePlugin.nodesMatchingSelectorNumber",
 	},
 	{
+		Name: "dra.availableNumber",
+		Path: ".status.dra.availableNumber",
+	},
+	{
+		Name: "dra.desiredNumber",
+		Path: ".status.dra.desiredNumber",
+	},
+	{
+		Name: "dra.nodesMatchingSelectorNumber",
+		Path: ".status.dra.nodesMatchingSelectorNumber",
+	},
+	{
 		Name: "moduleLoader.availableNumber",
 		Path: ".status.moduleLoader.availableNumber",
 	},

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -26,6 +26,22 @@ var (
 	mockKM *module.MockKernelMapper
 )
 
+var _ = Describe("moduleStatusJSONPaths", func() {
+	It("should contain all expected status feedback paths", func() {
+		Expect(moduleStatusJSONPaths).To(ConsistOf(
+			workv1.JsonPath{Name: "devicePlugin.availableNumber", Path: ".status.devicePlugin.availableNumber"},
+			workv1.JsonPath{Name: "devicePlugin.desiredNumber", Path: ".status.devicePlugin.desiredNumber"},
+			workv1.JsonPath{Name: "devicePlugin.nodesMatchingSelectorNumber", Path: ".status.devicePlugin.nodesMatchingSelectorNumber"},
+			workv1.JsonPath{Name: "dra.availableNumber", Path: ".status.dra.availableNumber"},
+			workv1.JsonPath{Name: "dra.desiredNumber", Path: ".status.dra.desiredNumber"},
+			workv1.JsonPath{Name: "dra.nodesMatchingSelectorNumber", Path: ".status.dra.nodesMatchingSelectorNumber"},
+			workv1.JsonPath{Name: "moduleLoader.availableNumber", Path: ".status.moduleLoader.availableNumber"},
+			workv1.JsonPath{Name: "moduleLoader.desiredNumber", Path: ".status.moduleLoader.desiredNumber"},
+			workv1.JsonPath{Name: "moduleLoader.nodesMatchingSelectorNumber", Path: ".status.moduleLoader.nodesMatchingSelectorNumber"},
+		))
+	})
+})
+
 var _ = Describe("GarbageCollect", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -163,8 +163,16 @@ func validateModule(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) (admission
 		return nil, fmt.Errorf("failed to validate DRA: %v", err)
 	}
 
-	if err := validateDevicePluginVolumes(mod.Spec.DevicePlugin); err != nil {
-		return nil, fmt.Errorf("failed to validate device plugin volumes: %v", err)
+	if mod.Spec.DRA != nil {
+		if err := validateHostPathVolumes("spec.dra", mod.Spec.DRA.Volumes); err != nil {
+			return nil, fmt.Errorf("failed to validate DRA volumes: %v", err)
+		}
+	}
+
+	if mod.Spec.DevicePlugin != nil {
+		if err := validateHostPathVolumes("spec.devicePlugin", mod.Spec.DevicePlugin.Volumes); err != nil {
+			return nil, fmt.Errorf("failed to validate device plugin volumes: %v", err)
+		}
 	}
 
 	if mod.Spec.ModuleLoader == nil {
@@ -239,16 +247,12 @@ func isAllowedHostPath(hostPath string) bool {
 	return false
 }
 
-func validateDevicePluginVolumes(dp *kmmv1beta1.DevicePluginSpec) error {
-	if dp == nil {
-		return nil
-	}
-
-	for i, vol := range dp.Volumes {
+func validateHostPathVolumes(fieldPath string, volumes []corev1.Volume) error {
+	for i, vol := range volumes {
 		if vol.HostPath != nil && !isAllowedHostPath(vol.HostPath.Path) {
 			return fmt.Errorf(
-				"spec.devicePlugin.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var and /opt paths are permitted",
-				i, vol.HostPath.Path,
+				"%s.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var and /opt paths are permitted",
+				fieldPath, i, vol.HostPath.Path,
 			)
 		}
 	}

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -830,182 +830,144 @@ var _ = Describe("validateDRA", func() {
 	})
 })
 
-var _ = Describe("validateDevicePluginVolumes", func() {
-	It("should accept nil DevicePlugin", func() {
-		Expect(validateDevicePluginVolumes(nil)).NotTo(HaveOccurred())
-	})
-
-	It("should accept DevicePlugin with no volumes", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+var _ = Describe("validateHostPathVolumes", func() {
+	It("should accept empty volume list", func() {
+		Expect(validateHostPathVolumes("spec.test", nil)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", []v1.Volume{})).NotTo(HaveOccurred())
 	})
 
 	It("should accept non-hostPath volumes", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "config",
-					VolumeSource: v1.VolumeSource{
-						ConfigMap: &v1.ConfigMapVolumeSource{
-							LocalObjectReference: v1.LocalObjectReference{Name: "my-cm"},
-						},
+		vols := []v1.Volume{
+			{
+				Name: "config",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{Name: "my-cm"},
 					},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
-	})
-
-	It("should accept hostPath volumes under /dev", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "dev-vfio",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/dev/vfio"},
-					},
-				},
-			},
-		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
 	})
 
 	It("should accept hostPath volumes equal to /dev", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "dev",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/dev"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "dev",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/dev"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
 	})
 
 	It("should accept hostPath volumes under /sys", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "sys-class",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/sys/class/net"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "sys-class",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/sys/class/net"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
 	})
 
 	It("should accept hostPath volumes under /var", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "var-lib",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/kubelet/device-plugins"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "var-lib",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/kubelet/device-plugins"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
 	})
 
 	It("should accept hostPath volumes under /opt", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "opt-lib",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/opt/lib/firmware"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "opt-lib",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/opt/lib/firmware"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
 	})
 
 	It("should reject hostPath volumes outside allowed paths", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "root",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "root",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).To(MatchError(ContainSubstring("not allowed")))
+		Expect(validateHostPathVolumes("spec.test", vols)).To(MatchError(ContainSubstring("not allowed")))
 	})
 
 	It("should reject hostPath volumes under /etc", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "etc",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/etc/config"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "etc",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/etc/config"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).To(MatchError(ContainSubstring("not allowed")))
+		Expect(validateHostPathVolumes("spec.test", vols)).To(MatchError(ContainSubstring("not allowed")))
 	})
 
 	It("should reject hostPath with prefix trick like /devious", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "tricky",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/devious"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "tricky",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/devious"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).To(MatchError(ContainSubstring("not allowed")))
+		Expect(validateHostPathVolumes("spec.test", vols)).To(MatchError(ContainSubstring("not allowed")))
 	})
 
 	It("should reject hostPath with path traversal like /dev/../etc", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "traversal",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/dev/../etc/shadow"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "traversal",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/dev/../etc/shadow"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).To(MatchError(ContainSubstring("not allowed")))
+		Expect(validateHostPathVolumes("spec.test", vols)).To(MatchError(ContainSubstring("not allowed")))
 	})
 
 	It("should accept hostPath with redundant slashes under /sys", func() {
-		dp := &kmmv1beta1.DevicePluginSpec{
-			Container: kmmv1beta1.DevicePluginContainerSpec{Image: "img:tag"},
-			Volumes: []v1.Volume{
-				{
-					Name: "sys-clean",
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{Path: "/sys//class//net"},
-					},
+		vols := []v1.Volume{
+			{
+				Name: "sys-clean",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/sys//class//net"},
 				},
 			},
 		}
-		Expect(validateDevicePluginVolumes(dp)).NotTo(HaveOccurred())
+		Expect(validateHostPathVolumes("spec.test", vols)).NotTo(HaveOccurred())
+	})
+
+	It("should include fieldPath in error message", func() {
+		vols := []v1.Volume{
+			{
+				Name: "bad",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/etc/secret"},
+				},
+			},
+		}
+		Expect(validateHostPathVolumes("spec.dra", vols)).To(MatchError(ContainSubstring("spec.dra.volumes[0]")))
+		Expect(validateHostPathVolumes("spec.devicePlugin", vols)).To(MatchError(ContainSubstring("spec.devicePlugin.volumes[0]")))
 	})
 })


### PR DESCRIPTION
## Summary

- Add three DRA status feedback JSON path entries (`dra.availableNumber`, `dra.desiredNumber`, `dra.nodesMatchingSelectorNumber`) to the ManifestWork feedback rules, mirroring the existing `devicePlugin.*` pattern so DRA status is reported back from spoke to hub.
- Add DRA hostPath volume validation to the webhook, enforcing the same allowlist (`/dev`, `/sys`, `/var`, `/opt`) used for DevicePlugin volumes.

## Changes

### `internal/manifestwork/manifestwork.go`
Added 3 `JsonPath` entries for DRA status to `moduleStatusJSONPaths`, maintaining alphabetical grouping between `devicePlugin.*` and `moduleLoader.*`.

### `internal/manifestwork/manifestwork_test.go`
Added a `Describe("moduleStatusJSONPaths")` block using `ConsistOf` to assert all 9 expected feedback paths (3 devicePlugin + 3 DRA + 3 moduleLoader).

### `internal/webhook/module.go`
Added `validateDRAVolumes()` function and wired it into `validateModule()`. This validates `spec.dra.volumes` hostPath entries against the same allowlist used for DevicePlugin, with path traversal protection via `filepath.Clean`.

### `internal/webhook/module_test.go`
Added `Describe("validateDRAVolumes")` with 6 test cases covering: nil DRA, no volumes, non-hostPath, allowed hostPath, disallowed hostPath, and path traversal.

## Test plan

- [x] Unit tests pass (`go test ./internal/manifestwork/ ./internal/webhook/`)
- [x] Hub-and-spoke e2e verified on minikube (K8s 1.35):
  - ManifestWork created with all 9 feedback paths (3 DP + 3 DRA + 3 ML)
  - Module propagated to spoke with DRA spec intact (driverName, container, volumes)
  - DRA DaemonSet created on spoke with correct labels, volumes, nodeSelector
  - DRA status feedback (`dra.desiredNumber`, `dra.nodesMatchingSelectorNumber`) flowing back to hub
  - Hub webhook rejects disallowed DRA hostPath volumes (`/etc/shadow`)
  - Hub webhook rejects path traversal (`/dev/../etc/shadow`)
  - Hub webhook accepts allowed DRA hostPaths (`/dev/vfio`, `/sys/bus/pci`)


---

/cc @yevgeny-shnaidman @ybettan 
/assign @ybettan @yevgeny-shnaidman 
/uncc @mresvanis 