### PR TITLE
Adding imagePullPolicy support and HELM_EXTRA_ARGS to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,7 @@ operatorhub-release:
 HELM_RELEASE_KMM ?= kmm
 HELM_RELEASE_KMM_HUB ?= kmm-hub
 HELM_NAMESPACE ?= kmm-operator-system
+HELM_EXTRA_ARGS ?=
 
 .PHONY: helm-deploy
 helm-deploy: deploy-cert-manager manifests ## Deploy KMM controller using Helm to the K8s cluster specified in ~/.kube/config.
@@ -386,7 +387,8 @@ helm-deploy: deploy-cert-manager manifests ## Deploy KMM controller using Helm t
 		--set controller.image=$(IMG) \
 		--set controller.workerImage=$(WORKER_IMG) \
 		--set controller.signerImage=$(SIGNER_IMG) \
-		--set webhookServer.image=$(WEBHOOK_IMG)
+		--set webhookServer.image=$(WEBHOOK_IMG) \
+		$(HELM_EXTRA_ARGS)
 
 .PHONY: helm-deploy-hub
 helm-deploy-hub: deploy-cert-manager manifests ## Deploy KMM-Hub controller using Helm to the K8s cluster specified in ~/.kube/config.
@@ -394,7 +396,8 @@ helm-deploy-hub: deploy-cert-manager manifests ## Deploy KMM-Hub controller usin
 		--namespace $(HELM_NAMESPACE) --create-namespace \
 		--set controller.image=$(HUB_IMG) \
 		--set controller.signerImage=$(SIGNER_IMG) \
-		--set webhookServer.image=$(WEBHOOK_IMG)
+		--set webhookServer.image=$(WEBHOOK_IMG) \
+		$(HELM_EXTRA_ARGS)
 
 .PHONY: helm-undeploy-kmm
 helm-undeploy-kmm: ## Uninstall KMM Helm release from the K8s cluster.

--- a/deployment/helm/kmm-hub/templates/manager-deployment.yaml
+++ b/deployment/helm/kmm-hub/templates/manager-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         runAsNonRoot: true
       containers:
       - image: {{ .Values.controller.image }}
+        {{- if .Values.controller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+        {{- end }}
         name: manager
         args:
           - "--config={{ .Values.controller.managerConfig }}"

--- a/deployment/helm/kmm-hub/templates/webhook-server-deployment.yaml
+++ b/deployment/helm/kmm-hub/templates/webhook-server-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         runAsNonRoot: true
       containers:
         - image: {{ .Values.webhookServer.image }}
+          {{- if .Values.webhookServer.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.webhookServer.imagePullPolicy }}
+          {{- end }}
           name: webhook-server
           env:
             - name: OPERATOR_NAMESPACE

--- a/deployment/helm/kmm-hub/values.yaml
+++ b/deployment/helm/kmm-hub/values.yaml
@@ -2,6 +2,7 @@ namePrefix: "kmm-operator-hub-"
 
 controller:
   image: gcr.io/k8s-staging-kmm/kernel-module-management-operator-hub:latest
+  imagePullPolicy: ""
   replicas: 1
   resources:
     limits:
@@ -16,6 +17,7 @@ controller:
 
 webhookServer:
   image: gcr.io/k8s-staging-kmm/kernel-module-management-webhook-server:latest
+  imagePullPolicy: ""
   replicas: 1
   resources:
     limits:

--- a/deployment/helm/kmm/templates/manager-deployment.yaml
+++ b/deployment/helm/kmm/templates/manager-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         runAsNonRoot: true
       containers:
       - image: {{ .Values.controller.image }}
+        {{- if .Values.controller.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+        {{- end }}
         name: manager
         args:
           - "--config={{ .Values.controller.managerConfig }}"

--- a/deployment/helm/kmm/templates/webhook-server-deployment.yaml
+++ b/deployment/helm/kmm/templates/webhook-server-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         runAsNonRoot: true
       containers:
         - image: {{ .Values.webhookServer.image }}
+          {{- if .Values.webhookServer.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.webhookServer.imagePullPolicy }}
+          {{- end }}
           name: webhook-server
           env:
             - name: OPERATOR_NAMESPACE

--- a/deployment/helm/kmm/values.yaml
+++ b/deployment/helm/kmm/values.yaml
@@ -2,6 +2,7 @@ namePrefix: "kmm-operator-"
 
 controller:
   image: gcr.io/k8s-staging-kmm/kernel-module-management-operator:latest
+  imagePullPolicy: ""
   replicas: 1
   resources:
     limits:
@@ -17,6 +18,7 @@ controller:
 
 webhookServer:
   image: gcr.io/k8s-staging-kmm/kernel-module-management-webhook-server:latest
+  imagePullPolicy: ""
   replicas: 1
   resources:
     limits:


### PR DESCRIPTION
Add optional imagePullPolicy field to both kmm and kmm-hub Helm charts (controller and webhook-server deployments). When not set, the field is omitted and Kubernetes applies its default policy.

Add HELM_EXTRA_ARGS variable to helm-deploy and helm-deploy-hub Makefile targets, allowing callers to pass additional Helm flags (e.g. --set controller.imagePullPolicy=Never).