### PR TITLE
Propagate Module tolerations to image pull pods

### DIFF
--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -286,6 +286,7 @@ func (mrhi *micReconcilerHelperImpl) processImagesSpecs(ctx context.Context, mic
 					oneTimePod,
 					micObj.Spec.ImageRepoSecret,
 					micObj.Spec.ImagePullPolicy,
+					micObj.Spec.Tolerations,
 					micObj)
 				errs = append(errs, err)
 			}

--- a/internal/controllers/mic_reconciler_test.go
+++ b/internal/controllers/mic_reconciler_test.go
@@ -548,7 +548,7 @@ var _ = Describe("processImagesSpecs", func() {
 				micHelper.EXPECT().GetImageState(&testMic, "image 1").Return(kmmv1beta1.ImageState("")),
 				mockImagePuller.EXPECT().GetPullPodForImage(pullPods, "image 1").Return(nil),
 				mockImagePuller.EXPECT().CreatePullPod(ctx, "some name", "some namespace", "image 1", expectedOneTimePodFlag,
-					nil, v1.PullPolicy(""), &testMic).Return(nil),
+					nil, v1.PullPolicy(""), testMic.Spec.Tolerations, &testMic).Return(nil),
 			)
 			err := mrh.processImagesSpecs(ctx, &testMic, pullPods)
 			Expect(err).To(BeNil())

--- a/internal/pod/imagepuller.go
+++ b/internal/pod/imagepuller.go
@@ -35,7 +35,8 @@ const (
 
 type ImagePuller interface {
 	CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
-		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error
+		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy,
+		tolerations []v1.Toleration, owner metav1.Object) error
 	DeletePod(ctx context.Context, pod *v1.Pod) error
 	ListPullPods(ctx context.Context, name, namespace string) ([]v1.Pod, error)
 	GetPullPodForImage(pods []v1.Pod, image string) *v1.Pod
@@ -56,7 +57,8 @@ func NewImagePuller(client client.Client, scheme *runtime.Scheme) ImagePuller {
 }
 
 func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
-	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error {
+	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy,
+	tolerations []v1.Toleration, owner metav1.Object) error {
 
 	pullPodTypeLabelValue := pullPodUntilSuccess
 	if oneTimePod {
@@ -88,6 +90,7 @@ func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, name, namespace, 
 			},
 			RestartPolicy:    v1.RestartPolicyNever,
 			ImagePullSecrets: imagePullSecrets,
+			Tolerations:      tolerations,
 		},
 	}
 

--- a/internal/pod/imagepuller_test.go
+++ b/internal/pod/imagepuller_test.go
@@ -163,6 +163,14 @@ var _ = Describe("CreatePullPod", func() {
 	testMic := kmmv1beta1.ModuleImagesConfig{}
 	testRepoSecret := v1.LocalObjectReference{}
 	imagePullPolicy := v1.PullAlways
+	testTolerations := []v1.Toleration{
+		{
+			Key:      "custom-taint",
+			Operator: v1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
 
 	It("check the pod fields", func() {
 		expectedPod := v1.Pod{
@@ -185,6 +193,7 @@ var _ = Describe("CreatePullPod", func() {
 				},
 				RestartPolicy:    v1.RestartPolicyNever,
 				ImagePullSecrets: []v1.LocalObjectReference{testRepoSecret},
+				Tolerations:      testTolerations,
 			},
 		}
 
@@ -200,7 +209,7 @@ var _ = Describe("CreatePullPod", func() {
 				}
 				return nil
 			})
-		err := ip.CreatePullPod(ctx, testName, testNamespace, testImage, false, &testRepoSecret, imagePullPolicy, &testMic)
+		err := ip.CreatePullPod(ctx, testName, testNamespace, testImage, false, &testRepoSecret, imagePullPolicy, testTolerations, &testMic)
 		Expect(err).To(BeNil())
 	})
 })

--- a/internal/pod/mock_imagepuller.go
+++ b/internal/pod/mock_imagepuller.go
@@ -41,17 +41,17 @@ func (m *MockImagePuller) EXPECT() *MockImagePullerMockRecorder {
 }
 
 // CreatePullPod mocks base method.
-func (m *MockImagePuller) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) error {
+func (m *MockImagePuller) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, tolerations []v1.Toleration, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePullPod", ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner)
+	ret := m.ctrl.Call(m, "CreatePullPod", ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, tolerations, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreatePullPod indicates an expected call of CreatePullPod.
-func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner any) *gomock.Call {
+func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, tolerations, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, tolerations, owner)
 }
 
 // DeletePod mocks base method.


### PR DESCRIPTION
Pull pods created by CreatePullPod did not inherit the tolerations from Module.spec.tolerations. On clusters where all worker nodes have custom taints, the pull pod could not be scheduled and blocked the entire module workflow.

---

/cc @yevgeny-shnaidman 