### PR TITLE
Remove modulesLoadingOrder from CI build-sign module spec

### DIFF
--- a/ci/module-kmm-ci-dra.yaml
+++ b/ci/module-kmm-ci-dra.yaml
@@ -8,7 +8,6 @@ spec:
     container:
       modprobe:
         moduleName: kmm_ci_a
-        modulesLoadingOrder: [kmm_ci_a, kmm_ci_b]
       kernelMappings:
         - regexp: '^.+$'
           containerImage: host.minikube.internal:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION


### PR DESCRIPTION
We currently try to load 2 kmods in dra ci even though we do not need to, this commit loads the main kmod only.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 