### PR TITLE
Add DRA e2e CI test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -130,6 +130,11 @@ jobs:
             env:
               KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci
             script: ./ci/prow/e2e-incluster-build
+          - name: e2e-dra
+            env:
+              KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci
+            script: ./ci/prow/e2e-dra
+            start-args: --nodes=2
           - name: e2e-hub
             env:
               KUSTOMIZE_CONFIG_HUB_DEFAULT: ci/install-ci-hub
@@ -154,7 +159,7 @@ jobs:
       - name: Create the minikube cluster
         uses: ./.github/actions/create-minikube-cluster
         with:
-          start-args: --insecure-registry=host.minikube.internal:5000
+          start-args: --insecure-registry=host.minikube.internal:5000 ${{ matrix.start-args || '' }}
 
       - name: Download container images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/ci/dra-consumer-pod.yaml
+++ b/ci/dra-consumer-pod.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: dra-test-claim
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: kmm-ci-test-device
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dra-consumer
+spec:
+  # Prefer the node WITHOUT the DRA device. This ensures that if the pod
+  # still lands on minikube (the node with the device), it is because DRA
+  # scheduling overrode the node preference — not scheduler coincidence.
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: kubernetes.io/hostname
+            operator: In
+            values:
+            - minikube-m02
+  containers:
+  - name: consumer
+    image: busybox:1.36
+    command: ["sh", "-c", "sleep infinity"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: dra-test-claim

--- a/ci/dra-example-driver-rbac.yaml
+++ b/ci/dra-example-driver-rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dra-example-driver
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dra-example-driver
+rules:
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/status"]
+  verbs: ["update"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs: ["associated-node:update", "associated-node:patch"]
+  resourceNames: ["gpu.example.com"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceslices"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dra-example-driver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dra-example-driver
+subjects:
+- kind: ServiceAccount
+  name: dra-example-driver
+  namespace: default

--- a/ci/module-kmm-ci-dra.yaml
+++ b/ci/module-kmm-ci-dra.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci-dra
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: kmm_ci_a
+        modulesLoadingOrder: [kmm_ci_a, kmm_ci_b]
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION
+          registryTLS:
+            insecure: true
+          build:
+            secrets:
+              - name: build-secret
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+            kanikoParams:
+              tag: "debug"
+  dra:
+    driverName: gpu.example.com
+    serviceAccountName: dra-example-driver
+    container:
+      image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0
+      command: ["dra-example-kubeletplugin"]
+      env:
+        - name: DRIVER_NAME
+          value: gpu.example.com
+    deviceClasses:
+      - name: kmm-ci-test-device
+  selector:
+    kubernetes.io/hostname: minikube

--- a/ci/prow/e2e-dra
+++ b/ci/prow/e2e-dra
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+KUBE_MAJOR=$(kubectl version -o json | jq -r '.serverVersion.major' | tr -d '+')
+KUBE_MINOR=$(kubectl version -o json | jq -r '.serverVersion.minor' | tr -d '+')
+if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -lt 34 ]; then
+  echo "SKIP: DRA requires Kubernetes >= 1.34, got ${KUBE_MAJOR}.${KUBE_MINOR}"
+  exit 0
+fi
+
+echo "Wait for the second node"
+kubectl wait --for=condition=Ready node/minikube-m02 --timeout=2m
+
+echo "Deploy KMM"
+make deploy
+
+echo "Create a build secret"
+kubectl create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+
+echo "Add a configmap that contains the kernel module build dockerfile"
+kubectl apply -f ci/kmm-kmod-dockerfile.yaml
+
+kubectl wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook -n kmm-operator-system
+
+echo "Create RBAC for the DRA example driver"
+kubectl apply -f ci/dra-example-driver-rbac.yaml
+
+echo "Add a Module with DRA spec"
+timeout 1m bash -c 'until kubectl apply -f ci/module-kmm-ci-dra.yaml; do sleep 3; done'
+
+echo "Check that the module gets loaded on the node"
+timeout 10m bash -c 'until minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Check that the DRA DaemonSet gets created"
+timeout 2m bash -c 'until kubectl get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra -o name 2>/dev/null | grep -q daemonset; do sleep 3; done'
+
+echo "Check that the DRA DaemonSet pod is ready"
+timeout 5m bash -c 'until [ "$(kubectl get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra -o jsonpath="{.items[0].status.numberReady}" 2>/dev/null)" = "1" ]; do sleep 3; done'
+
+echo "Check that the DeviceClass was created with correct labels"
+DC_MODULE_NAME=$(kubectl get deviceclass kmm-ci-test-device -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/module\.name}')
+DC_MODULE_NS=$(kubectl get deviceclass kmm-ci-test-device -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/module\.namespace}')
+[ "${DC_MODULE_NAME}" = "kmm-ci-dra" ]
+[ "${DC_MODULE_NS}" = "default" ]
+
+echo "Check that the DRA node label was set"
+timeout 2m bash -c 'until kubectl get node minikube -o jsonpath="{.metadata.labels}" | grep "kmm\.node\.kubernetes\.io/default\.kmm-ci-dra\.dra-ready"; do sleep 3; done'
+
+echo "Check that ResourceSlices were published by the driver"
+timeout 2m bash -c 'until [ "$(kubectl get resourceslice --no-headers 2>/dev/null | grep gpu.example.com | wc -l)" -gt 0 ]; do sleep 3; done'
+
+echo "Check that Module status.dra is populated"
+[ "$(kubectl get module kmm-ci-dra -o jsonpath='{.status.dra.availableNumber}')" = "1" ]
+
+echo "Deploy a consumer pod requesting DRA hardware"
+kubectl apply -f ci/dra-consumer-pod.yaml
+
+echo "Check that the consumer pod is running on the node with the DRA driver"
+kubectl wait --for=condition=Ready pod/dra-consumer --timeout=2m
+[ "$(kubectl get pod dra-consumer -o jsonpath='{.spec.nodeName}')" = "minikube" ]
+
+echo "Remove the consumer pod"
+kubectl delete -f ci/dra-consumer-pod.yaml
+timeout 1m bash -c 'until ! kubectl get pod dra-consumer 2>/dev/null; do sleep 3; done'
+
+echo "Remove the Module"
+kubectl delete -f ci/module-kmm-ci-dra.yaml --wait=false
+
+echo "Check that the DRA DaemonSet gets cleaned up"
+timeout 2m bash -c 'until [ "$(kubectl get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra --no-headers 2>/dev/null | wc -l)" -eq 0 ]; do sleep 3; done'
+
+echo "Check that the DeviceClass gets cleaned up"
+timeout 1m bash -c 'until ! kubectl get deviceclass kmm-ci-test-device 2>/dev/null; do sleep 3; done'
+
+echo "Check that the module gets unloaded from the node"
+timeout 1m bash -c 'until ! minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Wait for the Module to be deleted"
+kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci-dra


### PR DESCRIPTION
Add an end-to-end test that validates the full DRA lifecycle: DaemonSet creation, DeviceClass management, node labeling, status reporting, and cleanup on Module deletion.

---

/cc @ybettan @yevgeny-shnaidman 