### PR TITLE
Adding Helm-based e2e tests for spoke and hub-spoke

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -141,6 +141,16 @@ jobs:
               KUSTOMIZE_CONFIG_DEFAULT: ci/install-ci-spoke
             import_hub_image: true
             script: ./ci/prow/e2e-hub-spoke-incluster-build
+          - name: e2e-helm
+            env:
+              HELM_VALUES_FILE: ci/helm-values-ci.yaml
+            script: ./ci/prow/e2e-helm-incluster-build
+          - name: e2e-helm-hub
+            env:
+              HELM_VALUES_FILE: ci/helm-values-ci-spoke.yaml
+              HELM_HUB_VALUES_FILE: ci/helm-values-ci-hub.yaml
+            import_hub_image: true
+            script: ./ci/prow/e2e-helm-hub-spoke-incluster-build
 
     runs-on: ubuntu-24.04
     name: ${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -379,24 +379,21 @@ HELM_RELEASE_KMM ?= kmm
 HELM_RELEASE_KMM_HUB ?= kmm-hub
 HELM_NAMESPACE ?= kmm-operator-system
 HELM_EXTRA_ARGS ?=
+HELM_VALUES_FILE ?=
+HELM_HUB_VALUES_FILE ?=
 
 .PHONY: helm-deploy
 helm-deploy: deploy-cert-manager manifests ## Deploy KMM controller using Helm to the K8s cluster specified in ~/.kube/config.
 	helm upgrade --install $(HELM_RELEASE_KMM) $(HELM_CHART_KMM) \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
-		--set controller.image=$(IMG) \
-		--set controller.workerImage=$(WORKER_IMG) \
-		--set controller.signerImage=$(SIGNER_IMG) \
-		--set webhookServer.image=$(WEBHOOK_IMG) \
+		$(if $(HELM_VALUES_FILE),-f $(HELM_VALUES_FILE)) \
 		$(HELM_EXTRA_ARGS)
 
 .PHONY: helm-deploy-hub
 helm-deploy-hub: deploy-cert-manager manifests ## Deploy KMM-Hub controller using Helm to the K8s cluster specified in ~/.kube/config.
 	helm upgrade --install $(HELM_RELEASE_KMM_HUB) $(HELM_CHART_KMM_HUB) \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
-		--set controller.image=$(HUB_IMG) \
-		--set controller.signerImage=$(SIGNER_IMG) \
-		--set webhookServer.image=$(WEBHOOK_IMG) \
+		$(if $(HELM_HUB_VALUES_FILE),-f $(HELM_HUB_VALUES_FILE)) \
 		$(HELM_EXTRA_ARGS)
 
 .PHONY: helm-undeploy-kmm

--- a/ci/helm-values-ci-hub.yaml
+++ b/ci/helm-values-ci-hub.yaml
@@ -1,0 +1,8 @@
+controller:
+  image: kmm-hub:local
+  imagePullPolicy: Never
+  signerImage: host.minikube.internal:5000/kmm/signimage:local
+
+webhookServer:
+  image: kmm-webhook-server:local
+  imagePullPolicy: Never

--- a/ci/helm-values-ci-spoke.yaml
+++ b/ci/helm-values-ci-spoke.yaml
@@ -1,0 +1,10 @@
+controller:
+  image: kmm:local
+  imagePullPolicy: Never
+  workerImage: kmm-worker:local
+  signerImage: host.minikube.internal:5000/kmm/signimage:local
+  managed: true
+
+webhookServer:
+  image: kmm-webhook-server:local
+  imagePullPolicy: Never

--- a/ci/helm-values-ci.yaml
+++ b/ci/helm-values-ci.yaml
@@ -1,0 +1,9 @@
+controller:
+  image: kmm:local
+  imagePullPolicy: Never
+  workerImage: kmm-worker:local
+  signerImage: host.minikube.internal:5000/kmm/signimage:local
+
+webhookServer:
+  image: kmm-webhook-server:local
+  imagePullPolicy: Never

--- a/ci/prow/e2e-helm-hub-spoke-incluster-build
+++ b/ci/prow/e2e-helm-hub-spoke-incluster-build
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+set -euxo pipefail
+
+# Install the `clusteradm` command
+curl -LO https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/v0.7.2/install.sh
+chmod +x install.sh
+./install.sh 0.7.2
+
+export MINIKUBE=minikube
+export OPERATOR_NAMESPACE=kmm-operator-system
+
+kubectl label node/${MINIKUBE} node-role.kubernetes.io/worker=""
+
+# Init OCM in the cluster
+clusteradm init --wait
+kubectl wait --for=condition=Available -n open-cluster-management deployment/cluster-manager
+kubectl wait --for=condition=Available --timeout=2m -n open-cluster-management-hub \
+    deployment/cluster-manager-placement-controller \
+    deployment/cluster-manager-registration-controller \
+    deployment/cluster-manager-registration-webhook \
+    deployment/cluster-manager-work-webhook
+
+# Join the "spoke" cluster to the "hub" cluster (in this case a single cluster is both hub and spoke)
+token=$(clusteradm get token | grep token= | cut -d"=" -f2-)
+hub_api_server=$(kubectl config view -o yaml | yq '.clusters[] | select(.. | .name?=="minikube")' | yq '.cluster.server')
+clusteradm join \
+  --hub-token ${token} \
+  --hub-apiserver ${hub_api_server} \
+  --cluster-name ${MINIKUBE}
+
+# Wait for the join command to succeed
+kubectl wait --for=condition=Established crd managedclusters.cluster.open-cluster-management.io
+timeout 60 sh -c "until kubectl get managedcluster ${MINIKUBE}; do sleep 2; done"
+timeout 30 sh -c "until kubectl get csr -l open-cluster-management.io/cluster-name=${MINIKUBE} | grep Pending; do sleep 2; done"
+timeout 1m bash -c "until kubectl get csr -l open-cluster-management.io/cluster-name=${MINIKUBE} -o json | jq -er \".items[].metadata.name\"; do sleep 2; done"
+kubectl wait --for=condition=Available deployment/klusterlet-registration-agent -n open-cluster-management-agent
+
+clusteradm accept --clusters ${MINIKUBE}
+
+# Installing required addons to the hub/spoke clusters
+clusteradm install hub-addon --names application-manager
+clusteradm addon enable --names application-manager --clusters ${MINIKUBE}
+
+clusteradm install hub-addon --names governance-policy-framework
+clusteradm addon enable --names governance-policy-framework --clusters ${MINIKUBE}
+
+clusteradm addon enable addon --names config-policy-controller --clusters ${MINIKUBE}
+
+# Install kmm and kmm-hub via Helm
+make helm-deploy HELM_VALUES_FILE=ci/helm-values-ci-spoke.yaml
+make helm-deploy-hub HELM_HUB_VALUES_FILE=ci/helm-values-ci-hub.yaml
+
+kubectl wait --for=condition=Available --timeout=2m -n ${OPERATOR_NAMESPACE} \
+  deployment/kmm-operator-hub-controller \
+  deployment/kmm-operator-hub-webhook \
+  deployment/kmm-operator-controller \
+  deployment/kmm-operator-webhook
+
+# Make the ManagedCluster selected by the ManagedClusterModule
+kubectl label managedcluster minikube name=minikube
+
+# Apply the ManagedClusterModule
+timeout 1m bash -c 'until kubectl apply -f ci/managedclustermodule-kmm-ci-build-sign.yaml; do sleep 3; done'
+
+# Waiting for the manifestwork to be created
+timeout 1m bash -c 'until kubectl -n ${MINIKUBE} get manifestwork/mod-example; do sleep 1; done'
+kubectl get manifestwork/mod-example -n ${MINIKUBE} -o yaml | yq '.spec.workload.manifests'
+
+# Validate that the Module has no `build`/`sign` sections
+timeout 1m bash -c 'until kubectl -n ${OPERATOR_NAMESPACE} get module/mod-example; do sleep 1; done'
+kubectl -n ${OPERATOR_NAMESPACE} get module/mod-example -o json | \
+    jq '.spec.moduleLoader.container.kernelMappings[] | (.build | type) == "null" and (.sign // null | type) == "null"' | grep true

--- a/ci/prow/e2e-helm-incluster-build
+++ b/ci/prow/e2e-helm-incluster-build
@@ -12,8 +12,8 @@ check_module_not_loaded () {
   fi
 }
 
-echo "Deploy KMM..."
-make deploy
+echo "Deploy KMM via Helm..."
+make helm-deploy
 
 check_module_not_loaded "kmm_ci_a"
 check_module_not_loaded "kmm_ci_b"

--- a/deployment/helm/kmm/templates/manager-deployment.yaml
+++ b/deployment/helm/kmm/templates/manager-deployment.yaml
@@ -54,6 +54,10 @@ spec:
             value: {{ .Values.controller.signerImage }}
           - name: RELATED_IMAGE_WORKER
             value: {{ .Values.controller.workerImage }}
+          {{- if .Values.controller.managed }}
+          - name: KMM_MANAGED
+            value: "1"
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/deployment/helm/kmm/values.yaml
+++ b/deployment/helm/kmm/values.yaml
@@ -14,6 +14,7 @@ controller:
   workerImage: gcr.io/k8s-staging-kmm/kernel-module-management-worker:latest
   signerImage: gcr.io/k8s-staging-kmm/kernel-module-management-signimage:latest
   buildImage: gcr.io/kaniko-project/executor:latest
+  managed: false
   managerConfig: kmm-operator-manager-config
 
 webhookServer:


### PR DESCRIPTION
Add two new e2e test scripts that mirror the existing kustomize-based e2e tests but deploy KMM using Helm charts instead:

- ci/prow/e2e-helm-incluster-build: deploys KMM via helm-deploy, then runs the full module build/sign/load/unload lifecycle test.
- ci/prow/e2e-helm-hub-spoke-incluster-build: deploys both KMM and KMM-Hub via helm-deploy/helm-deploy-hub with OCM, then validates ManagedClusterModule propagation.