### PR TITLE
Clear stale status.moduleLoader when spec.moduleLoader is removed

### DIFF
--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -42,6 +42,20 @@ func (m *MockmoduleReconcilerHelperAPI) EXPECT() *MockmoduleReconcilerHelperAPIM
 	return m.recorder
 }
 
+// clearModuleLoaderStatus mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) clearModuleLoaderStatus(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "clearModuleLoaderStatus", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// clearModuleLoaderStatus indicates an expected call of clearModuleLoaderStatus.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) clearModuleLoaderStatus(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "clearModuleLoaderStatus", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).clearModuleLoaderStatus), ctx, mod)
+}
+
 // disableModuleOnNode mocks base method.
 func (m *MockmoduleReconcilerHelperAPI) disableModuleOnNode(ctx context.Context, modNamespace, modName, nodeName string) error {
 	m.ctrl.T.Helper()

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -118,7 +118,7 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 
 	if mod.Spec.ModuleLoader == nil {
 		logger.Info("ModuleLoader is not defined, skipping loading kernel module")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, mr.reconHelper.clearModuleLoaderStatus(ctx, mod)
 	}
 
 	// get nodes targeted by selector
@@ -194,6 +194,7 @@ type moduleReconcilerHelperAPI interface {
 	enableModuleOnNode(ctx context.Context, mld *api.ModuleLoaderData, node *v1.Node) error
 	disableModuleOnNode(ctx context.Context, modNamespace, modName, nodeName string) error
 	updateModuleStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error
+	clearModuleLoaderStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 }
 
 type moduleReconcilerHelper struct {
@@ -514,6 +515,19 @@ func (mrh *moduleReconcilerHelper) updateModuleLoaderStatus(ctx context.Context,
 	mod.Status.ModuleLoader.AvailableNumber = int32(numAvailable)
 
 	return nil
+}
+
+func (mrh *moduleReconcilerHelper) clearModuleLoaderStatus(ctx context.Context, mod *kmmv1beta1.Module) error {
+	emptyStatus := kmmv1beta1.DaemonSetStatus{}
+	if mod.Status.ModuleLoader == emptyStatus {
+		return nil
+	}
+
+	unmodifiedMod := mod.DeepCopy()
+
+	mod.Status.ModuleLoader = kmmv1beta1.DaemonSetStatus{}
+
+	return mrh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
 }
 
 func (mrh *moduleReconcilerHelper) updateImageRebuildTriggerGenerationStatus(ctx context.Context, mod *kmmv1beta1.Module) error {

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -221,12 +221,28 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().clearModuleLoaderStatus(ctx, mod).Return(nil),
 		)
 
 		res, err := mr.Reconcile(ctx, modWithoutModuleLoader)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when clearModuleLoaderStatus fails", func() {
+		modWithoutModuleLoader := mod
+		modWithoutModuleLoader.Spec.ModuleLoader = nil
+		gomock.InOrder(
+			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().clearModuleLoaderStatus(ctx, mod).Return(fmt.Errorf("some error")),
+		)
+
+		res, err := mr.Reconcile(ctx, modWithoutModuleLoader)
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
 	})
 })
 
@@ -1104,6 +1120,46 @@ var _ = Describe("updateModuleLoaderStatus", func() {
 		Expect(mod.Status.ModuleLoader.NodesMatchingSelectorNumber).To(Equal(int32(2)))
 		Expect(mod.Status.ModuleLoader.DesiredNumber).To(Equal(int32(1)))
 		Expect(mod.Status.ModuleLoader.AvailableNumber).To(Equal(int32(1)))
+	})
+})
+
+var _ = Describe("clearModuleLoaderStatus", func() {
+	var (
+		ctx  context.Context
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mrh  *moduleReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mrh = &moduleReconcilerHelper{client: clnt}
+	})
+
+	It("should do nothing when status is already empty", func() {
+		mod := kmmv1beta1.Module{}
+		err := mrh.clearModuleLoaderStatus(ctx, &mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should patch status when moduleLoader status is non-empty", func() {
+		mod := kmmv1beta1.Module{
+			Status: kmmv1beta1.ModuleStatus{
+				ModuleLoader: kmmv1beta1.DaemonSetStatus{
+					DesiredNumber:   3,
+					AvailableNumber: 2,
+				},
+			},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		clnt.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
+
+		err := mrh.clearModuleLoaderStatus(ctx, &mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ModuleLoader).To(Equal(kmmv1beta1.DaemonSetStatus{}))
 	})
 })
 


### PR DESCRIPTION
When spec.moduleLoader is removed, the ModuleReconciler returns early without clearing status.moduleLoader, leaving stale counts. Add clearModuleLoaderStatus to zero out the status, matching clearDRAStatus.

---

/cc @ybettan @yevgeny-shnaidman 