### PR TITLE
Rename version-schedule-plugin label to version-schedule-pod

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -11,9 +11,9 @@ const (
 	DaemonSetRole          = "kmm.node.kubernetes.io/role"
 	NamespaceLabelKey      = "kmm.node.k8s.io/contains-modules"
 
-	WorkerPodVersionLabelPrefix      = "beta.kmm.node.kubernetes.io/version-worker-pod"
-	SchedulePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-schedule-plugin"
-	ModuleVersionLabelPrefix         = "kmm.node.kubernetes.io/version-module"
+	WorkerPodVersionLabelPrefix   = "beta.kmm.node.kubernetes.io/version-worker-pod"
+	SchedulePodVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-schedule-pod"
+	ModuleVersionLabelPrefix      = "kmm.node.kubernetes.io/version-module"
 
 	GCDelayFinalizer  = "kmm.node.kubernetes.io/gc-delay"
 	ModuleFinalizer   = "kmm.node.kubernetes.io/module-finalizer"

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -507,7 +507,7 @@ func generateDevicePluginLabelsAndSelector(mod *kmmv1beta1.Module) (map[string]s
 	}
 
 	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
-		versionLabel := utils.GetSchedulePluginVersionLabelName(mod.Namespace, mod.Name)
+		versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
 		labels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
 		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
 	} else if mod.Spec.ModuleLoader == nil {
@@ -543,7 +543,7 @@ func getExistingDSFromVersion(existingDS []appsv1.DaemonSet,
 		version = moduleLoader.Container.Version
 	}
 
-	versionLabel := utils.GetSchedulePluginVersionLabelName(moduleNamespace, moduleName)
+	versionLabel := utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName)
 	for _, ds := range existingDS {
 		dsModuleVersion := ds.GetLabels()[versionLabel]
 		if dsModuleVersion == version {
@@ -556,7 +556,7 @@ func getExistingDSFromVersion(existingDS []appsv1.DaemonSet,
 func isOlderVersionUnusedDevicePluginDaemonset(ds *appsv1.DaemonSet, moduleVersion string) bool {
 	moduleName := ds.Labels[constants.ModuleNameLabel]
 	moduleNamespace := ds.Namespace
-	versionLabel := utils.GetSchedulePluginVersionLabelName(moduleNamespace, moduleName)
+	versionLabel := utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName)
 	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
 }
 

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -316,7 +316,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 			},
 		},
 	}
-	schedulePluginVersionLabel := utils.GetSchedulePluginVersionLabelName(mod.Namespace, mod.Name)
+	schedulePodVersionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
 
 	DescribeTable("device-plugin GC", func(devicePluginFormerLabel bool, devicePluginFormerDesired int) {
 		devicePluginDS := appsv1.DaemonSet{
@@ -324,8 +324,8 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 				Name:      "devicePlugin",
 				Namespace: "namespace",
 				Labels: map[string]string{
-					schedulePluginVersionLabel: currentModuleVersion,
-					constants.ModuleNameLabel:  mod.Name,
+					schedulePodVersionLabel:   currentModuleVersion,
+					constants.ModuleNameLabel: mod.Name,
 				},
 			},
 		}
@@ -335,7 +335,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 		if devicePluginFormerLabel {
 			devicePluginFormerVersionDS = devicePluginDS.DeepCopy()
 			devicePluginFormerVersionDS.SetName("devicePluginFormer")
-			devicePluginFormerVersionDS.Labels[schedulePluginVersionLabel] = "former label"
+			devicePluginFormerVersionDS.Labels[schedulePodVersionLabel] = "former label"
 			devicePluginFormerVersionDS.Status.DesiredNumberScheduled = int32(devicePluginFormerDesired)
 			existingDS = append(existingDS, *devicePluginFormerVersionDS)
 		}
@@ -357,7 +357,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "devicePlugin",
 				Namespace: "namespace",
-				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePluginVersionLabel: "formerVersion"},
+				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "formerVersion"},
 			},
 		}
 		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
@@ -375,7 +375,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "devicePlugin",
 				Namespace: "namespace",
-				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePluginVersionLabel: "formerVersion"},
+				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "formerVersion"},
 			},
 		}
 
@@ -738,7 +738,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		err := dsc.setDevicePluginAsDesired(context.Background(), &ds, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
-		versionLabel := utils.GetSchedulePluginVersionLabelName(namespace, moduleName)
+		versionLabel := utils.GetSchedulePodVersionLabelName(namespace, moduleName)
 		Expect(ds.GetLabels()).Should(HaveKeyWithValue(versionLabel, "some version"))
 	})
 
@@ -968,7 +968,7 @@ var _ = Describe("DevicePluginReconciler_getExistingDSFromVersion", func() {
 	)
 
 	devicePluginLabels := map[string]string{
-		utils.GetSchedulePluginVersionLabelName(moduleNamespace, moduleName): moduleVersion,
+		utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName): moduleVersion,
 	}
 
 	ds := appsv1.DaemonSet{

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -240,7 +240,7 @@ func getExistingDRADSFromVersion(existingDS []appsv1.DaemonSet,
 		version = moduleLoader.Container.Version
 	}
 
-	versionLabel := utils.GetSchedulePluginVersionLabelName(moduleNamespace, moduleName)
+	versionLabel := utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName)
 	for _, ds := range existingDS {
 		dsModuleVersion := ds.GetLabels()[versionLabel]
 		if dsModuleVersion == version {
@@ -252,7 +252,7 @@ func getExistingDRADSFromVersion(existingDS []appsv1.DaemonSet,
 
 func isOlderVersionUnusedDRADaemonSet(ds *appsv1.DaemonSet, moduleNamespace, moduleVersion string) bool {
 	moduleName := ds.Labels[constants.ModuleNameLabel]
-	versionLabel := utils.GetSchedulePluginVersionLabelName(moduleNamespace, moduleName)
+	versionLabel := utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName)
 	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
 }
 
@@ -513,7 +513,7 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 	}
 
 	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
-		versionLabel := utils.GetSchedulePluginVersionLabelName(mod.Namespace, mod.Name)
+		versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
 		standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
 		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
 	}

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -794,7 +794,7 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 		err := dsc.setDRAAsDesired(context.Background(), &ds, &mod)
 		Expect(err).NotTo(HaveOccurred())
 
-		versionLabel := utils.GetSchedulePluginVersionLabelName(namespace, draModuleName)
+		versionLabel := utils.GetSchedulePodVersionLabelName(namespace, draModuleName)
 
 		Expect(ds.Labels).To(HaveKeyWithValue(versionLabel, "1"))
 		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(versionLabel, "1"))
@@ -832,7 +832,7 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 			},
 		},
 	}
-	schedulePluginVersionLabel := utils.GetSchedulePluginVersionLabelName(mod.Namespace, mod.Name)
+	schedulePodVersionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
 
 	DescribeTable("DRA GC", func(formerDSExists bool, formerDesired int) {
 		currentDS := appsv1.DaemonSet{
@@ -840,8 +840,8 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 				Name:      "dra-current",
 				Namespace: "namespace",
 				Labels: map[string]string{
-					schedulePluginVersionLabel: currentModuleVersion,
-					constants.ModuleNameLabel:  mod.Name,
+					schedulePodVersionLabel:   currentModuleVersion,
+					constants.ModuleNameLabel: mod.Name,
 				},
 			},
 		}
@@ -851,7 +851,7 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 		if formerDSExists {
 			formerDS = currentDS.DeepCopy()
 			formerDS.SetName("dra-former")
-			formerDS.Labels[schedulePluginVersionLabel] = "former"
+			formerDS.Labels[schedulePodVersionLabel] = "former"
 			formerDS.Status.DesiredNumberScheduled = int32(formerDesired)
 			existingDS = append(existingDS, *formerDS)
 		}
@@ -872,7 +872,7 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dra-old",
 				Namespace: "namespace",
-				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePluginVersionLabel: "formerVersion"},
+				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "formerVersion"},
 			},
 		}
 		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
@@ -888,7 +888,7 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dra-old",
 				Namespace: "namespace",
-				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePluginVersionLabel: "formerVersion"},
+				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "formerVersion"},
 			},
 		}
 

--- a/internal/controllers/mock_node_label_module_version_reconciler.go
+++ b/internal/controllers/mock_node_label_module_version_reconciler.go
@@ -68,33 +68,33 @@ func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getLoadedKernelModule
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getLoadedKernelModules", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getLoadedKernelModules), labels)
 }
 
-// getSchedulePluginPods mocks base method.
-func (m *MocknodeLabelModuleVersionHelperAPI) getSchedulePluginPods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
+// getSchedulePods mocks base method.
+func (m *MocknodeLabelModuleVersionHelperAPI) getSchedulePods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getSchedulePluginPods", ctx, nodeName)
+	ret := m.ctrl.Call(m, "getSchedulePods", ctx, nodeName)
 	ret0, _ := ret[0].([]v1.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// getSchedulePluginPods indicates an expected call of getSchedulePluginPods.
-func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getSchedulePluginPods(ctx, nodeName any) *gomock.Call {
+// getSchedulePods indicates an expected call of getSchedulePods.
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getSchedulePods(ctx, nodeName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getSchedulePluginPods", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getSchedulePluginPods), ctx, nodeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getSchedulePods", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getSchedulePods), ctx, nodeName)
 }
 
 // reconcileLabels mocks base method.
-func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, schedulePluginPods []v1.Pod, kernelModuleReadyLabels []types.NamespacedName) *reconcileLabelsResult {
+func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, schedulePods []v1.Pod, kernelModuleReadyLabels []types.NamespacedName) *reconcileLabelsResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, schedulePluginPods, kernelModuleReadyLabels)
+	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, schedulePods, kernelModuleReadyLabels)
 	ret0, _ := ret[0].(*reconcileLabelsResult)
 	return ret0
 }
 
 // reconcileLabels indicates an expected call of reconcileLabels.
-func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, schedulePluginPods, kernelModuleReadyLabels any) *gomock.Call {
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, schedulePods, kernelModuleReadyLabels any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, schedulePluginPods, kernelModuleReadyLabels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, schedulePods, kernelModuleReadyLabels)
 }
 
 // updateNodeLabels mocks base method.

--- a/internal/controllers/module_version_label_action_table.go
+++ b/internal/controllers/module_version_label_action_table.go
@@ -13,9 +13,9 @@ const (
 )
 
 type labelActionKey struct {
-	module         string
-	workerPod      string
-	schedulePlugin string
+	module      string
+	workerPod   string
+	schedulePod string
 }
 
 type labelAction struct {
@@ -25,42 +25,42 @@ type labelAction struct {
 
 var labelActionTable = map[labelActionKey]labelAction{
 	{
-		module:         labelMissing,
-		workerPod:      labelMissing,
-		schedulePlugin: labelMissing}: {getLabelName: nil, action: noneAction},
+		module:      labelMissing,
+		workerPod:   labelMissing,
+		schedulePod: labelMissing}: {getLabelName: nil, action: noneAction},
 
 	{
-		module:         labelMissing,
-		workerPod:      labelPresent,
-		schedulePlugin: labelPresent}: {getLabelName: utils.GetSchedulePluginVersionLabelName, action: deleteAction},
+		module:      labelMissing,
+		workerPod:   labelPresent,
+		schedulePod: labelPresent}: {getLabelName: utils.GetSchedulePodVersionLabelName, action: deleteAction},
 
 	{
-		module:         labelMissing,
-		workerPod:      labelPresent,
-		schedulePlugin: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
+		module:      labelMissing,
+		workerPod:   labelPresent,
+		schedulePod: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
 
 	{
-		module:         labelPresent,
-		workerPod:      labelMissing,
-		schedulePlugin: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: addAction},
+		module:      labelPresent,
+		workerPod:   labelMissing,
+		schedulePod: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: addAction},
 
 	{
-		module:         labelPresent,
-		workerPod:      labelPresent,
-		schedulePlugin: labelMissing}: {getLabelName: utils.GetSchedulePluginVersionLabelName, action: addAction},
+		module:      labelPresent,
+		workerPod:   labelPresent,
+		schedulePod: labelMissing}: {getLabelName: utils.GetSchedulePodVersionLabelName, action: addAction},
 
 	{
-		module:         labelPresent,
-		workerPod:      labelPresent,
-		schedulePlugin: labelPresent}: {getLabelName: nil, action: noneAction},
+		module:      labelPresent,
+		workerPod:   labelPresent,
+		schedulePod: labelPresent}: {getLabelName: nil, action: noneAction},
 
 	{
-		module:         labelPresent,
-		workerPod:      labelDifferent,
-		schedulePlugin: labelDifferent}: {getLabelName: utils.GetSchedulePluginVersionLabelName, action: deleteAction},
+		module:      labelPresent,
+		workerPod:   labelDifferent,
+		schedulePod: labelDifferent}: {getLabelName: utils.GetSchedulePodVersionLabelName, action: deleteAction},
 
 	{
-		module:         labelPresent,
-		workerPod:      labelDifferent,
-		schedulePlugin: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
+		module:      labelPresent,
+		workerPod:   labelDifferent,
+		schedulePod: labelMissing}: {getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
 }

--- a/internal/controllers/node_label_module_version_reconciler.go
+++ b/internal/controllers/node_label_module_version_reconciler.go
@@ -19,11 +19,11 @@ import (
 )
 
 type modulesVersionLabels struct {
-	name                       string
-	namespace                  string
-	moduleVersionLabel         string
-	workerPodVersionLabel      string
-	schedulePluginVersionLabel string
+	name                    string
+	namespace               string
+	moduleVersionLabel      string
+	workerPodVersionLabel   string
+	schedulePodVersionLabel string
 }
 
 const (
@@ -51,14 +51,14 @@ func NewNodeLabelModuleVersionReconciler(client client.Client) *NodeLabelModuleV
 func (nlmvr *NodeLabelModuleVersionReconciler) Reconcile(ctx context.Context, node *v1.Node) (ctrl.Result, error) {
 	modulesVersionLabels := nlmvr.helperAPI.getLabelsPerModules(ctx, node.Labels)
 
-	schedulePluginPods, err := nlmvr.helperAPI.getSchedulePluginPods(ctx, node.Name)
+	schedulePods, err := nlmvr.helperAPI.getSchedulePods(ctx, node.Name)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not get schedule plugin pods for the node %s: %v", node.Name, err)
+		return ctrl.Result{}, fmt.Errorf("could not get schedule pods for the node %s: %v", node.Name, err)
 	}
 
 	loadedKernelModules := nlmvr.helperAPI.getLoadedKernelModules(node.GetLabels())
 
-	reconLabelsRes := nlmvr.helperAPI.reconcileLabels(modulesVersionLabels, schedulePluginPods, loadedKernelModules)
+	reconLabelsRes := nlmvr.helperAPI.reconcileLabels(modulesVersionLabels, schedulePods, loadedKernelModules)
 
 	logger := log.FromContext(ctx).WithValues("node name", node.Name)
 	logLabelsUpdateData(logger, reconLabelsRes)
@@ -75,9 +75,9 @@ func (nlmvr *NodeLabelModuleVersionReconciler) Reconcile(ctx context.Context, no
 
 type nodeLabelModuleVersionHelperAPI interface {
 	getLabelsPerModules(ctx context.Context, nodeLabels map[string]string) map[string]*modulesVersionLabels
-	getSchedulePluginPods(ctx context.Context, nodeName string) ([]v1.Pod, error)
+	getSchedulePods(ctx context.Context, nodeName string) ([]v1.Pod, error)
 	getLoadedKernelModules(labels map[string]string) []types.NamespacedName
-	reconcileLabels(modulesLabels map[string]*modulesVersionLabels, schedulePluginPods []v1.Pod, kernelModuleReadyLabels []types.NamespacedName) *reconcileLabelsResult
+	reconcileLabels(modulesLabels map[string]*modulesVersionLabels, schedulePods []v1.Pod, kernelModuleReadyLabels []types.NamespacedName) *reconcileLabelsResult
 	updateNodeLabels(ctx context.Context, nodeName string, reconLabelsRes *reconcileLabelsResult) error
 }
 
@@ -110,8 +110,8 @@ func (nlmvha *nodeLabelModuleVersionHelper) getLabelsPerModules(ctx context.Cont
 				labelsPerModule[mapKey].moduleVersionLabel = value
 			case utils.IsWorkerPodVersionLabel(key):
 				labelsPerModule[mapKey].workerPodVersionLabel = value
-			case utils.IsSchedulePluginVersionLabel(key):
-				labelsPerModule[mapKey].schedulePluginVersionLabel = value
+			case utils.IsSchedulePodVersionLabel(key):
+				labelsPerModule[mapKey].schedulePodVersionLabel = value
 			}
 		}
 	}
@@ -119,7 +119,7 @@ func (nlmvha *nodeLabelModuleVersionHelper) getLabelsPerModules(ctx context.Cont
 	return labelsPerModule
 }
 
-func (nlmvha *nodeLabelModuleVersionHelper) getSchedulePluginPods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
+func (nlmvha *nodeLabelModuleVersionHelper) getSchedulePods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
 	req, err := labels.NewRequirement(
 		constants.DaemonSetRole,
 		selection.In,
@@ -136,7 +136,7 @@ func (nlmvha *nodeLabelModuleVersionHelper) getSchedulePluginPods(ctx context.Co
 		client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(*req)},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get list of schedule plugin pods on node %s: %v", nodeName, err)
+		return nil, fmt.Errorf("failed to get list of schedule pods on node %s: %v", nodeName, err)
 	}
 	return podsList.Items, nil
 }
@@ -176,7 +176,7 @@ func (nlmvha *nodeLabelModuleVersionHelper) updateNodeLabels(ctx context.Context
 }
 
 func (nlmvha *nodeLabelModuleVersionHelper) reconcileLabels(modulesLabels map[string]*modulesVersionLabels,
-	schedulePluginPods []v1.Pod,
+	schedulePods []v1.Pod,
 	loadedKernelModules []types.NamespacedName) *reconcileLabelsResult {
 
 	reconRes := reconcileLabelsResult{
@@ -187,7 +187,7 @@ func (nlmvha *nodeLabelModuleVersionHelper) reconcileLabels(modulesLabels map[st
 		label, labelValue, action := getLabelAndAction(moduleLabels)
 		switch action {
 		case deleteAction:
-			if utils.IsWorkerPodVersionLabel(label) && !verifyLabelDeleteValidity(moduleLabels.name, moduleLabels.namespace, schedulePluginPods) {
+			if utils.IsWorkerPodVersionLabel(label) && !verifyLabelDeleteValidity(moduleLabels.name, moduleLabels.namespace, schedulePods) {
 				reconRes.requeue = true
 			} else {
 				reconRes.labelsToDelete = append(reconRes.labelsToDelete, label)
@@ -204,7 +204,7 @@ func (nlmvha *nodeLabelModuleVersionHelper) reconcileLabels(modulesLabels map[st
 	return &reconRes
 }
 
-// verifyLabelDeleteValidity checks that no schedule plugin pod (device plugin
+// verifyLabelDeleteValidity checks that no schedule pod (device plugin
 // or DRA) matching the module name and namespace is present. If a matching pod
 // exists, the delete action is invalid regardless of pod state.
 func verifyLabelDeleteValidity(name, namespace string, pods []v1.Pod) bool {
@@ -245,9 +245,9 @@ func getLabelAndAction(moduleLabels *modulesVersionLabels) (string, string, stri
 
 func getModuleVersionLabelsState(moduleLabels *modulesVersionLabels) labelActionKey {
 	key := labelActionKey{
-		module:         labelPresent,
-		workerPod:      labelPresent,
-		schedulePlugin: labelPresent,
+		module:      labelPresent,
+		workerPod:   labelPresent,
+		schedulePod: labelPresent,
 	}
 	if moduleLabels.moduleVersionLabel == "" {
 		key.module = labelMissing
@@ -257,10 +257,10 @@ func getModuleVersionLabelsState(moduleLabels *modulesVersionLabels) labelAction
 	} else if moduleLabels.moduleVersionLabel != "" && moduleLabels.workerPodVersionLabel != moduleLabels.moduleVersionLabel {
 		key.workerPod = labelDifferent
 	}
-	if moduleLabels.schedulePluginVersionLabel == "" {
-		key.schedulePlugin = labelMissing
-	} else if moduleLabels.moduleVersionLabel != "" && moduleLabels.schedulePluginVersionLabel != moduleLabels.moduleVersionLabel {
-		key.schedulePlugin = labelDifferent
+	if moduleLabels.schedulePodVersionLabel == "" {
+		key.schedulePod = labelMissing
+	} else if moduleLabels.moduleVersionLabel != "" && moduleLabels.schedulePodVersionLabel != moduleLabels.moduleVersionLabel {
+		key.schedulePod = labelDifferent
 	}
 	return key
 }

--- a/internal/controllers/node_label_module_version_reconciler_test.go
+++ b/internal/controllers/node_label_module_version_reconciler_test.go
@@ -41,22 +41,22 @@ var _ = Describe("Reconcile", func() {
 	ctx := context.Background()
 	nodeLabels := map[string]string{"some label": "some label value"}
 
-	DescribeTable("reconciler flow", func(getSchedulePluginPodsError, upDateNodeLabelsErrors, requeue bool) {
+	DescribeTable("reconciler flow", func(getSchedulePodsError, upDateNodeLabelsErrors, requeue bool) {
 		labelsPerModules := map[string]*modulesVersionLabels{
 			"moduleNameNamespace": {name: "name", namespace: "namespace"},
 		}
-		schedulePluginPods := []v1.Pod{{}}
+		schedulePods := []v1.Pod{{}}
 		loadedKernelModules := []types.NamespacedName{{Name: "some name", Namespace: "some namespace"}}
 		reconcileLabelsResult := &reconcileLabelsResult{requeue: requeue}
 		expectedRes := ctrl.Result{Requeue: requeue}
 		mockHelper.EXPECT().getLabelsPerModules(ctx, nodeLabels).Return(labelsPerModules)
-		if getSchedulePluginPodsError {
-			mockHelper.EXPECT().getSchedulePluginPods(ctx, nodeName).Return(nil, fmt.Errorf("some error"))
+		if getSchedulePodsError {
+			mockHelper.EXPECT().getSchedulePods(ctx, nodeName).Return(nil, fmt.Errorf("some error"))
 			goto executeTestFunction
 		}
-		mockHelper.EXPECT().getSchedulePluginPods(ctx, nodeName).Return(schedulePluginPods, nil)
+		mockHelper.EXPECT().getSchedulePods(ctx, nodeName).Return(schedulePods, nil)
 		mockHelper.EXPECT().getLoadedKernelModules(nodeLabels).Return(loadedKernelModules)
-		mockHelper.EXPECT().reconcileLabels(labelsPerModules, schedulePluginPods, loadedKernelModules).Return(reconcileLabelsResult)
+		mockHelper.EXPECT().reconcileLabels(labelsPerModules, schedulePods, loadedKernelModules).Return(reconcileLabelsResult)
 		if upDateNodeLabelsErrors {
 			mockHelper.EXPECT().updateNodeLabels(ctx, nodeName, reconcileLabelsResult).Return(fmt.Errorf("some error"))
 			goto executeTestFunction
@@ -71,7 +71,7 @@ var _ = Describe("Reconcile", func() {
 		}
 
 		res, err := nlmvr.Reconcile(ctx, &node)
-		if upDateNodeLabelsErrors || getSchedulePluginPodsError {
+		if upDateNodeLabelsErrors || getSchedulePodsError {
 			Expect(err).To(HaveOccurred())
 		} else {
 			Expect(err).ToNot(HaveOccurred())
@@ -80,7 +80,7 @@ var _ = Describe("Reconcile", func() {
 	},
 		Entry("good flow, no requeue", false, false, false),
 		Entry("good flow, with requeue", false, false, true),
-		Entry("get schedule plugin pods failed", true, false, false),
+		Entry("get schedule pods failed", true, false, false),
 		Entry("update node labels failed", false, true, false),
 	)
 })
@@ -97,26 +97,26 @@ var _ = Describe("getLabelsPerModules", func() {
 	nodeLabels := map[string]string{
 		"some label 1": "some value1",
 		"some label 2": "",
-		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace1.module1":      "1",
-		"beta.kmm.node.kubernetes.io/version-schedule-plugin.namespace1.module1": "1",
-		"kmm.node.kubernetes.io/version-module.namespace1.module1":               "1",
-		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace2.module2":      "3",
-		"kmm.node.kubernetes.io/version-module.namespace2.module2":               "3",
-		"beta.kmm.node.kubernetes.io/version-schedule-plugin.namespace3.module3": "4",
-		"kmm.node.kubernetes.io/version-module.namespace5.module5":               "10",
-		"beta.kmm.node.kubernetes.io/version-schedule-plugin.namespace4.module4": "5",
-		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace4.module4":      "5",
-		"kmm.node.kubernetes.io/version-module.namespace4.module4":               "5",
+		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace1.module1":   "1",
+		"beta.kmm.node.kubernetes.io/version-schedule-pod.namespace1.module1": "1",
+		"kmm.node.kubernetes.io/version-module.namespace1.module1":            "1",
+		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace2.module2":   "3",
+		"kmm.node.kubernetes.io/version-module.namespace2.module2":            "3",
+		"beta.kmm.node.kubernetes.io/version-schedule-pod.namespace3.module3": "4",
+		"kmm.node.kubernetes.io/version-module.namespace5.module5":            "10",
+		"beta.kmm.node.kubernetes.io/version-schedule-pod.namespace4.module4": "5",
+		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace4.module4":   "5",
+		"kmm.node.kubernetes.io/version-module.namespace4.module4":            "5",
 	}
 
 	It("normal flow", func() {
 		expectedRes := map[string]*modulesVersionLabels{
 			"namespace1-module1": {
-				name:                       "module1",
-				namespace:                  "namespace1",
-				moduleVersionLabel:         "1",
-				workerPodVersionLabel:      "1",
-				schedulePluginVersionLabel: "1",
+				name:                    "module1",
+				namespace:               "namespace1",
+				moduleVersionLabel:      "1",
+				workerPodVersionLabel:   "1",
+				schedulePodVersionLabel: "1",
 			},
 			"namespace2-module2": {
 				name:                  "module2",
@@ -125,16 +125,16 @@ var _ = Describe("getLabelsPerModules", func() {
 				workerPodVersionLabel: "3",
 			},
 			"namespace3-module3": {
-				name:                       "module3",
-				namespace:                  "namespace3",
-				schedulePluginVersionLabel: "4",
+				name:                    "module3",
+				namespace:               "namespace3",
+				schedulePodVersionLabel: "4",
 			},
 			"namespace4-module4": {
-				name:                       "module4",
-				namespace:                  "namespace4",
-				moduleVersionLabel:         "5",
-				workerPodVersionLabel:      "5",
-				schedulePluginVersionLabel: "5",
+				name:                    "module4",
+				namespace:               "namespace4",
+				moduleVersionLabel:      "5",
+				workerPodVersionLabel:   "5",
+				schedulePodVersionLabel: "5",
 			},
 			"namespace5-module5": {
 				name:               "module5",
@@ -151,7 +151,7 @@ var _ = Describe("getLabelsPerModules", func() {
 	})
 })
 
-var _ = Describe("getSchedulePluginPods", func() {
+var _ = Describe("getSchedulePods", func() {
 	const (
 		nodeName = "node-name"
 	)
@@ -186,7 +186,7 @@ var _ = Describe("getSchedulePluginPods", func() {
 			},
 		)
 
-		res, err := helper.getSchedulePluginPods(ctx, nodeName)
+		res, err := helper.getSchedulePods(ctx, nodeName)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(res)).To(Equal(1))
 		Expect(res[0]).To(Equal(pod1))
@@ -195,7 +195,7 @@ var _ = Describe("getSchedulePluginPods", func() {
 	It("error flow", func() {
 		kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		res, err := helper.getSchedulePluginPods(ctx, nodeName)
+		res, err := helper.getSchedulePods(ctx, nodeName)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeNil())
 	})
@@ -203,14 +203,14 @@ var _ = Describe("getSchedulePluginPods", func() {
 })
 
 var _ = Describe("getLabelAndAction", func() {
-	DescribeTable("should return correct label and action", func(moduleVersionValue, workerPodVersionValue, schedulePluginVersionValue string,
+	DescribeTable("should return correct label and action", func(moduleVersionValue, workerPodVersionValue, schedulePodVersionValue string,
 		expectedLabelFunc func(string, string) string, expectedLabelValue, expectedAction string) {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         moduleVersionValue,
-			workerPodVersionLabel:      workerPodVersionValue,
-			schedulePluginVersionLabel: schedulePluginVersionValue,
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      moduleVersionValue,
+			workerPodVersionLabel:   workerPodVersionValue,
+			schedulePodVersionLabel: schedulePodVersionValue,
 		}
 		expectedLabel := ""
 		if expectedLabelFunc != nil {
@@ -224,13 +224,13 @@ var _ = Describe("getLabelAndAction", func() {
 		Expect(action).To(Equal(expectedAction))
 	},
 		Entry("all labels present with the same label", "1", "1", "1", nil, "", noneAction),
-		Entry("module version missing, worker pod present, schedule plugin present", "", "1", "1", utils.GetSchedulePluginVersionLabelName, "", deleteAction),
-		Entry("module version missing, worker pod present, schedule plugin missing", "", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
+		Entry("module version missing, worker pod present, schedule pod present", "", "1", "1", utils.GetSchedulePodVersionLabelName, "", deleteAction),
+		Entry("module version missing, worker pod present, schedule pod missing", "", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
 		Entry("all labels missing", "", "", "", nil, "", noneAction),
-		Entry("module version present, worker pod missing, schedule plugin missing", "1", "", "", utils.GetWorkerPodVersionLabelName, "1", addAction),
-		Entry("module version present, worker pod present, schedule plugin missing", "1", "1", "", utils.GetSchedulePluginVersionLabelName, "1", addAction),
-		Entry("module version present, worker pod different, schedule plugin different", "2", "1", "1", utils.GetSchedulePluginVersionLabelName, "", deleteAction),
-		Entry("module version present, worker pod different, schedule plugin missing", "2", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
+		Entry("module version present, worker pod missing, schedule pod missing", "1", "", "", utils.GetWorkerPodVersionLabelName, "1", addAction),
+		Entry("module version present, worker pod present, schedule pod missing", "1", "1", "", utils.GetSchedulePodVersionLabelName, "1", addAction),
+		Entry("module version present, worker pod different, schedule pod different", "2", "1", "1", utils.GetSchedulePodVersionLabelName, "", deleteAction),
+		Entry("module version present, worker pod different, schedule pod missing", "2", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
 	)
 })
 
@@ -247,29 +247,29 @@ var _ = Describe("reconcileLabels", func() {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "moduleNamespace"},
 	}
 
-	It("delete schedule plugin label, schedule plugin pod not present", func() {
+	It("delete schedule pod label, schedule pod not present", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "1",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "1",
 		}
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, nil)
 
 		Expect(res.requeue).To(BeFalse())
 		Expect(len(res.labelsToAdd)).To(Equal(0))
-		Expect(res.labelsToDelete).To(Equal([]string{utils.GetSchedulePluginVersionLabelName("moduleNamespace", "moduleName")}))
+		Expect(res.labelsToDelete).To(Equal([]string{utils.GetSchedulePodVersionLabelName("moduleNamespace", "moduleName")}))
 	})
 
-	It("delete worker pod label, schedule plugin pod not present", func() {
+	It("delete worker pod label, schedule pod not present", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "",
 		}
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, nil)
@@ -279,30 +279,30 @@ var _ = Describe("reconcileLabels", func() {
 		Expect(res.labelsToDelete).To(Equal([]string{utils.GetWorkerPodVersionLabelName("moduleNamespace", "moduleName")}))
 	})
 
-	It("delete schedule plugin label, schedule plugin pod present", func() {
+	It("delete schedule pod label, schedule pod present", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "1",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "1",
 		}
 		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName"})
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, nil)
 
 		Expect(res.requeue).To(BeFalse())
-		Expect(res.labelsToDelete).To(Equal([]string{utils.GetSchedulePluginVersionLabelName("moduleNamespace", "moduleName")}))
+		Expect(res.labelsToDelete).To(Equal([]string{utils.GetSchedulePodVersionLabelName("moduleNamespace", "moduleName")}))
 		Expect(len(res.labelsToAdd)).To(Equal(0))
 	})
 
-	It("delete worker pod label, schedule plugin pod present", func() {
+	It("delete worker pod label, schedule pod present", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "",
 		}
 		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName"})
 
@@ -315,11 +315,11 @@ var _ = Describe("reconcileLabels", func() {
 
 	It("add worker pod label, kernel module is not loaded", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "1",
-			workerPodVersionLabel:      "",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "1",
+			workerPodVersionLabel:   "",
+			schedulePodVersionLabel: "",
 		}
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, nil)
@@ -331,11 +331,11 @@ var _ = Describe("reconcileLabels", func() {
 
 	It("add worker pod label, kernel module is loaded", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "1",
-			workerPodVersionLabel:      "",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "1",
+			workerPodVersionLabel:   "",
+			schedulePodVersionLabel: "",
 		}
 
 		loadedKernelModules := []types.NamespacedName{{Name: "moduleName", Namespace: "moduleNamespace"}}
@@ -347,29 +347,29 @@ var _ = Describe("reconcileLabels", func() {
 		Expect(len(res.labelsToAdd)).To(Equal(0))
 	})
 
-	It("add schedule plugin label, kernel module is not loaded", func() {
+	It("add schedule pod label, kernel module is not loaded", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "1",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "1",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "",
 		}
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, nil)
 
 		Expect(res.requeue).To(BeFalse())
-		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetSchedulePluginVersionLabelName("moduleNamespace", "moduleName"): "1"}))
+		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetSchedulePodVersionLabelName("moduleNamespace", "moduleName"): "1"}))
 		Expect(len(res.labelsToDelete)).To(Equal(0))
 	})
 
-	It("add schedule plugin label, kernel module is loaded", func() {
+	It("add schedule pod label, kernel module is loaded", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "1",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "1",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "",
 		}
 
 		loadedKernelModules := []types.NamespacedName{{Name: "moduleName", Namespace: "moduleNamespace"}}
@@ -377,17 +377,17 @@ var _ = Describe("reconcileLabels", func() {
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod}, loadedKernelModules)
 
 		Expect(res.requeue).To(BeFalse())
-		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetSchedulePluginVersionLabelName("moduleNamespace", "moduleName"): "1"}))
+		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetSchedulePodVersionLabelName("moduleNamespace", "moduleName"): "1"}))
 		Expect(len(res.labelsToDelete)).To(Equal(0))
 	})
 
 	It("no label needs to be added due to none action", func() {
 		moduleLabels := &modulesVersionLabels{
-			name:                       "moduleName",
-			namespace:                  "moduleNamespace",
-			moduleVersionLabel:         "1",
-			workerPodVersionLabel:      "1",
-			schedulePluginVersionLabel: "1",
+			name:                    "moduleName",
+			namespace:               "moduleNamespace",
+			moduleVersionLabel:      "1",
+			workerPodVersionLabel:   "1",
+			schedulePodVersionLabel: "1",
 		}
 		pod := v1.Pod{}
 		pod.Namespace = "moduleNamespace"

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -23,8 +23,8 @@ func GetWorkerPodVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.WorkerPodVersionLabelPrefix, namespace, name)
 }
 
-func GetSchedulePluginVersionLabelName(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.SchedulePluginVersionLabelPrefix, namespace, name)
+func GetSchedulePodVersionLabelName(namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", constants.SchedulePodVersionLabelPrefix, namespace, name)
 }
 
 func GetNamespaceNameFromVersionLabel(label string) (string, string, error) {
@@ -36,7 +36,7 @@ func GetNamespaceNameFromVersionLabel(label string) (string, string, error) {
 }
 
 func IsVersionLabel(label string) bool {
-	return IsModuleVersionLabel(label) || IsWorkerPodVersionLabel(label) || IsSchedulePluginVersionLabel(label)
+	return IsModuleVersionLabel(label) || IsWorkerPodVersionLabel(label) || IsSchedulePodVersionLabel(label)
 }
 
 func IsModuleVersionLabel(label string) bool {
@@ -47,8 +47,8 @@ func IsWorkerPodVersionLabel(label string) bool {
 	return strings.HasPrefix(label, constants.WorkerPodVersionLabelPrefix)
 }
 
-func IsSchedulePluginVersionLabel(label string) bool {
-	return strings.HasPrefix(label, constants.SchedulePluginVersionLabelPrefix)
+func IsSchedulePodVersionLabel(label string) bool {
+	return strings.HasPrefix(label, constants.SchedulePodVersionLabelPrefix)
 }
 
 func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -19,10 +19,10 @@ var _ = Describe("GetWorkerPodVersionLabelName", func() {
 	})
 })
 
-var _ = Describe("GetSchedulePluginVersionLabelName", func() {
+var _ = Describe("GetSchedulePodVersionLabelName", func() {
 	It("should work as expected", func() {
-		res := GetSchedulePluginVersionLabelName("some-namespace", "some-name")
-		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-schedule-plugin.some-namespace.some-name"))
+		res := GetSchedulePodVersionLabelName("some-namespace", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-schedule-pod.some-namespace.some-name"))
 	})
 })
 
@@ -33,12 +33,12 @@ var _ = Describe("GetDRANodeLabel", func() {
 	})
 })
 
-var _ = Describe("IsSchedulePluginVersionLabel", func() {
+var _ = Describe("IsSchedulePodVersionLabel", func() {
 	DescribeTable("should work as expected",
 		func(input string, expected bool) {
-			Expect(IsSchedulePluginVersionLabel(input)).To(Equal(expected))
+			Expect(IsSchedulePodVersionLabel(input)).To(Equal(expected))
 		},
-		Entry("schedule plugin version label", "beta.kmm.node.kubernetes.io/version-schedule-plugin.ns.name", true),
+		Entry("schedule pod version label", "beta.kmm.node.kubernetes.io/version-schedule-pod.ns.name", true),
 		Entry("worker pod version label", "beta.kmm.node.kubernetes.io/version-worker-pod.ns.name", false),
 		Entry("module version label", "kmm.node.kubernetes.io/version-module.ns.name", false),
 		Entry("unrelated label", "some-other-label", false),
@@ -59,7 +59,7 @@ var _ = Describe("GetNamespaceNameFromVersionLabel", func() {
 			Expect(name).To(Equal(expectedName))
 		},
 		Entry("workerPod label", "beta.kmm.node.kubernetes.io/version-worker-pod.some-namespace.some-name", "some-namespace", "some-name", false),
-		Entry("schedule plugin label", "beta.kmm.node.kubernetes.io/version-schedule-plugin.some-namespace.some-name", "some-namespace", "some-name", false),
+		Entry("schedule pod label", "beta.kmm.node.kubernetes.io/version-schedule-pod.some-namespace.some-name", "some-namespace", "some-name", false),
 		Entry("module label", "kmm.node.kubernetes.io/version-module.some-namespace.some-name", "some-namespace", "some-name", false),
 		Entry("with error", "version-module-some-namespace-some-name", "some-namespace", "some-name", true),
 	)

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -38,8 +38,8 @@ import (
 )
 
 // maxCombinedLength is the maximum combined length of Module name and namespace when the version field is set.
-// 63 (max label key length after slash) - len("version-schedule-plugin.") = 38
-const maxCombinedLength = 38
+// 63 (max label key length after slash) - len("version-schedule-pod..") = 41
+const maxCombinedLength = 41
 
 type ModuleValidator struct {
 	logger      logr.Logger

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -69,7 +69,7 @@ var _ = Describe("maxCombinedLength", func() {
 			baseLength = l
 		}
 
-		if l := getLengthAfterSlash(utils.GetSchedulePluginVersionLabelName("", "")); l > baseLength {
+		if l := getLengthAfterSlash(utils.GetSchedulePodVersionLabelName("", "")); l > baseLength {
 			baseLength = l
 		}
 


### PR DESCRIPTION
This shortens the label prefix by 3 characters, increasing maxCombinedLength from 38 to 41 and allowing longer Module name+namespace combinations when versioning is enabled.

---

/cc @yevgeny-shnaidman @ybettan 
/assign @yevgeny-shnaidman @ybettan 