### PR TITLE
Gate DRA reconciler on Kubernetes >= 1.34

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/metrics"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/nmc"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/version"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -113,7 +114,16 @@ func main() {
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	restCfg := ctrl.GetConfigOrDie()
+
+	kubeVersion, err := version.DiscoverKubeVersion(restCfg)
+	if err != nil {
+		cmd.FatalError(setupLogger, err, "unable to discover Kubernetes version")
+	}
+
+	setupLogger.Info("Detected Kubernetes version", "major", kubeVersion.Major, "minor", kubeVersion.Minor)
+
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create manager")
 	}
@@ -170,8 +180,16 @@ func main() {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PodNodeLabelReconcilerName)
 	}
 
-	if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
-		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
+	if kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
+		if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
+		}
+	} else {
+		setupLogger.Info(
+			fmt.Sprintf("Skipping DRA controller; requires Kubernetes >= %d.%d", constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA),
+			"detectedMajor", kubeVersion.Major,
+			"detectedMinor", kubeVersion.Minor,
+		)
 	}
 
 	if err = controllers.NewNodeLabelModuleVersionReconciler(client).SetupWithManager(mgr); err != nil {

--- a/cmd/webhook-server/main.go
+++ b/cmd/webhook-server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/cmd"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/config"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/version"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/webhook"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/webhook/hub"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,7 +86,7 @@ func main() {
 	if enableModule {
 		logger.Info("Enabling Module webhook")
 
-		kubeVersion, err := webhook.DiscoverKubeVersion(restCfg)
+		kubeVersion, err := version.DiscoverKubeVersion(restCfg)
 		if err != nil {
 			cmd.FatalError(setupLogger, err, "unable to discover Kubernetes version")
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+var kubeVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// KubeVersion holds the parsed major and minor version of a Kubernetes cluster.
+type KubeVersion struct {
+	Major int
+	Minor int
+}
+
+// AtLeast returns true if kv is greater than or equal to the given major.minor version.
+func (kv KubeVersion) AtLeast(major, minor int) bool {
+	return kv.Major > major || (kv.Major == major && kv.Minor >= minor)
+}
+
+// DiscoverKubeVersion queries the Kubernetes API server and returns its version.
+func DiscoverKubeVersion(cfg *rest.Config) (KubeVersion, error) {
+	discClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("failed to create discovery client: %v", err)
+	}
+
+	serverVersion, err := discClient.ServerVersion()
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("failed to query Kubernetes server version: %v", err)
+	}
+
+	return ParseKubeVersion(serverVersion.GitVersion)
+}
+
+// ParseKubeVersion extracts the major and minor version from a Kubernetes
+// GitVersion string such as "v1.34.0" or "v1.34.0+k3s1".
+func ParseKubeVersion(gitVersion string) (KubeVersion, error) {
+	m := kubeVersionRe.FindStringSubmatch(gitVersion)
+	if m == nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes version from %q", gitVersion)
+	}
+
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes major version from %q: %w", gitVersion, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes minor version from %q: %w", gitVersion, err)
+	}
+	return KubeVersion{Major: major, Minor: minor}, nil
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}
+
+var _ = Describe("AtLeast", func() {
+	DescribeTable(
+		"should compare versions correctly",
+		func(major, minor, minMajor, minMinor int, expected bool) {
+			kv := KubeVersion{Major: major, Minor: minor}
+			Expect(kv.AtLeast(minMajor, minMinor)).To(Equal(expected))
+		},
+		Entry("exact match", 1, 34, 1, 34, true),
+		Entry("higher minor", 1, 35, 1, 34, true),
+		Entry("lower minor", 1, 33, 1, 34, false),
+		Entry("higher major, lower minor", 2, 0, 1, 34, true),
+		Entry("lower major", 0, 99, 1, 34, false),
+	)
+})
+
+var _ = Describe("ParseKubeVersion", func() {
+	DescribeTable(
+		"should parse valid version strings",
+		func(gitVersion string, expectedMajor, expectedMinor int) {
+			kv, err := ParseKubeVersion(gitVersion)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kv.Major).To(Equal(expectedMajor))
+			Expect(kv.Minor).To(Equal(expectedMinor))
+		},
+		Entry("standard version", "v1.34.0", 1, 34),
+		Entry("with build metadata", "v1.34.0+k3s1", 1, 34),
+		Entry("pre-release version", "v1.33.0-alpha.1", 1, 33),
+		Entry("higher minor", "v1.35.1", 1, 35),
+		Entry("without v prefix", "1.34.0", 1, 34),
+		Entry("hypothetical k8s 2.0", "v2.0.0", 2, 0),
+		Entry("hypothetical k8s 2.5", "v2.5.3", 2, 5),
+	)
+
+	DescribeTable(
+		"should return error for invalid strings",
+		func(gitVersion string) {
+			_, err := ParseKubeVersion(gitVersion)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("empty string", ""),
+		Entry("garbage", "invalid"),
+		Entry("no minor", "v1"),
+	)
+})

--- a/internal/webhook/hub/managedclustermodule_webhook.go
+++ b/internal/webhook/hub/managedclustermodule_webhook.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kubernetes-sigs/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/version"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,7 +35,7 @@ type ManagedClusterModuleValidator struct {
 	m      admission.CustomValidator
 }
 
-func NewManagedClusterModuleValidator(logger logr.Logger, kubeVersion *webhook.KubeVersion) *ManagedClusterModuleValidator {
+func NewManagedClusterModuleValidator(logger logr.Logger, kubeVersion *version.KubeVersion) *ManagedClusterModuleValidator {
 	return &ManagedClusterModuleValidator{
 		logger: logger,
 		m:      webhook.NewModuleValidator(logger, kubeVersion),

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,10 +30,9 @@ import (
 	"github.com/go-logr/logr"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/version"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -43,54 +41,13 @@ import (
 // 63 (max label key length after slash) - len("version-schedule-plugin.") = 38
 const maxCombinedLength = 38
 
-var kubeVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
-
-// KubeVersion holds the parsed major and minor version of a Kubernetes cluster.
-type KubeVersion struct {
-	Major int
-	Minor int
-}
-
 type ModuleValidator struct {
 	logger      logr.Logger
-	kubeVersion *KubeVersion
+	kubeVersion *version.KubeVersion
 }
 
-func NewModuleValidator(logger logr.Logger, kubeVersion *KubeVersion) *ModuleValidator {
+func NewModuleValidator(logger logr.Logger, kubeVersion *version.KubeVersion) *ModuleValidator {
 	return &ModuleValidator{logger: logger, kubeVersion: kubeVersion}
-}
-
-// DiscoverKubeVersion queries the Kubernetes API server and returns its version.
-func DiscoverKubeVersion(cfg *rest.Config) (KubeVersion, error) {
-	discClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return KubeVersion{}, fmt.Errorf("failed to create discovery client: %v", err)
-	}
-
-	serverVersion, err := discClient.ServerVersion()
-	if err != nil {
-		return KubeVersion{}, fmt.Errorf("failed to query Kubernetes server version: %v", err)
-	}
-
-	return parseKubeVersion(serverVersion.GitVersion)
-}
-
-// parseKubeVersion extracts the major and minor version from a Kubernetes
-// GitVersion string such as "v1.34.0" or "v1.34.0+k3s1".
-func parseKubeVersion(gitVersion string) (KubeVersion, error) {
-	m := kubeVersionRe.FindStringSubmatch(gitVersion)
-	if m == nil {
-		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes version from %q", gitVersion)
-	}
-	major, err := strconv.Atoi(m[1])
-	if err != nil {
-		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes major version from %q: %v", gitVersion, err)
-	}
-	minor, err := strconv.Atoi(m[2])
-	if err != nil {
-		return KubeVersion{}, fmt.Errorf("cannot parse Kubernetes minor version from %q: %v", gitVersion, err)
-	}
-	return KubeVersion{Major: major, Minor: minor}, nil
 }
 
 func (m *ModuleValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -145,7 +102,7 @@ func (m *ModuleValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 	return nil, NotImplemented
 }
 
-func validateModule(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) (admission.Warnings, error) {
+func validateModule(mod *kmmv1beta1.Module, kubeVersion *version.KubeVersion) (admission.Warnings, error) {
 	nameLength := len(mod.Name + mod.Namespace)
 
 	if nameLength > maxCombinedLength {
@@ -192,20 +149,18 @@ func validateModule(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) (admission
 	return nil, validateFilesToSign(mod.Spec.ModuleLoader.Container)
 }
 
-func validateDRA(mod *kmmv1beta1.Module, kubeVersion *KubeVersion) error {
+func validateDRA(mod *kmmv1beta1.Module, kubeVersion *version.KubeVersion) error {
 	if mod.Spec.DRA == nil {
 		return nil
 	}
 
 	// Skip version gating when kubeVersion is nil (e.g. hub webhook validating
 	// a ManagedClusterModule — the spoke's own webhook will enforce its version).
-	if kubeVersion != nil {
-		if kubeVersion.Major < constants.MinKubeMajorForDRA || (kubeVersion.Major == constants.MinKubeMajorForDRA && kubeVersion.Minor < constants.MinKubeMinorForDRA) {
-			return fmt.Errorf(
-				"spec.dra requires Kubernetes %d.%d or later; current cluster version is %d.%d",
-				constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA, kubeVersion.Major, kubeVersion.Minor,
-			)
-		}
+	if kubeVersion != nil && !kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
+		return fmt.Errorf(
+			"spec.dra requires Kubernetes %d.%d or later; current cluster version is %d.%d",
+			constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA, kubeVersion.Major, kubeVersion.Minor,
+		)
 	}
 
 	driverName := mod.Spec.DRA.DriverName
@@ -252,7 +207,7 @@ func validateHostPathVolumes(fieldPath string, volumes []corev1.Volume) error {
 	for i, vol := range volumes {
 		if vol.HostPath != nil && !isAllowedHostPath(vol.HostPath.Path) {
 			return fmt.Errorf(
-				"%s.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var and /opt paths are permitted",
+				"%s.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var, /opt and /run paths are permitted",
 				fieldPath, i, vol.HostPath.Path,
 			)
 		}

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -23,6 +23,7 @@ import (
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -53,7 +54,7 @@ var (
 		},
 	}
 
-	moduleWebhook = NewModuleValidator(GinkgoLogr, &KubeVersion{Major: 1, Minor: 34})
+	moduleWebhook = NewModuleValidator(GinkgoLogr, &version.KubeVersion{Major: 1, Minor: 34})
 )
 
 var _ = Describe("maxCombinedLength", func() {
@@ -411,7 +412,7 @@ var _ = Describe("validateModule", func() {
 			mod.Name = name
 			mod.Namespace = ns
 
-			_, err := validateModule(&mod, &KubeVersion{Major: 1, Minor: 34})
+			_, err := validateModule(&mod, &version.KubeVersion{Major: 1, Minor: 34})
 			exp := Expect(err)
 
 			if errExpected {
@@ -426,7 +427,7 @@ var _ = Describe("validateModule", func() {
 	It("should pass when moduleLoader is not defined", func() {
 		mod := validModule
 		mod.Spec.ModuleLoader = nil
-		_, err := validateModule(&mod, &KubeVersion{Major: 1, Minor: 34})
+		_, err := validateModule(&mod, &version.KubeVersion{Major: 1, Minor: 34})
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -699,36 +700,6 @@ var _ = Describe("validateTolerations", func() {
 	})
 })
 
-var _ = Describe("parseKubeVersion", func() {
-	DescribeTable(
-		"should parse valid version strings",
-		func(gitVersion string, expectedMajor, expectedMinor int) {
-			kv, err := parseKubeVersion(gitVersion)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(kv.Major).To(Equal(expectedMajor))
-			Expect(kv.Minor).To(Equal(expectedMinor))
-		},
-		Entry("standard version", "v1.34.0", 1, 34),
-		Entry("with build metadata", "v1.34.0+k3s1", 1, 34),
-		Entry("pre-release version", "v1.33.0-alpha.1", 1, 33),
-		Entry("higher minor", "v1.35.1", 1, 35),
-		Entry("without v prefix", "1.34.0", 1, 34),
-		Entry("hypothetical k8s 2.0", "v2.0.0", 2, 0),
-		Entry("hypothetical k8s 2.5", "v2.5.3", 2, 5),
-	)
-
-	DescribeTable(
-		"should return error for invalid strings",
-		func(gitVersion string) {
-			_, err := parseKubeVersion(gitVersion)
-			Expect(err).To(HaveOccurred())
-		},
-		Entry("empty string", ""),
-		Entry("garbage", "invalid"),
-		Entry("no minor", "v1"),
-	)
-})
-
 var _ = Describe("validateDRA", func() {
 	validDRASpec := func() *kmmv1beta1.DRASpec {
 		return &kmmv1beta1.DRASpec{
@@ -739,7 +710,7 @@ var _ = Describe("validateDRA", func() {
 		}
 	}
 
-	minValidKubeVersion := &KubeVersion{Major: 1, Minor: 34}
+	minValidKubeVersion := &version.KubeVersion{Major: 1, Minor: 34}
 
 	It("should be a no-op when spec.dra is nil", func() {
 		mod := &kmmv1beta1.Module{}
@@ -748,7 +719,7 @@ var _ = Describe("validateDRA", func() {
 
 	DescribeTable(
 		"Kubernetes version gate",
-		func(kv *KubeVersion, shouldFail bool) {
+		func(kv *version.KubeVersion, shouldFail bool) {
 			mod := &kmmv1beta1.Module{
 				Spec: kmmv1beta1.ModuleSpec{
 					DRA: validDRASpec(),
@@ -761,11 +732,11 @@ var _ = Describe("validateDRA", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},
-		Entry("k8s 1.33 rejects", &KubeVersion{Major: 1, Minor: 33}, true),
-		Entry("k8s 1.34 accepts", &KubeVersion{Major: 1, Minor: 34}, false),
-		Entry("k8s 1.35 accepts", &KubeVersion{Major: 1, Minor: 35}, false),
-		Entry("k8s 2.0 accepts (future major)", &KubeVersion{Major: 2, Minor: 0}, false),
-		Entry("k8s 0.99 rejects (old major)", &KubeVersion{Major: 0, Minor: 99}, true),
+		Entry("k8s 1.33 rejects", &version.KubeVersion{Major: 1, Minor: 33}, true),
+		Entry("k8s 1.34 accepts", &version.KubeVersion{Major: 1, Minor: 34}, false),
+		Entry("k8s 1.35 accepts", &version.KubeVersion{Major: 1, Minor: 35}, false),
+		Entry("k8s 2.0 accepts (future major)", &version.KubeVersion{Major: 2, Minor: 0}, false),
+		Entry("k8s 0.99 rejects (old major)", &version.KubeVersion{Major: 0, Minor: 99}, true),
 		Entry("nil version skips gate (hub webhook)", nil, false),
 	)
 


### PR DESCRIPTION
The DRA reconciler was registered unconditionally, which would crash the entire operator on clusters older than 1.34 because the resource.k8s.io/v1 DeviceClass API does not exist there.

Introduce an internal/version package with KubeVersion, DiscoverKubeVersion, and an AtLeast method to centralise version discovery and comparison. The manager now checks the cluster version at startup and only registers the DRA controller when the minimum version is met. The webhook package is updated to use the shared version package instead of its own local types.

Also fixes a pre-existing bug where /run was missing from the allowed hostPath prefixes error message.


---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 