### PR TITLE
Fix DRA nodeSelector for in-tree driver mode

### DIFF
--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -512,10 +512,14 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 		utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
 	}
 
-	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
-		versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
-		standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
-		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+	if mod.Spec.ModuleLoader != nil {
+		if mod.Spec.ModuleLoader.Container.Version != "" {
+			versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
+			standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+			nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+		}
+	} else {
+		nodeSelector = mod.Spec.Selector
 	}
 
 	ds.SetLabels(

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -700,10 +700,8 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 									},
 								},
 							},
-							ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
-							NodeSelector: map[string]string{
-								utils.GetKernelModuleReadyNodeLabel(namespace, draModuleName): "",
-							},
+							ImagePullSecrets:   []v1.LocalObjectReference{repoSecret},
+							NodeSelector:       map[string]string{"has-feature-x": "true"},
 							PriorityClassName:  "system-node-critical",
 							HostNetwork:        true,
 							ServiceAccountName: serviceAccountName,


### PR DESCRIPTION
When `spec.moduleLoader` is nil (in-tree driver mode), the DRA reconciler's `nodeSelector` includes the KMM ready label, which is never set because no module loading occurs. This prevents the DRA DaemonSet from scheduling on any node.

Fall back to `spec.selector` instead, matching the existing behavior in the device plugin reconciler.

This PR was written in part with the assistance of generative AI.

**Suggested test plan**
- [ ] Verify the DRA DaemonSet uses `spec.selector` as its nodeSelector
- [ ] Deploy KMM with an in-tree Module (`moduleLoader: nil`) and DRA enabled
- [ ] Verify the DRA DaemonSet pods schedule correctly on matching nodes