### PR TITLE
docs: update max combined length from 39 to 41

### DIFF
--- a/docs/mkdocs/documentation/ordered_upgrade.md
+++ b/docs/mkdocs/documentation/ordered_upgrade.md
@@ -24,7 +24,7 @@ There are 3 types of workloads that can use a kernel module:
   The operator will manage the unloading/loading of the DRA driver on a node being upgraded, following the same
   lifecycle as the device plugin.
 
-Due to Kubernetes limitations in label names, the combined length of `Module` name and namespace may not exceed 39
+Due to Kubernetes limitations in label names, the combined length of `Module` name and namespace may not exceed 41
 characters.
 
 ## Upgrade steps


### PR DESCRIPTION
The maxCombinedLength constant was changed from 39 to 41 in the webhook code, but the ordered upgrade documentation was not updated to reflect the new limit.

---

/cc @yevgeny-shnaidman @ybettan 