### PR TITLE
Updating the `release-2.7` kustomization installation command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment \
 
 Install KMM.
 ```shell
-kubectl apply -k https://github.com/kubernetes-sigs/kernel-module-management/config/default
+kubectl apply -k https://github.com/kubernetes-sigs/kernel-module-management/config/default?ref=release-2.7
 ```
 
 ## Documentation and lab


### PR DESCRIPTION
In the `release-2.7` branch, in the README.md, the installation instructions were referring to the `main` branch files.

It is now pointing to the files in the `release-2.7` branch instead.

---

/assign @TomerNewman 