### PR TITLE
Fix DRA driver Pod not evicted during node drain

### DIFF
--- a/ci/dra-consumer-pod.yaml
+++ b/ci/dra-consumer-pod.yaml
@@ -15,6 +15,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dra-consumer
+  labels:
+    app: dra-consumer
 spec:
   # Prefer the node WITHOUT the DRA device. This ensures that if the pod
   # still lands on minikube (the node with the device), it is because DRA

--- a/ci/prow/e2e-dra
+++ b/ci/prow/e2e-dra
@@ -53,6 +53,39 @@ timeout 2m bash -c 'until [ "$(kubectl get resourceslice --no-headers 2>/dev/nul
 echo "Check that Module status.dra is populated"
 [ "$(kubectl get module kmm-ci-dra -o jsonpath='{.status.dra.availableNumber}')" = "1" ]
 
+# The waits added here assign the kubectl output before testing it, so that a kubectl failure keeps
+# the loop running until it times out instead of being read as "the resource is already gone".
+DRA_SELECTOR='kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra'
+DRA_TARGET_LABEL='kmm.node.kubernetes.io/default.kmm-ci-dra.dra-target'
+
+# The consumer Pod name is reused below, and the claim generated for the first one can outlive it,
+# so the owner is matched by UID and more than one match is an error rather than a concatenation.
+claim_for() {
+  kubectl get resourceclaims -o json |
+    jq -r --arg uid "$(kubectl get pod dra-consumer -o jsonpath='{.metadata.uid}')" \
+      '[.items[] | select(any(.metadata.ownerReferences[]?; .kind == "Pod" and .uid == $uid)) | .metadata.name]
+       | if length == 1 then .[0] else error("expected exactly one claim for the consumer") end'
+}
+
+echo "Check that the DRA DaemonSet requires the target label"
+kubectl get ds -l "${DRA_SELECTOR}" -o jsonpath='{.items[0].spec.template.spec.nodeSelector}' | grep "${DRA_TARGET_LABEL}"
+
+# A DaemonSet created by a KMM that predates the target label selects on the kernel-module-ready
+# label alone, and cordoning its node would not evict its Pod. Removing the selector here is what
+# such a DaemonSet looks like, and the reconciler has to put it back.
+echo "Check that the target selector is restored if it goes missing from the DaemonSet"
+DRA_DS=$(kubectl get ds -l "${DRA_SELECTOR}" -o jsonpath='{.items[0].metadata.name}')
+kubectl patch ds "${DRA_DS}" --type=json \
+  -p "[{\"op\": \"remove\", \"path\": \"/spec/template/spec/nodeSelector/${DRA_TARGET_LABEL/\//~1}\"}]"
+timeout 2m bash -c 'until kubectl get ds '"${DRA_DS}"' -o jsonpath="{.spec.template.spec.nodeSelector}" | grep -q '"${DRA_TARGET_LABEL}"'; do sleep 3; done'
+
+# Restoring the selector rolls the DaemonSet, and that rollout is exactly what the reconciler holds
+# back once a claim is reserved, so the drift has to be repaired before a consumer takes one.
+# A Pod from before the patch stays Ready while the replacement starts, so numberReady can reach
+# one again before the rollout has begun.
+echo "Wait for the restored DaemonSet to settle"
+kubectl rollout status daemonset/"${DRA_DS}" --timeout=5m
+
 echo "Deploy a consumer pod requesting DRA hardware"
 kubectl apply -f ci/dra-consumer-pod.yaml
 
@@ -60,9 +93,151 @@ echo "Check that the consumer pod is running on the node with the DRA driver"
 kubectl wait --for=condition=Ready pod/dra-consumer --timeout=2m
 [ "$(kubectl get pod dra-consumer -o jsonpath='{.spec.nodeName}')" = "minikube" ]
 
-echo "Remove the consumer pod"
-kubectl delete -f ci/dra-consumer-pod.yaml
-timeout 1m bash -c 'until ! kubectl get pod dra-consumer 2>/dev/null; do sleep 3; done'
+# The claim comes from a ResourceClaimTemplate, so its name is generated. Everything below asserts
+# against the reservation rather than the consumer Pod, since the reservation is what the reconciler
+# reads.
+echo "Find the ResourceClaim generated for the consumer"
+CLAIM=$(claim_for)
+
+echo "Check that the claim is reserved for the consumer"
+timeout 2m bash -c 'until [ "$(kubectl get resourceclaim '"${CLAIM}"' -o jsonpath="{.status.reservedFor[*].name}")" = "dra-consumer" ]; do sleep 3; done'
+
+echo "Check that the DaemonSet is not rolled while the claim is reserved"
+DS_GENERATION=$(kubectl get ds "${DRA_DS}" -o jsonpath='{.metadata.generation}')
+for _ in $(seq 7); do
+  [ "$(kubectl get ds "${DRA_DS}" -o jsonpath='{.metadata.generation}')" = "${DS_GENERATION}" ]
+  sleep 3
+done
+kubectl get ds "${DRA_DS}" -o jsonpath='{.spec.template.spec.nodeSelector}' | grep "${DRA_TARGET_LABEL}"
+
+echo "Check that the DRA target label was set on the node"
+timeout 2m bash -c 'until [ "$(kubectl get nodes -l '"${DRA_TARGET_LABEL}"' -o name)" = "node/minikube" ]; do sleep 3; done'
+
+# The consumer stays up on purpose. kubectl drain marks the node unschedulable before it evicts
+# anything, and the DRA driver is what kubelet calls to unprepare the devices this consumer holds,
+# so the target label has to outlive the cordon.
+#
+# The example driver does not hold kmm_ci_a, and kmm_ci_a exports nothing a process could hold open,
+# so here the kernel module unloads while the node is cordoned and the driver Pod goes with it
+# through the kernel-module-ready label, whatever the target label says. Pinning it would mean
+# giving kmm_ci_a something to hold, and kmm-kmod-dockerfile.yaml builds that module by cloning the
+# default branch and is shared with two other e2e jobs, so it is a fixture change of its own. What
+# is checked below is therefore the target label's own lifecycle, which is what gates the Pod for a
+# driver that does hold its kernel module: the label survives a cordon while a claim is reserved,
+# and only goes once nothing holds one.
+echo "Cordon the node while the consumer still holds its ResourceClaim"
+trap 'kubectl uncordon minikube || true' EXIT
+kubectl cordon minikube
+
+# The DRA reconciler reacts to the unschedulable taint the node lifecycle controller adds for the
+# cordon, so wait for that instead of guessing how long the cordon takes to land.
+echo "Wait for the cordon to reach the node taints"
+timeout 2m bash -c 'until kubectl get node minikube -o jsonpath="{.spec.taints}" | grep -q "node.kubernetes.io/unschedulable"; do sleep 3; done'
+
+# The label has to hold for the whole window rather than be there once, so a removal that arrives a
+# little later still fails the test. The reservation is asserted alongside it: a claim released
+# early would leave the label check passing for the wrong reason.
+echo "Check that the DRA target label survives the cordon while the claim is reserved"
+for _ in $(seq 10); do
+  [ "$(kubectl get nodes -l "${DRA_TARGET_LABEL}" -o name)" = "node/minikube" ]
+  [ "$(kubectl get resourceclaim "${CLAIM}" -o jsonpath='{.status.reservedFor[*].name}')" = "dra-consumer" ]
+  sleep 3
+done
+
+# The driver Pod is already gone here for the reason above, so kubelet cannot run
+# NodeUnprepareResources for this consumer and a graceful eviction never finishes. The delete is
+# forced so the test can still observe what the reconciler does once the consumer is gone. On a
+# driver that does hold its kernel module the driver would still be running for this ordering, which
+# is the one this PR covers. NMCReconciler removing the ready label first is tracked in #1332.
+echo "Remove the consumer from the node"
+kubectl delete pod dra-consumer --force --grace-period=0
+kubectl wait --for=delete pod/dra-consumer --timeout=2m
+
+# --ignore-not-found so that the claim going away reads as released, while a kubectl failure keeps
+# the loop running until it times out instead of being read the same way.
+echo "Check that nothing holds the claim any more"
+timeout 2m bash -c 'until out=$(kubectl get resourceclaim '"${CLAIM}"' --ignore-not-found \
+  -o jsonpath="{.status.reservedFor[*].name}") && [ -z "${out}" ]; do sleep 3; done'
+
+echo "Check that the DRA target label is removed once nothing holds a claim"
+timeout 2m bash -c 'until out=$(kubectl get nodes -l '"${DRA_TARGET_LABEL}"' -o name) && [ -z "${out}" ]; do sleep 3; done'
+
+echo "Check that the DRA DaemonSet stops targeting the node"
+timeout 2m bash -c 'until n=$(kubectl get ds -l '"${DRA_SELECTOR}"' -o jsonpath="{.items[0].status.desiredNumberScheduled}") && [ "${n}" = "0" ]; do sleep 3; done'
+
+echo "Check that the DRA driver pod is actually gone"
+timeout 2m bash -c 'until out=$(kubectl get pods -l '"${DRA_SELECTOR}"' -o name) && [ -z "${out}" ]; do sleep 3; done'
+
+echo "Check that the kernel module is unloaded"
+timeout 5m bash -c 'until out=$(minikube ssh -- lsmod) && ! echo "${out}" | grep -q kmm_ci_a; do sleep 3; done'
+
+echo "Uncordon the node"
+kubectl uncordon minikube
+trap - EXIT
+
+echo "Check that the DRA target label is restored"
+timeout 2m bash -c 'until [ "$(kubectl get nodes -l '"${DRA_TARGET_LABEL}"' -o name)" = "node/minikube" ]; do sleep 3; done'
+
+echo "Check that the kernel module is reloaded and the DRA DaemonSet pod comes back"
+timeout 10m bash -c 'until out=$(minikube ssh -- lsmod) && echo "${out}" | grep -q kmm_ci_a; do sleep 3; done'
+timeout 5m bash -c 'until n=$(kubectl get ds -l '"${DRA_SELECTOR}"' -o jsonpath="{.items[0].status.numberReady}") && [ "${n}" = "1" ]; do sleep 3; done'
+
+# Everything above proved the label's lifecycle. This proves the other half of the guard: while a
+# claim is reserved, KMM must not roll the DaemonSet to add a selector it is missing, because that
+# takes the driver off the node for as long as the replacement takes to start. The controller is
+# stopped while the selector is removed, so the drift is already there when it comes back and there
+# is a real migration waiting to be held.
+# Removing the selector rolls the DaemonSet itself, so it is done and settled before any claim is
+# taken. The other order would replace the driver Pod under an active claim, which is the very
+# thing the window below is meant to prove does not happen.
+echo "Recreate the legacy DaemonSet state with the controller stopped"
+trap 'kubectl scale deployment/kmm-operator-controller -n kmm-operator-system --replicas=1 || true' EXIT
+kubectl scale deployment/kmm-operator-controller -n kmm-operator-system --replicas=0
+timeout 2m bash -c 'until [ "$(kubectl get deployment/kmm-operator-controller -n kmm-operator-system -o jsonpath="{.status.replicas}")" = "" ]; do sleep 2; done'
+kubectl patch ds "${DRA_DS}" --type=json \
+  -p "[{\"op\": \"remove\", \"path\": \"/spec/template/spec/nodeSelector/${DRA_TARGET_LABEL/\//~1}\"}]"
+
+echo "Wait for the legacy DaemonSet to settle before a claim is taken"
+kubectl rollout status daemonset/"${DRA_DS}" --timeout=5m
+DS_GENERATION=$(kubectl get ds "${DRA_DS}" -o jsonpath='{.metadata.generation}')
+DRIVER_POD=$(kubectl get pods -l "${DRA_SELECTOR}" --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}')
+DRIVER_UID=$(kubectl get pod "${DRIVER_POD}" -o jsonpath='{.metadata.uid}')
+
+echo "Deploy a second consumer to hold a claim across the pending migration"
+kubectl apply -f ci/dra-consumer-pod.yaml
+kubectl wait --for=condition=Ready pod/dra-consumer --timeout=2m
+CLAIM2=$(claim_for)
+timeout 2m bash -c 'until [ "$(kubectl get resourceclaim '"${CLAIM2}"' -o jsonpath="{.status.reservedFor[*].name}")" = "dra-consumer" ]; do sleep 3; done'
+
+echo "Start the controller back up with the migration already pending"
+kubectl scale deployment/kmm-operator-controller -n kmm-operator-system --replicas=1
+kubectl wait --for=condition=Available deployment/kmm-operator-controller -n kmm-operator-system --timeout=5m
+
+# Long enough to cover several of the reconciler's own retries. The selector is read into a variable
+# first, so that a kubectl failure stops the test rather than reading as "the label is not there".
+# A generation that never moved would still pass if the Pod had gone some other way, and what the
+# hold is for is the driver staying on the node, so the Pod is identified by UID and checked too.
+echo "Check that the migration is held and the driver stays up while the claim is reserved"
+for _ in $(seq 15); do
+  DS_SELECTOR=$(kubectl get ds "${DRA_DS}" -o jsonpath='{.spec.template.spec.nodeSelector}')
+  case "${DS_SELECTOR}" in
+    *"${DRA_TARGET_LABEL}"*) echo "the selector came back while a claim was still reserved"; exit 1 ;;
+  esac
+  [ "$(kubectl get ds "${DRA_DS}" -o jsonpath='{.metadata.generation}')" = "${DS_GENERATION}" ]
+  [ "$(kubectl get pod "${DRIVER_POD}" -o jsonpath='{.metadata.uid}')" = "${DRIVER_UID}" ]
+  [ "$(kubectl get pod "${DRIVER_POD}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')" = "True" ]
+  [ "$(kubectl get resourceclaim "${CLAIM2}" -o jsonpath='{.status.reservedFor[*].name}')" = "dra-consumer" ]
+  sleep 3
+done
+
+# Deleted normally rather than forced: the driver was up for the whole window above, so kubelet can
+# run NodeUnprepareResources and the eviction has to finish on its own.
+echo "Release the claim and check that the migration then goes through"
+kubectl delete pod dra-consumer --timeout=2m
+timeout 3m bash -c 'until kubectl get ds '"${DRA_DS}"' -o jsonpath="{.spec.template.spec.nodeSelector}" | grep -q '"${DRA_TARGET_LABEL}"'; do sleep 3; done'
+kubectl rollout status daemonset/"${DRA_DS}" --timeout=5m
+trap - EXIT
 
 echo "Remove the Module"
 kubectl delete -f ci/module-kmm-ci-dra.yaml --wait=false
@@ -72,6 +247,9 @@ timeout 2m bash -c 'until [ "$(kubectl get ds -l kmm.node.kubernetes.io/role=dra
 
 echo "Check that the DeviceClass gets cleaned up"
 timeout 1m bash -c 'until ! kubectl get deviceclass kmm-ci-test-device 2>/dev/null; do sleep 3; done'
+
+echo "Check that the DRA target label gets cleaned up"
+timeout 1m bash -c 'until out=$(kubectl get nodes -l '"${DRA_TARGET_LABEL}"' -o name) && [ -z "${out}" ]; do sleep 3; done'
 
 echo "Check that the module gets unloaded from the node"
 timeout 1m bash -c 'until ! minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; done'

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	if kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
-		if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+		if err = controllers.NewDRAReconciler(client, mgr.GetAPIReader(), filterAPI, nodeAPI, eventRecorder, scheme).SetupWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 		}
 	} else {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   - nodes
   verbs:
@@ -130,4 +137,11 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims
+  verbs:
+  - list
   - watch

--- a/deployment/helm/kmm/templates/rbac.yaml
+++ b/deployment/helm/kmm/templates/rbac.yaml
@@ -133,6 +133,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/mkdocs/developer/reconciliation_loops.md
+++ b/docs/mkdocs/developer/reconciliation_loops.md
@@ -33,8 +33,34 @@ A separate DRA reconciler watches `Module` resources that have `.spec.dra` set.
    DeviceClasses are tracked via labels (`kmm.node.kubernetes.io/module.name` and
    `kmm.node.kubernetes.io/module.namespace`) since they are cluster-scoped while Modules are namespaced.
 
-1. When `spec.dra` is removed or the `Module` is deleted, the reconciler deletes all associated DRA `DaemonSet` and
-   `DeviceClass` resources.
+1. The reconciler also watches nodes and keeps a
+   `kmm.node.kubernetes.io/<module-namespace>.<module-name>.dra-target` label on the schedulable nodes selected by the
+   `Module`. The DRA `DaemonSet` requires that label on top of the kernel-module-ready one, so cordoning a node removes
+   the DRA driver Pod before the kernel module is unloaded. The label is reconciled over both the nodes the `Module`
+   selects and the nodes already carrying it, so narrowing the selector, or removing a selector label from a node, takes
+   the label off too. Modules without a `.spec.moduleLoader` keep targeting `.spec.selector` directly, since they have
+   no kernel module to unload.
+
+1. The reconciler watches `ResourceClaim` resources as well, and keeps the `dra-target` label on any node where a Pod
+   still holds a claim allocated from this `Module`'s driver, even once the `Module` selector or a `NoSchedule` taint
+   would have taken it off. kubelet calls the driver to unprepare those devices, so the label keeps the driver Pod
+   matching the `DaemonSet` while a claim is reserved, and is dropped once the last claim on the node is released. A
+   reservation that cannot be placed on a node, because its Pod is gone and the allocation names no single node, keeps
+   every label the pass would otherwise drop.
+
+   The label only decides which nodes the `DaemonSet` selects, which also asks for the kernel-module-ready label.
+   `NMCReconciler` removes that one for any `Module` still in a cordoned node's `NodeModulesConfig` spec, without
+   consulting claims, so whether the driver outlives its consumers still depends on which controller reaches the cordon
+   first. The label also cannot add tolerations to the driver Pod, so an untolerated `NoExecute` taint still evicts it.
+
+   The migration that adds this selector to a `DaemonSet` created before it rolls that `DaemonSet`'s Pods, so it is held
+   back while any claim on the driver is reserved or cannot be placed on a node. A pod template is not per node, so
+   that hold covers every `DaemonSet` the `Module` owns. Correcting a selector that carries the label with the wrong
+   value is not held: such a `DaemonSet` already selects no node, so the correction is what brings its driver back.
+
+1. `spec.dra` cannot be removed once set, and `spec.dra.driverName` cannot be changed, so deleting the `Module` is the
+   only way out. That deletes all associated DRA `DaemonSet` and `DeviceClass` resources and removes the `dra-target`
+   label from every node carrying it, without checking whether a claim still needs the driver.
 
 1. During [ordered upgrades](../documentation/ordered_upgrade.md), a new DRA `DaemonSet` is created for the new module
    version. Once the old-version `DaemonSet` is no longer scheduled on any node, it is garbage-collected.

--- a/docs/mkdocs/documentation/deploy_kmod.md
+++ b/docs/mkdocs/documentation/deploy_kmod.md
@@ -74,7 +74,44 @@ for modern hardware orchestration.
 The DRA DaemonSet will target nodes:
 
 - that match the `Module`'s `.spec.selector`;
-- on which the kernel module is loaded (using the `kmm.node.kubernetes.io/<namespace>.<modulename>.ready` label).
+- on which the kernel module is loaded (using the `kmm.node.kubernetes.io/<namespace>.<modulename>.ready` label);
+- that KMM still wants the driver on (using the `kmm.node.kubernetes.io/<namespace>.<modulename>.dra-target` label).
+
+KMM manages the `dra-target` label itself. DaemonSet pods tolerate the taint `kubectl cordon` adds, so without it a
+cordon would leave the driver pod in place while KMM tries to unload the kernel module underneath it. KMM removes the
+label from a node that is cordoned, that carries any other taint the `Module` does not tolerate, or that has stopped
+matching `.spec.selector`, and the DaemonSet controller then removes the driver pod.
+
+A DaemonSet created by a KMM that predates this label has to be given the selector, which changes its pod template and
+restarts its driver pods. KMM holds that back while any claim on the driver is reserved anywhere in the cluster, since
+a pod template is not per node: one long-lived claim can therefore keep an older DaemonSet on the previous selector
+while an unrelated node is drained. A selector that has the label with the wrong value is corrected straight away,
+because that DaemonSet already matches no node.
+
+A cordoned node keeps the label for as long as a pod on it still holds a `ResourceClaim` allocated from this `Module`'s
+driver, so that kubelet can still call the driver to unprepare those devices. The label goes once the last such claim is
+released.
+
+What the label controls is which nodes the DaemonSet selects, and that is all it controls. The DaemonSet asks for the
+`ready` label as well, and KMM removes that one as soon as it sees a cordoned node whose `Module` is still in the node's
+`NodeModulesConfig`, without looking at claims. Whether that happens before the driver is done depends on which
+controller reaches the cordon first, so the retention here narrows the window rather than closing it, whether or not the
+driver holds a reference to the kernel module.
+
+The label also does not add tolerations to the driver pod, so a `NoExecute` taint the `Module` does not tolerate still
+evicts the driver, and a `NoExecute` toleration with a `tolerationSeconds` still expires. Deleting the `Module` removes
+the label from every node without looking for claims.
+
+`.spec.dra` cannot be removed from a `Module` after it is set, and `.spec.dra.driverName` cannot be changed: both take
+the driver away from claims that may still be reserved. Adding `.spec.dra` to a `Module` that did not have one is
+allowed.
+
+`.spec.dra.driverName` must name one `Module` in the cluster. It is what KMM matches claims against to decide which
+nodes still need a driver, so two `Module`s sharing a name each keep the other's labels and hold up the other's
+`DaemonSet` updates. KMM does not reject that today.
+
+A `Module` with no `.spec.moduleLoader` has no kernel module to unload, so its DRA DaemonSet targets `.spec.selector`
+directly and no `dra-target` label is used.
 
 When the DRA driver pod is running and ready on a node, KMM sets the following label:
 ```

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -20,10 +20,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"time"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,6 +38,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -57,22 +66,52 @@ const (
 
 type DRAReconciler struct {
 	client         client.Client
+	filter         *filter.Filter
 	reconHelperAPI draReconcilerHelperAPI
 }
 
 func NewDRAReconciler(
 	client client.Client,
+	apiReader client.Reader,
+	filter *filter.Filter,
 	nodeAPI node.Node,
+	recorder record.EventRecorder,
 	scheme *runtime.Scheme,
 ) *DRAReconciler {
-	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, scheme)
+	reconHelperAPI := newDRAReconcilerHelper(client, apiReader, nodeAPI, recorder, scheme)
 	return &DRAReconciler{
 		client:         client,
+		filter:         filter,
 		reconHelperAPI: reconHelperAPI,
 	}
 }
 
+// draClaimDriverIndex keeps a pass looking for one driver from walking every claim in the cluster.
+const draClaimDriverIndex = "status.allocation.devices.results.driver"
+
+// resourceClaimDrivers names every driver an allocated ResourceClaim uses, and nothing for one the
+// scheduler has not allocated yet: an unallocated claim holds no driver on any node.
+func resourceClaimDrivers(rawObj client.Object) []string {
+	claim := rawObj.(*resourcev1.ResourceClaim)
+	if claim.Status.Allocation == nil {
+		return nil
+	}
+
+	drivers := make([]string, 0, len(claim.Status.Allocation.Devices.Results))
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		drivers = append(drivers, result.Driver)
+	}
+
+	return drivers
+}
+
 func (r *DRAReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &resourcev1.ResourceClaim{}, draClaimDriverIndex, resourceClaimDrivers,
+	); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
@@ -80,6 +119,16 @@ func (r *DRAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&resourcev1.DeviceClass{},
 			handler.EnqueueRequestsFromMapFunc(filter.DeviceClassToModuleReconcileRequest),
 			builder.WithPredicates(filter.HasLabel(constants.ModuleNameLabel)),
+		).
+		Watches(
+			&v1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.filter.FindDRAModulesForNode),
+			builder.WithPredicates(filter.DRAReconcilerNodePredicate()),
+		).
+		Watches(
+			&resourcev1.ResourceClaim{},
+			handler.EnqueueRequestsFromMapFunc(r.filter.FindDRAModulesForResourceClaim),
+			builder.WithPredicates(filter.ResourceClaimUsageChanged()),
 		).
 		Named(DRAReconcilerName).
 		Complete(
@@ -102,25 +151,72 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 		return res, fmt.Errorf("could not get DeviceClasses for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
 	}
 
+	// Everything past here writes, and a pass working from a spec the Module has moved on from can
+	// undo the current one.
+	current, err := r.reconHelperAPI.confirmCurrentModule(ctx, mod)
+	if err != nil {
+		return res, err
+	}
+
+	if !current {
+		logger.Info("Module changed before this pass wrote anything, leaving the rest to the next one")
+
+		return ctrl.Result{RequeueAfter: draTargetRequeue}, nil
+	}
+
+	// Labels go after the resources selecting on them, so a failed patch strands no DaemonSet.
 	if mod.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace)
+		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err = r.reconHelperAPI.removeDRATargetLabels(ctx, mod); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not remove dra-target labels on deletion: %v", err)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	if mod.Spec.DRA == nil {
 		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
 			return ctrl.Result{}, err
 		}
+		if err = r.reconHelperAPI.removeDRATargetLabels(ctx, mod); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not remove dra-target labels: %v", err)
+		}
 		return ctrl.Result{}, r.reconHelperAPI.clearDRAStatus(ctx, mod)
 	}
 
-	err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS)
-	if err != nil {
-		return res, fmt.Errorf("could not handle DRA: %v", err)
+	// The label has to exist before the DaemonSet requires it, and there is only something to
+	// sequence against while a kernel module is loaded, so without a loader it is dropped instead.
+	targetResult := draTargetResult{}
+	if mod.Spec.ModuleLoader != nil {
+		if targetResult, err = r.reconHelperAPI.handleDRATargetLabels(ctx, mod, existingDRADS); err != nil {
+			return res, fmt.Errorf("could not reconcile dra-target labels: %v", err)
+		}
+	}
+	// The rest of this pass would write from a spec that is no longer the Module's, and deleting a
+	// DaemonSet the current spec wants back is not something a later pass can undo.
+	if targetResult.stale {
+		logger.Info("Module changed while its target labels were being reconciled, leaving the rest to the next one")
+
+		return ctrl.Result{RequeueAfter: draTargetRequeue}, nil
 	}
 
-	err = r.reconHelperAPI.garbageCollectDRADaemonSets(ctx, mod, existingDRADS)
-	if err != nil {
-		return res, fmt.Errorf("failed to run DRA garbage collection: %v", err)
+	// setDRAAsDesired applies the same selector, and garbage collection reads a replica count the
+	// held migration has not settled yet, so both wait with it.
+	if !targetResult.deferDaemonSets {
+		if err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS); err != nil {
+			return res, fmt.Errorf("could not handle DRA: %v", err)
+		}
+
+		if err = r.reconHelperAPI.garbageCollectDRADaemonSets(ctx, mod, existingDRADS); err != nil {
+			return res, fmt.Errorf("failed to run DRA garbage collection: %v", err)
+		}
+	}
+
+	if mod.Spec.ModuleLoader == nil {
+		if err = r.reconHelperAPI.removeDRATargetLabels(ctx, mod); err != nil {
+			return res, fmt.Errorf("could not remove stale dra-target labels: %v", err)
+		}
 	}
 
 	err = r.reconHelperAPI.handleDeviceClasses(ctx, mod, existingDCs)
@@ -128,12 +224,15 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 		return res, fmt.Errorf("could not handle DeviceClasses: %v", err)
 	}
 
-	err = r.reconHelperAPI.moduleUpdateDRAStatus(ctx, mod, existingDRADS)
+	err = r.reconHelperAPI.moduleUpdateDRAStatus(ctx, mod, existingDRADS, targetResult.targeted)
 	if err != nil {
 		return res, fmt.Errorf("failed to update DRA status of the module: %v", err)
 	}
 
 	logger.Info("DRA reconcile loop finished successfully")
+
+	// Only here: controller-runtime ignores a result handed to it next to an error.
+	res.RequeueAfter = targetResult.requeueAfter
 
 	return res, nil
 }
@@ -143,33 +242,58 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 type draReconcilerHelperAPI interface {
 	getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
+	confirmCurrentModule(ctx context.Context, mod *kmmv1beta1.Module) (bool, error)
+	handleDRATargetLabels(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) (draTargetResult, error)
+	removeDRATargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 	garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
 	deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error
-	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
+	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet, targetedNodes int) error
 	clearDRAStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error)
 	handleDeviceClasses(ctx context.Context, mod *kmmv1beta1.Module, existingDCs []resourcev1.DeviceClass) error
 }
 
 type draReconcilerHelper struct {
-	client          client.Client
+	client client.Client
+	// apiReader bypasses the cache: dropping a label deletes the driver Pod, and nothing calls the
+	// termination back, while adding one from a stale read is harmless.
+	apiReader       client.Reader
 	daemonSetHelper draDaemonSetCreator
 	nodeAPI         node.Node
+	recorder        record.EventRecorder
+}
+
+// event is a no-op when the helper was built without a recorder, which is how the unit tests build
+// it. A drain that does not converge is otherwise only visible in the controller's own logs.
+func (drh *draReconcilerHelper) event(mod *kmmv1beta1.Module, reason, format string, args ...any) {
+	if drh.recorder == nil {
+		return
+	}
+
+	drh.recorder.Eventf(mod, v1.EventTypeWarning, reason, format, args...)
 }
 
 func newDRAReconcilerHelper(client client.Client,
+	apiReader client.Reader,
 	nodeAPI node.Node,
+	recorder record.EventRecorder,
 	scheme *runtime.Scheme,
 ) draReconcilerHelperAPI {
 	daemonSetHelper := newDRADaemonSetCreator(scheme)
 	return &draReconcilerHelper{
 		client:          client,
+		apiReader:       apiReader,
 		daemonSetHelper: daemonSetHelper,
 		nodeAPI:         nodeAPI,
+		recorder:        recorder,
 	}
 }
 
 func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
+	return listModuleDRADaemonSets(ctx, drh.client, name, namespace)
+}
+
+func listModuleDRADaemonSets(ctx context.Context, reader client.Reader, name, namespace string) ([]appsv1.DaemonSet, error) {
 	dsList := appsv1.DaemonSetList{}
 	opts := []client.ListOption{
 		client.MatchingLabels(map[string]string{
@@ -178,7 +302,7 @@ func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name
 		}),
 		client.InNamespace(namespace),
 	}
-	if err := drh.client.List(ctx, &dsList, opts...); err != nil {
+	if err := reader.List(ctx, &dsList, opts...); err != nil {
 		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
 	}
 
@@ -193,15 +317,51 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 	logger := log.FromContext(ctx)
 
 	ds, version := getExistingDRADSFromVersion(existingDRADS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader)
+
+	// The list this pass started from is cached, and writing a node label queues the Module again,
+	// so a pass can run before the DaemonSet the last one created is visible. Creating one then
+	// succeeds, because a generated name never conflicts, and leaves two for the same version.
 	if ds == nil {
+		fresh, err := listModuleDRADaemonSets(ctx, drh.apiReader, mod.Name, mod.Namespace)
+		if err != nil {
+			return err
+		}
+
+		ds, version = getExistingDRADSFromVersion(fresh, mod.Namespace, mod.Name, mod.Spec.ModuleLoader)
+	}
+
+	creating := ds == nil
+	if creating {
 		logger.Info("creating new DRA DaemonSet", "version", version)
 		ds = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-dra-"},
 		}
 	}
 
+	targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
 	opRes, err := controllerutil.CreateOrPatch(ctx, drh.client, ds, func() error {
-		return drh.daemonSetHelper.setDRAAsDesired(ctx, ds, mod)
+		// Requiring this label narrows what an existing DaemonSet selects, which is the migration
+		// the claims hold back, so only the gated pass may start it. Carry over what the live
+		// object has instead of asserting it, and a stale classification cannot migrate behind it.
+		held, wasSet := ds.Spec.Template.Spec.NodeSelector[targetLabel]
+
+		if err := drh.daemonSetHelper.setDRAAsDesired(ctx, ds, mod); err != nil {
+			return err
+		}
+
+		// Without a loader the node selector is the Module's own map, which must not be edited.
+		if creating || mod.Spec.ModuleLoader == nil {
+			return nil
+		}
+
+		if wasSet {
+			ds.Spec.Template.Spec.NodeSelector[targetLabel] = held
+		} else {
+			delete(ds.Spec.Template.Spec.NodeSelector, targetLabel)
+		}
+
+		return nil
 	})
 
 	if err == nil {
@@ -209,6 +369,623 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 	}
 
 	return err
+}
+
+// handleDRATargetLabels brings the nodes carrying the dra-target label in line, then the DaemonSets
+// selecting on it, in that order, since a DaemonSet must never require a label before its nodes
+// have it. It returns how many driver Pods the reconciled label leaves the Module wanting.
+func (drh *draReconcilerHelper) handleDRATargetLabels(
+	ctx context.Context,
+	mod *kmmv1beta1.Module,
+	existingDRADS []appsv1.DaemonSet,
+) (draTargetResult, error) {
+	if mod.Spec.DRA == nil {
+		return draTargetResult{}, nil
+	}
+
+	// The index lives in the cache, and the API server has no field selector for this, so only the
+	// cached read narrows the list; the uncached recheck below still walks it.
+	usage, err := drh.nodesUsingDRADriver(ctx, drh.client, mod,
+		client.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName})
+	if err != nil {
+		return draTargetResult{}, fmt.Errorf("could not determine which nodes still use the DRA driver: %v", err)
+	}
+
+	targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
+	result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, usage, drh.newDriverRecheck(ctx, mod))
+
+	drift := targetSelectorDriftIn(existingDRADS, targetLabel)
+	if err != nil || result.stale || (!drift.missing && !drift.wrong) {
+		return result, err
+	}
+
+	if !drift.missing {
+		retry, err := drh.ensureDRATargetNodeSelector(ctx, existingDRADS, targetLabel, true)
+		if retry {
+			// The DaemonSets are not the ones this pass classified, and the work below acts on
+			// that classification.
+			result.deferDaemonSets = true
+			result.requeueAfter = draTargetRequeue
+		}
+
+		return result, err
+	}
+
+	// Adding the selector to a DaemonSet that predates it rolls its Pods, and a retrying unloader
+	// can take the kernel module in that gap. Read again rather than reusing what the label pass
+	// saw: a reservation can appear between dropping a label and rolling a DaemonSet.
+	fresh, err := drh.recheckDriverUsage(ctx, mod)
+	if err != nil {
+		return result, fmt.Errorf("could not confirm the DRA driver is unused before migrating: %v", err)
+	}
+
+	// Nothing else, not even the recovery: this pass no longer knows what the Module wants.
+	if fresh.stale {
+		result.stale = true
+		result.requeueAfter = draTargetRequeue
+
+		return result, nil
+	}
+
+	if fresh.unresolved || fresh.nodes.Len() > 0 {
+		result.deferDaemonSets = true
+		result.requeueAfter = draTargetRequeue
+
+		log.FromContext(ctx).Info("Holding the DRA DaemonSet migration",
+			"label", targetLabel, "nodes", fresh.nodes.Len(), "unresolved", fresh.unresolved)
+		drh.event(mod, "DRAMigrationDeferred",
+			"Holding the DRA DaemonSet selector migration: %d node(s) still hold a claim for %s, unresolved reservations: %t",
+			fresh.nodes.Len(), mod.Spec.DRA.DriverName, fresh.unresolved)
+
+		// A wrong value is still worth correcting: it is what took the driver away.
+		_, err = drh.ensureDRATargetNodeSelector(ctx, existingDRADS, targetLabel, true)
+
+		return result, err
+	}
+
+	retry, err := drh.ensureDRATargetNodeSelector(ctx, existingDRADS, targetLabel, false)
+	if retry {
+		result.deferDaemonSets = true
+		result.requeueAfter = draTargetRequeue
+	}
+
+	return result, err
+}
+
+// jsonPointerEscape encodes a map key for a JSON Patch path. Label keys carry a slash.
+func jsonPointerEscape(key string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(key, "~", "~0"), "/", "~1")
+}
+
+// targetSelectorDrift separates the two ways a DaemonSet can fail to select on targetLabel, because
+// they are not equally safe to correct. Adding the key narrows what the DaemonSet selects and rolls
+// its Pods; a wrong value already selects no node, so correcting it is what brings the driver back.
+type targetSelectorDrift struct {
+	missing bool
+	wrong   bool
+}
+
+func targetSelectorDriftIn(existingDRADS []appsv1.DaemonSet, targetLabel string) targetSelectorDrift {
+	drift := targetSelectorDrift{}
+
+	for i := range existingDRADS {
+		ds := &existingDRADS[i]
+
+		if ds.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		switch value, ok := ds.Spec.Template.Spec.NodeSelector[targetLabel]; {
+		case !ok:
+			drift.missing = true
+		case value != "":
+			drift.wrong = true
+		}
+	}
+
+	return drift
+}
+
+// reconcileDRATargetLabel makes targetLabel reflect the desired state over the nodes the Module
+// selects and those already carrying it. A node keeps it while the Module selects it and can
+// schedule on it; usage overrides both, since a Pod there still holds one of the driver's devices.
+func (drh *draReconcilerHelper) reconcileDRATargetLabel(
+	ctx context.Context,
+	mod *kmmv1beta1.Module,
+	targetLabel string,
+	usage driverUsage,
+	recheck driverRecheck,
+) (draTargetResult, error) {
+	result := draTargetResult{}
+
+	selectedNodes, err := drh.nodeAPI.GetAllNodesBySelector(ctx, mod.Spec.Selector)
+	if err != nil {
+		return result, fmt.Errorf("could not list nodes targeted by module: %v", err)
+	}
+
+	// By key, not value: a node whose label value was corrupted still needs correcting.
+	labeledNodes, err := drh.nodeAPI.GetAllNodesByLabelKey(ctx, targetLabel)
+	if err != nil {
+		return result, fmt.Errorf("could not list nodes with %s label: %v", targetLabel, err)
+	}
+
+	selectedNames := sets.New[string]()
+	nodesByName := make(map[string]*v1.Node, len(selectedNodes)+len(labeledNodes))
+
+	for i := range selectedNodes {
+		n := &selectedNodes[i]
+		selectedNames.Insert(n.Name)
+		nodesByName[n.Name] = n
+	}
+
+	for i := range labeledNodes {
+		n := &labeledNodes[i]
+		if _, ok := nodesByName[n.Name]; !ok {
+			nodesByName[n.Name] = n
+		}
+	}
+
+	// A node that no longer matches the selector and has already lost the label appears in neither
+	// list, so fetch the ones still in use by name to put their label back.
+	for _, name := range sets.List(usage.nodes) {
+		if _, ok := nodesByName[name]; ok {
+			continue
+		}
+
+		// Uncached, and asking again later: this is the only path that can put the label back on a
+		// node the selector has dropped, and a node event for it maps to no Module.
+		n := &v1.Node{}
+		if err := drh.apiReader.Get(ctx, types.NamespacedName{Name: name}, n); apierrors.IsNotFound(err) {
+			result.requeueAfter = draTargetRequeue
+			continue
+		} else if err != nil {
+			return result, fmt.Errorf("could not get node %s still using the DRA driver: %v", name, err)
+		}
+
+		nodesByName[name] = n
+	}
+
+	tolerations := module.EffectiveTolerations(mod.Spec.Tolerations)
+
+	// Sorted so that the errors returned for a given cluster state are always the same.
+	names := slices.Sorted(maps.Keys(nodesByName))
+
+	var (
+		errs        []error
+		errReported bool
+	)
+
+	// Dropping a label deletes the driver Pod, so it is judged against an uncached read rather than
+	// the informer, which can lag the reservation being decided against. Every removal in this pass
+	// shares the one read; the migration takes its own.
+	mustKeep := func(name string) bool {
+		fresh, err := recheck()
+		if err != nil {
+			if !errReported {
+				errReported = true
+				errs = append(errs, fmt.Errorf("could not confirm the DRA driver is unused: %v", err))
+			}
+
+			return true
+		}
+
+		result.stale = result.stale || fresh.stale
+
+		return fresh.stale || fresh.unresolved || fresh.nodes.Has(name)
+	}
+
+	if usage.unresolved {
+		result.requeueAfter = draTargetRequeue
+	}
+
+	// The whole batch is decided before any of it is written. A pass that finds the Module has
+	// moved on halfway through then leaves every node as it was.
+	type nodeLabelChange struct {
+		node *v1.Node
+		add  bool
+	}
+
+	var plan []nodeLabelChange
+
+	for _, name := range names {
+		n := nodesByName[name]
+
+		value, hasLabel := n.Labels[targetLabel]
+
+		// Cordoning, an unrelated NoSchedule taint and a narrowed selector all leave running Pods
+		// in place, so a node still in use overrides both conditions.
+		byClaim := usage.nodes.Has(name)
+		bySelector := selectedNames.Has(name) && drh.nodeAPI.IsNodeSchedulable(n, tolerations)
+		wantLabel := byClaim || bySelector
+
+		if !wantLabel && hasLabel && mustKeep(name) {
+			wantLabel = true
+			byClaim = true
+		}
+
+		// Nothing here watches what releases a claim on a node the selector would otherwise have
+		// given up, so that node has to be looked at again unprompted.
+		if byClaim && !bySelector {
+			result.requeueAfter = draTargetRequeue
+		}
+
+		if wantLabel {
+			result.targeted++
+		}
+
+		// The DaemonSet selects on targetLabel="", so any other value still has to be patched.
+		if (wantLabel && hasLabel && value == "") || (!wantLabel && !hasLabel) {
+			continue
+		}
+
+		plan = append(plan, nodeLabelChange{node: n, add: wantLabel})
+	}
+
+	// The recheck proved the Module moved on while this pass was deciding, and a label outlives the
+	// generation that asked for it: the DRA resources have no finalizer to clean up after one.
+	if result.stale {
+		result.requeueAfter = draTargetRequeue
+
+		return result, errors.Join(errs...)
+	}
+
+	for _, change := range plan {
+		name := change.node.Name
+
+		if change.add {
+			// A node deleted between the list and the patch needs no label, and leaves the count.
+			err := drh.nodeAPI.UpdateLabels(ctx, change.node, map[string]string{targetLabel: ""}, nil)
+			switch {
+			case apierrors.IsNotFound(err):
+				result.targeted--
+			case err != nil:
+				errs = append(errs, fmt.Errorf("could not add %s label to node %s: %v", targetLabel, name, err))
+			}
+
+			continue
+		}
+
+		// The node changed after the read this decision came from, and the change that caused it
+		// may be one this controller never sees.
+		err := drh.nodeAPI.UpdateLabelsWithOptimisticLock(ctx, change.node, nil, map[string]string{targetLabel: ""})
+		switch {
+		case apierrors.IsNotFound(err):
+		case apierrors.IsConflict(err):
+			result.requeueAfter = draTargetRequeue
+			result.targeted++
+		case err != nil:
+			errs = append(errs, fmt.Errorf("could not remove %s label from node %s: %v", targetLabel, name, err))
+		}
+	}
+
+	return result, errors.Join(errs...)
+}
+
+// ensureDRATargetNodeSelector adds targetLabel to the node selector of every DaemonSet passed in,
+// and nothing else. Only the current version goes through setDRAAsDesired, so the ones an ordered
+// upgrade left behind would otherwise survive a cordon on the kernel-module-ready label alone.
+func (drh *draReconcilerHelper) ensureDRATargetNodeSelector(
+	ctx context.Context,
+	existingDRADS []appsv1.DaemonSet,
+	targetLabel string,
+	recoverOnly bool,
+) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	var (
+		errs  []error
+		retry bool
+	)
+	for i := range existingDRADS {
+		ds := &existingDRADS[i]
+
+		// Patching a DaemonSet on its way out would only race with its deletion.
+		if ds.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		// Nodes carry it with an empty value, so any other value selects nothing and invites the GC.
+		value, ok := ds.Spec.Template.Spec.NodeSelector[targetLabel]
+		if ok && value == "" {
+			continue
+		}
+
+		if recoverOnly && !ok {
+			continue
+		}
+
+		var patch client.Patch
+
+		if ok {
+			// Guarded on the value this pass classified. A bare replace would not do: the API
+			// server accepts one for a key that has since gone, which would turn the correction
+			// into the migration the claims are holding back.
+			pointer := jsonPointerEscape(targetLabel)
+			patch = client.RawPatch(types.JSONPatchType, []byte(fmt.Sprintf(
+				`[{"op":"test","path":"/spec/template/spec/nodeSelector/%s","value":%q},`+
+					`{"op":"replace","path":"/spec/template/spec/nodeSelector/%s","value":""}]`,
+				pointer, value, pointer,
+			)))
+		} else {
+			patchFrom := client.MergeFrom(ds.DeepCopy())
+
+			if ds.Spec.Template.Spec.NodeSelector == nil {
+				ds.Spec.Template.Spec.NodeSelector = make(map[string]string, 1)
+			}
+			ds.Spec.Template.Spec.NodeSelector[targetLabel] = ""
+
+			patch = patchFrom
+		}
+
+		err := drh.client.Patch(ctx, ds, patch)
+		switch {
+		case apierrors.IsNotFound(err):
+			continue
+		// A rejected test operation is reported as 422, but so is ordinary validation, and the
+		// merge patch above carries no test at all. Only a value that really moved is the guard.
+		case ok && apierrors.IsInvalid(err):
+			moved, checkErr := drh.targetSelectorMoved(ctx, ds, targetLabel, value)
+			if checkErr != nil {
+				errs = append(errs, checkErr)
+				continue
+			}
+
+			if !moved {
+				errs = append(errs, fmt.Errorf("could not correct %s on DaemonSet %s: %v", targetLabel, ds.Name, err))
+				continue
+			}
+
+			logger.Info("Target node selector changed under the correction", "name", ds.Name)
+
+			retry = true
+
+			continue
+		case err != nil:
+			errs = append(errs, fmt.Errorf("could not add %s to DaemonSet %s: %v", targetLabel, ds.Name, err))
+			continue
+		}
+
+		logger.Info("Added the target node selector to an existing DaemonSet", "name", ds.Name, "label", targetLabel)
+	}
+
+	return retry, errors.Join(errs...)
+}
+
+// targetSelectorMoved reports whether the DaemonSet still holds the value the guarded patch tested
+// against. Only a value that has moved makes a rejection worth retrying.
+func (drh *draReconcilerHelper) targetSelectorMoved(
+	ctx context.Context,
+	ds *appsv1.DaemonSet,
+	targetLabel string,
+	tested string,
+) (bool, error) {
+	current := appsv1.DaemonSet{}
+	if err := drh.apiReader.Get(ctx, client.ObjectKeyFromObject(ds), &current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("could not re-read DaemonSet %s: %v", ds.Name, err)
+	}
+
+	value, ok := current.Spec.Template.Spec.NodeSelector[targetLabel]
+
+	return !ok || value != tested, nil
+}
+
+// draTargetResult is what the label pass leaves for its caller: how many nodes end up wanting the
+// driver, whether the DaemonSets have to wait for the claims, and when to look again unprompted.
+type draTargetResult struct {
+	targeted        int
+	deferDaemonSets bool
+	stale           bool
+	requeueAfter    time.Duration
+}
+
+// draTargetRequeue paces the passes nothing wakes: a consumer Pod being scheduled raises no event.
+const draTargetRequeue = 15 * time.Second
+
+// driverUsage names the nodes that still need this Module's DRA driver. unresolved records a
+// reservation that could not be placed on a node, and stale that the Module moved on while the pass
+// was reading it; either one makes dropping a label unsafe.
+type driverUsage struct {
+	nodes      sets.Set[string]
+	unresolved bool
+	stale      bool
+}
+
+// driverRecheck asks once per pass, uncached: is the driver still in use, and is this still the spec.
+type driverRecheck func() (driverUsage, error)
+
+func (drh *draReconcilerHelper) newDriverRecheck(ctx context.Context, mod *kmmv1beta1.Module) driverRecheck {
+	return sync.OnceValues(func() (driverUsage, error) {
+		return drh.recheckDriverUsage(ctx, mod)
+	})
+}
+
+// confirmCurrentModule reports whether mod is still the Module the API server holds. Every branch
+// below it writes something the next pass cannot always take back, and a converged pass would
+// otherwise never look: it drops out of the label pass before any uncached read happens.
+func (drh *draReconcilerHelper) confirmCurrentModule(ctx context.Context, mod *kmmv1beta1.Module) (bool, error) {
+	current := kmmv1beta1.Module{}
+	key := types.NamespacedName{Namespace: mod.Namespace, Name: mod.Name}
+
+	if err := drh.apiReader.Get(ctx, key, &current); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not re-read module %s: %v", key, err)
+	}
+
+	return current.UID == mod.UID &&
+		current.Generation == mod.Generation &&
+		current.DeletionTimestamp.IsZero() == mod.DeletionTimestamp.IsZero(), nil
+}
+
+// recheckDriverUsage re-reads, uncached, the state a target label removal rests on. A Module that
+// changed is reported as such: a newer selector or toleration can make the node eligible again.
+func (drh *draReconcilerHelper) recheckDriverUsage(
+	ctx context.Context,
+	mod *kmmv1beta1.Module,
+) (driverUsage, error) {
+	current := kmmv1beta1.Module{}
+	key := types.NamespacedName{Namespace: mod.Namespace, Name: mod.Name}
+
+	if err := drh.apiReader.Get(ctx, key, &current); err != nil {
+		return driverUsage{}, fmt.Errorf("could not re-read module %s: %v", key, err)
+	}
+
+	// Deletion does not bump the generation, so a pass that started before it has to be caught
+	// here too rather than carrying on writing.
+	if current.UID != mod.UID || current.Generation != mod.Generation ||
+		current.DeletionTimestamp.IsZero() != mod.DeletionTimestamp.IsZero() {
+		return driverUsage{stale: true}, nil
+	}
+
+	return drh.nodesUsingDRADriver(ctx, drh.apiReader, mod)
+}
+
+// nodesUsingDRADriver returns the nodes running a Pod that still holds a ResourceClaim allocated to
+// this Module's DRA driver. Kubelet calls the driver to unprepare those devices, so it has to stay
+// until they are done, and a terminating Pod counts: unpreparing is what it is waiting for.
+func (drh *draReconcilerHelper) nodesUsingDRADriver(
+	ctx context.Context,
+	reader client.Reader,
+	mod *kmmv1beta1.Module,
+	opts ...client.ListOption,
+) (driverUsage, error) {
+	logger := log.FromContext(ctx)
+	usage := driverUsage{nodes: sets.New[string]()}
+
+	claims := resourcev1.ResourceClaimList{}
+	if err := reader.List(ctx, &claims, opts...); err != nil {
+		return usage, fmt.Errorf("could not list ResourceClaims: %v", err)
+	}
+
+	for i := range claims.Items {
+		claim := &claims.Items[i]
+
+		if !claimUsesDriver(claim, mod.Spec.DRA.DriverName) {
+			continue
+		}
+
+		for _, consumer := range claim.Status.ReservedFor {
+			nodeName := ""
+
+			if consumer.APIGroup == "" && consumer.Resource == "pods" {
+				pod := v1.Pod{}
+				key := types.NamespacedName{Namespace: claim.Namespace, Name: consumer.Name}
+				err := reader.Get(ctx, key, &pod)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return usage, fmt.Errorf("could not get Pod %s reserving ResourceClaim %s: %v", key, claim.Name, err)
+				}
+
+				// The UID is what stops a Pod recreated under the same name inheriting it.
+				if err == nil && pod.UID == consumer.UID {
+					nodeName = pod.Spec.NodeName
+				}
+			}
+
+			// A reservation the Pod cannot answer for still pins the driver: unbound, or gone.
+			if nodeName == "" {
+				nodeName = allocatedNodeName(claim)
+			}
+
+			// A reservation this pass cannot place is not proof the driver is free, so hold them all.
+			if nodeName == "" {
+				// Named once: the first is enough to point at what is holding the labels.
+				if !usage.unresolved {
+					logger.Info("Cannot place a ResourceClaim reservation, keeping every DRA target label",
+						"claim", claim.Namespace+"/"+claim.Name, "consumer", consumer.Resource+"/"+consumer.Name)
+					drh.event(mod, "DRAReservationUnresolved",
+						"ResourceClaim %s/%s is reserved by %s/%s, which cannot be placed on a node; keeping every %s label",
+						claim.Namespace, claim.Name, consumer.Resource, consumer.Name,
+						utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name))
+				}
+				usage.unresolved = true
+				continue
+			}
+
+			usage.nodes.Insert(nodeName)
+		}
+	}
+
+	return usage, nil
+}
+
+// allocatedNodeName returns the node a claim's devices sit on, or "" when the selector could match
+// more than one: terms are ORed, so every term has to pin the same metadata.name.
+func allocatedNodeName(claim *resourcev1.ResourceClaim) string {
+	if claim.Status.Allocation == nil || claim.Status.Allocation.NodeSelector == nil {
+		return ""
+	}
+
+	nodeName := ""
+
+	for _, term := range claim.Status.Allocation.NodeSelector.NodeSelectorTerms {
+		termName := ""
+
+		for _, req := range term.MatchFields {
+			if req.Key != "metadata.name" || req.Operator != v1.NodeSelectorOpIn || len(req.Values) != 1 {
+				continue
+			}
+
+			if termName != "" && termName != req.Values[0] {
+				return ""
+			}
+
+			termName = req.Values[0]
+		}
+
+		// A term that does not pin the name can match another node, so one is enough to give up.
+		if termName == "" || (nodeName != "" && nodeName != termName) {
+			return ""
+		}
+
+		nodeName = termName
+	}
+
+	return nodeName
+}
+
+func claimUsesDriver(claim *resourcev1.ResourceClaim, driverName string) bool {
+	if claim.Status.Allocation == nil {
+		return false
+	}
+
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if result.Driver == driverName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeDRATargetLabels removes the dra-target label from every node carrying it, so it also
+// reaches nodes the Module's selector no longer matches. It does not check for claims: its callers
+// have stopped managing a DRA driver at all, and gating them needs the finalizer from #1331.
+func (drh *draReconcilerHelper) removeDRATargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
+	targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
+	nodes, err := drh.nodeAPI.GetAllNodesByLabelKey(ctx, targetLabel)
+	if err != nil {
+		return fmt.Errorf("could not list nodes with %s label: %v", targetLabel, err)
+	}
+
+	var errs []error
+	for i := range nodes {
+		n := &nodes[i]
+		if err := drh.nodeAPI.UpdateLabels(ctx, n, nil, map[string]string{targetLabel: ""}); apierrors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			errs = append(errs, fmt.Errorf("could not remove %s label from node %s: %v", targetLabel, n.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (drh *draReconcilerHelper) garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error {
@@ -253,7 +1030,16 @@ func getExistingDRADSFromVersion(existingDS []appsv1.DaemonSet,
 func isOlderVersionUnusedDRADaemonSet(ds *appsv1.DaemonSet, moduleNamespace, moduleVersion string) bool {
 	moduleName := ds.Labels[constants.ModuleNameLabel]
 	versionLabel := utils.GetSchedulePodVersionLabelName(moduleNamespace, moduleName)
-	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
+	// A DaemonSet whose node selector was just migrated still reports the replica count from
+	// before the patch, so wait for its status to catch up before reading zero as unused. Wanting
+	// no Pods is not the same as having none: once the selector stops matching, the Pod left behind
+	// is counted in NumberMisscheduled alone, and deleting the DaemonSet takes it with it.
+	return ds.Labels[versionLabel] != moduleVersion &&
+		ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.DesiredNumberScheduled == 0 &&
+		ds.Status.CurrentNumberScheduled == 0 &&
+		ds.Status.NumberMisscheduled == 0 &&
+		ds.Status.NumberReady == 0
 }
 
 // deleteDRAResources deletes all DRA-owned DaemonSets and DeviceClasses using label-based bulk deletion.
@@ -286,17 +1072,21 @@ func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, moduleNa
 
 func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,
 	mod *kmmv1beta1.Module,
-	existingDRADS []appsv1.DaemonSet) error {
+	existingDRADS []appsv1.DaemonSet,
+	targetedNodes int) error {
 
 	if mod.Spec.DRA == nil {
 		return nil
 	}
 
-	numTargetedNodes, err := drh.nodeAPI.GetNumTargetedNodes(ctx, mod.Spec.Selector, mod.Spec.Tolerations)
+	// The same tolerations the target pass uses, so the two numbers cannot disagree.
+	numTargetedNodes, err := drh.nodeAPI.GetNumTargetedNodes(ctx, mod.Spec.Selector, module.EffectiveTolerations(mod.Spec.Tolerations))
 	if err != nil {
 		return fmt.Errorf("failed to determine the number of nodes targeted by Module %s/%s selector: %v", mod.Namespace, mod.Name, err)
 	}
 
+	// Every version the Module still owns counts, so during an ordered upgrade this can exceed the
+	// desired number while two DaemonSets briefly run a driver for the same node.
 	numAvailable := int32(0)
 	for _, ds := range existingDRADS {
 		numAvailable += ds.Status.NumberAvailable
@@ -304,8 +1094,15 @@ func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,
 
 	unmodifiedMod := mod.DeepCopy()
 
+	// The target label, not the selector, is what the DaemonSet ends up selecting on, and a claim
+	// can keep a node in that set after the selector has stopped matching it.
+	desired := targetedNodes
+	if mod.Spec.ModuleLoader == nil {
+		desired = numTargetedNodes
+	}
+
 	mod.Status.DRA.NodesMatchingSelectorNumber = int32(numTargetedNodes)
-	mod.Status.DRA.DesiredNumber = int32(numTargetedNodes)
+	mod.Status.DRA.DesiredNumber = int32(desired)
 	mod.Status.DRA.AvailableNumber = numAvailable
 
 	return drh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
@@ -510,6 +1307,7 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 
 	nodeSelector := map[string]string{
 		utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
+		utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name):         "",
 	}
 
 	if mod.Spec.ModuleLoader != nil {
@@ -519,6 +1317,7 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 			nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
 		}
 	} else {
+		// Nothing to unload, so drain gating is unnecessary.
 		nodeSelector = mod.Spec.Selector
 	}
 

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -19,11 +19,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -33,14 +36,76 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+var _ = Describe("NewDRAReconciler", func() {
+	It("should wire the filter used by the node watch", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		clnt := client.NewMockClient(ctrl)
+
+		dr := NewDRAReconciler(clnt, clnt, filter.New(clnt, nil), node.NewNode(clnt), nil, scheme)
+
+		Expect(dr.client).To(Equal(clnt))
+		Expect(dr.filter).NotTo(BeNil())
+		Expect(dr.reconHelperAPI).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("resourceClaimDrivers", func() {
+	It("names nothing for a claim the scheduler has not allocated", func() {
+		Expect(resourceClaimDrivers(&resourcev1.ResourceClaim{})).To(BeNil())
+	})
+
+	It("names every driver the allocation results carry", func() {
+		claim := &resourcev1.ResourceClaim{Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{Devices: resourcev1.DeviceAllocationResult{
+				Results: []resourcev1.DeviceRequestAllocationResult{
+					{Driver: "gpu.example.com"},
+					{Driver: "nic.example.com"},
+				},
+			}},
+		}}
+
+		Expect(resourceClaimDrivers(claim)).To(Equal([]string{"gpu.example.com", "nic.example.com"}))
+	})
+})
+
+var _ = Describe("DRAReconciler_SetupWithManager", func() {
+	It("should register the controller and all of its watches", func() {
+		// A static mapper, so that registering the ResourceClaim index does not need discovery.
+		mapper := meta.NewDefaultRESTMapper(nil)
+		mapper.Add(resourcev1.SchemeGroupVersion.WithKind("ResourceClaim"), meta.RESTScopeNamespace)
+
+		mgr, err := manager.New(
+			&rest.Config{Host: "http://127.0.0.1:1"},
+			manager.Options{
+				Scheme:         scheme,
+				Metrics:        metricsserver.Options{BindAddress: "0"},
+				MapperProvider: func(*rest.Config, *http.Client) (meta.RESTMapper, error) { return mapper, nil },
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		clnt := mgr.GetClient()
+		dr := NewDRAReconciler(clnt, clnt, filter.New(clnt, nil), node.NewNode(clnt), nil, scheme)
+
+		Expect(dr.SetupWithManager(mgr)).To(Succeed())
+	})
+})
 
 var _ = Describe("DRAReconciler_Reconcile", func() {
 	const draModuleName = "dra-module"
@@ -59,7 +124,8 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		mod = &kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName},
 			Spec: kmmv1beta1.ModuleSpec{
-				DRA: &kmmv1beta1.DRASpec{},
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
 			},
 		}
 
@@ -70,7 +136,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, getDCError, handleDRAError, gcError, handleDCError bool) {
+	DescribeTable("check error flows", func(getDSError, getDCError, targetLabelsError, handleDRAError, gcError, handleDCError bool) {
 		draDS := []appsv1.DaemonSet{{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -83,6 +149,12 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil)
+		mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil)
+		if targetLabelsError {
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).Return(draTargetResult{}, returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).Return(draTargetResult{}, nil)
 		if handleDRAError {
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(returnedError)
 			goto executeTestFunction
@@ -98,7 +170,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil)
-		mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS).Return(returnedError)
+		mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS, gomock.Any()).Return(returnedError)
 
 	executeTestFunction:
 		res, err := dr.Reconcile(ctx, mod)
@@ -107,23 +179,104 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getModuleDRADaemonSets failed", true, false, false, false, false),
-		Entry("getModuleDeviceClasses failed", false, true, false, false, false),
-		Entry("handleDRA failed", false, false, true, false, false),
-		Entry("garbageCollectDRADaemonSets failed", false, false, false, true, false),
-		Entry("handleDeviceClasses failed", false, false, false, false, true),
-		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false),
+		Entry("getModuleDRADaemonSets failed", true, false, false, false, false, false),
+		Entry("getModuleDeviceClasses failed", false, true, false, false, false, false),
+		Entry("handleDRATargetLabels failed", false, false, true, false, false, false),
+		Entry("handleDRA failed", false, false, false, true, false, false),
+		Entry("garbageCollectDRADaemonSets failed", false, false, false, false, true, false),
+		Entry("handleDeviceClasses failed", false, false, false, false, false, true),
+		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false, false),
 	)
+
+	It("should not return a requeue next to an error", func() {
+		// controller-runtime ignores the result next to an error, and warns about being given both.
+		draDS := []appsv1.DaemonSet{{}}
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).
+				Return(draTargetResult{requeueAfter: draTargetRequeue}, nil),
+			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(fmt.Errorf("some error")),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+	})
+
+	It("should fail the pass when the Module cannot be confirmed", func() {
+		draDS := []appsv1.DaemonSet{{}}
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(false, fmt.Errorf("some error")),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(res.RequeueAfter).To(BeZero())
+	})
+
+	It("should stop a converged pass when the Module is no longer current", func() {
+		// A converged pass reaches no uncached read on its own.
+		draDS := []appsv1.DaemonSet{{}}
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(false, nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(draTargetRequeue))
+	})
+
+	It("should stop the whole pass when the Module changed under it", func() {
+		// Garbage collection reads the version off this object, so letting it run could delete the
+		// DaemonSet the current spec wants back.
+		draDS := []appsv1.DaemonSet{{}}
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).
+				Return(draTargetResult{stale: true}, nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(draTargetRequeue))
+	})
+
+	It("should skip the DaemonSet work and come back when the migration is held", func() {
+		draDS := []appsv1.DaemonSet{{}}
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).
+				Return(draTargetResult{targeted: 1, deferDaemonSets: true, requeueAfter: draTargetRequeue}, nil),
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS, 1).Return(nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(draTargetRequeue))
+	})
 
 	It("Good flow", func() {
 		draDS := []appsv1.DaemonSet{{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod, draDS).Return(draTargetResult{}, nil),
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS, gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -141,17 +294,33 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 
+		By("error flow - removeDRATargetLabels fails")
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
+		)
+
+		res, err = dr.Reconcile(ctx, mod)
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+
 		By("error flow - deleteDRAResources fails")
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(fmt.Errorf("some error")),
 		)
 
@@ -165,7 +334,9 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
 
@@ -183,7 +354,9 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
 
@@ -199,8 +372,67 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(fmt.Errorf("some error")),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("cleanup when spec.dra is nil and removeDRATargetLabels fails", func() {
+		mod.Spec.DRA = nil
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("cleans up stale target labels when the Module has no ModuleLoader", func() {
+		mod.Spec.ModuleLoader = nil
+		draDS := []appsv1.DaemonSet{{}}
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS, gomock.Any()).Return(nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when cleaning up stale target labels fails", func() {
+		mod.Spec.ModuleLoader = nil
+		draDS := []appsv1.DaemonSet{{}}
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().confirmCurrentModule(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().removeDRATargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -224,6 +456,7 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 		mockDSHelper = NewMockdraDaemonSetCreator(ctrl)
 		drh = draReconcilerHelper{
 			client:          clnt,
+			apiReader:       clnt,
 			daemonSetHelper: mockDSHelper,
 		}
 	})
@@ -258,6 +491,7 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-dra-"},
 		}
 		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.DaemonSetList{}), gomock.Any(), gomock.Any()).Return(nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			mockDSHelper.EXPECT().setDRAAsDesired(ctx, newDS, &mod).Return(nil),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
@@ -266,6 +500,108 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 		err := drh.handleDRA(ctx, &mod, nil)
 
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should reuse a DaemonSet the cache has not caught up with", func() {
+		// Writing a node label queues this Module again, so a pass can run before the DaemonSet
+		// the last one created is visible. A generated name would make a second one, not a conflict.
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{}},
+		}
+
+		const name = "created-last-pass"
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.AssignableToTypeOf(&appsv1.DaemonSetList{}), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, l *appsv1.DaemonSetList, _ ...ctrlclient.ListOption) error {
+					l.Items = []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name}}}
+					return nil
+				}),
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).Return(nil),
+		)
+
+		// No Create: a second DaemonSet for this version would never be garbage collected.
+		Expect(drh.handleDRA(ctx, &mod, nil)).To(Succeed())
+	})
+
+	It("should not add the target selector to a DaemonSet that predates it", func() {
+		// Requiring it narrows what the DaemonSet selects and rolls the driver, which is the
+		// migration the claims hold back, so only the gated pass may start it.
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+		targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
+		const name = "legacy"
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name}}}
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{"other": "keep"}
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).DoAndReturn(
+				func(_ context.Context, ds *appsv1.DaemonSet, _ *kmmv1beta1.Module) error {
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{"other": "keep", targetLabel: ""}
+					return nil
+				},
+			),
+		)
+
+		// No Patch: the key this would have added is the migration itself.
+		Expect(drh.handleDRA(ctx, &mod, existing)).To(Succeed())
+	})
+
+	It("should leave a wrong target selector value to the guarded correction", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+		targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
+		const name = "corrupted"
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name}}}
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{targetLabel: "wrong"}
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).DoAndReturn(
+				func(_ context.Context, ds *appsv1.DaemonSet, _ *kmmv1beta1.Module) error {
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{targetLabel: ""}
+					return nil
+				},
+			),
+		)
+
+		// No Patch: correcting the value is guarded on the one this pass read.
+		Expect(drh.handleDRA(ctx, &mod, existing)).To(Succeed())
 	})
 
 	It("existing daemonset", func() {
@@ -301,6 +637,679 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 	})
 })
 
+// reservedClaimOn builds an allocated claim reserved by a Pod. An empty nodeName leaves it without
+// a node selector, which is what an unplaceable reservation looks like.
+func reservedClaimOn(driver, nodeName string) resourcev1.ResourceClaim {
+	c := resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "workloads"},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{Driver: driver}},
+				},
+			},
+			ReservedFor: []resourcev1.ResourceClaimConsumerReference{
+				{Resource: "pods", Name: "consumer", UID: "uid-1"},
+			},
+		},
+	}
+	if nodeName != "" {
+		c.Status.Allocation.NodeSelector = &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{{
+				MatchFields: []v1.NodeSelectorRequirement{{
+					Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{nodeName},
+				}},
+			}},
+		}
+	}
+	return c
+}
+
+// handleTargets drops the target count so these assertions can stay on the error alone.
+func handleTargets(drh *draReconcilerHelper, ctx context.Context, mod *kmmv1beta1.Module,
+	existing []appsv1.DaemonSet) error {
+	_, err := drh.handleDRATargetLabels(ctx, mod, existing)
+	return err
+}
+
+// expectFreshModule covers the uncached Module read a removal starts from. The same UID and
+// generation is what lets the pass keep acting on the spec it decided from.
+func expectFreshModule(clnt *client.MockClient, mod *kmmv1beta1.Module) {
+	clnt.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+			current := o.(*kmmv1beta1.Module)
+			current.UID = mod.UID
+			current.Generation = mod.Generation
+			return nil
+		})
+}
+
+// expectFreshUsage adds the uncached reservation read. No claims is what lets the removal go ahead.
+func expectStaleModule(clnt *client.MockClient, mod *kmmv1beta1.Module) {
+	clnt.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+			current := o.(*kmmv1beta1.Module)
+			current.UID = mod.UID
+			current.Generation = mod.Generation + 1
+			return nil
+		})
+}
+
+// expectMovedSelector answers the re-read that tells a rejected guard from ordinary validation.
+func expectMovedSelector(clnt *client.MockClient, targetLabel, value string) {
+	clnt.EXPECT().
+		Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&appsv1.DaemonSet{})).
+		DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+			o.(*appsv1.DaemonSet).Spec.Template.Spec.NodeSelector = map[string]string{targetLabel: value}
+			return nil
+		})
+}
+
+func expectFreshUsage(clnt *client.MockClient, mod *kmmv1beta1.Module) {
+	expectFreshModule(clnt, mod)
+	clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).Return(nil)
+}
+
+var _ = Describe("draReconcilerHelper_handleDRATargetLabels", func() {
+	const draModuleName = "dra-module"
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		nm   *node.MockNode
+		drh  draReconcilerHelper
+		ctx  context.Context
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		nm = node.NewMockNode(ctrl)
+		ctx = context.Background()
+		clnt = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{nodeAPI: nm, client: clnt, apiReader: clnt}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName, UID: "module-uid", Generation: 7},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{DriverName: "gpu.example.com"}},
+		}
+	})
+
+	It("should return nil when DRA is nil", func() {
+		mod.Spec.DRA = nil
+		Expect(handleTargets(&drh, ctx, mod, nil)).To(Succeed())
+	})
+
+	It("should fail when the claim lookup fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(fmt.Errorf("some error"))
+
+		Expect(handleTargets(&drh, ctx, mod, nil)).NotTo(Succeed())
+	})
+
+	It("should write no label at all once the Module has moved on", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		// Sorted by name, so the removal that discovers the change is reached first and the
+		// addition after it is the one a pass that kept going would still have written.
+		remove := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "a-remove", Labels: map[string]string{targetLabel: ""}}}
+		add := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "z-add"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{add}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{remove}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+		expectStaleModule(clnt, mod)
+
+		// Neither UpdateLabels nor UpdateLabelsWithOptimisticLock: nothing outlives this spec.
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.stale).To(BeTrue())
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should not correct a label value once the Module has moved on", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		corrupted := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "only", Labels: map[string]string{targetLabel: "corrupted"}},
+		}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{corrupted}, nil)
+		expectStaleModule(clnt, mod)
+
+		// No UpdateLabels: the value would be normalized to match a spec that is gone.
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.stale).To(BeTrue())
+	})
+
+	It("should reconcile the dra-target label", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(handleTargets(&drh, ctx, mod, nil)).To(Succeed())
+	})
+
+	It("should give the DaemonSets the target selector once the nodes carry the label", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "old-version"}}}
+
+		var labelled bool
+		expectFreshModule(clnt, mod)
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil),
+			nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil),
+			nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil),
+			nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true),
+			nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).
+				DoAndReturn(func(context.Context, *v1.Node, map[string]string, map[string]string) error {
+					labelled = true
+					return nil
+				}),
+			clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).Return(nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, ds *appsv1.DaemonSet, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					Expect(labelled).To(BeTrue())
+					Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(targetLabel, ""))
+					return nil
+				},
+			),
+		)
+
+		Expect(handleTargets(&drh, ctx, mod, existing)).To(Succeed())
+	})
+
+	It("should read again between dropping a label and rolling a DaemonSet", func() {
+		// A reservation can appear in between, and the migration must not roll the driver on the
+		// strength of what the removal saw.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{targetLabel: ""}}}
+		legacy := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "old-version"}}}
+
+		moduleGets, claimLists := 0, 0
+
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				moduleGets++
+				current := o.(*kmmv1beta1.Module)
+				current.UID, current.Generation = mod.UID, mod.Generation
+				return nil
+			}).AnyTimes()
+		countClaimList := func(_ context.Context, _ *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+			claimLists++
+			return nil
+		}
+		// The cached read narrows on the driver index; the recheck below it cannot.
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{}),
+			ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).
+			DoAndReturn(countClaimList).AnyTimes()
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).
+			DoAndReturn(countClaimList).AnyTimes()
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
+		_, err := drh.handleDRATargetLabels(ctx, mod, legacy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(moduleGets).To(Equal(2))
+		Expect(claimLists).To(Equal(3))
+	})
+
+	DescribeTable("confirmCurrentModule",
+		func(mutate func(*kmmv1beta1.Module), expected bool) {
+			clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+				DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+					current := o.(*kmmv1beta1.Module)
+					mod.DeepCopyInto(current)
+					mutate(current)
+					return nil
+				})
+
+			Expect(drh.confirmCurrentModule(ctx, mod)).To(Equal(expected))
+		},
+		Entry("unchanged", func(*kmmv1beta1.Module) {}, true),
+		Entry("generation moved on", func(m *kmmv1beta1.Module) { m.Generation++ }, false),
+		Entry("replaced under the same name", func(m *kmmv1beta1.Module) { m.UID = "another" }, false),
+		// Deletion leaves the generation alone, so it has to be compared on its own.
+		Entry("entered deletion", func(m *kmmv1beta1.Module) {
+			now := metav1.Now()
+			m.DeletionTimestamp = &now
+		}, false),
+	)
+
+	It("should surface a read failure rather than call the Module gone", func() {
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			Return(fmt.Errorf("some error"))
+
+		_, err := drh.confirmCurrentModule(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should treat a Module that is already gone as not current", func() {
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "modules"}, mod.Name))
+
+		current, err := drh.confirmCurrentModule(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(current).To(BeFalse())
+	})
+
+	It("should not touch a DaemonSet once the Module has moved on", func() {
+		// The pass already knows it is working from a spec that is gone, so not even the recovery.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-value"},
+			Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: "wrong"}},
+			}},
+		}}
+
+		// A node whose label would come off, so the pass reaches the uncached read and learns the
+		// Module has moved on before it gets to the DaemonSets.
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n1", Labels: map[string]string{targetLabel: ""}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				current := o.(*kmmv1beta1.Module)
+				current.UID, current.Generation = mod.UID, mod.Generation+1
+				return nil
+			})
+
+		// No Patch and no UpdateLabels: any write here fails the test.
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.stale).To(BeTrue())
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should not even recover a selector once the migration read finds the Module gone", func() {
+		// No label to drop, so the pass only reaches an uncached read at the migration decision.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{
+			{ObjectMeta: metav1.ObjectMeta{Name: "legacy"}},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "wrong-value"},
+				Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: "wrong"}},
+				}},
+			},
+		}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				current := o.(*kmmv1beta1.Module)
+				current.UID, current.Generation = mod.UID, mod.Generation+1
+				return nil
+			})
+
+		// No Patch: the recovery is a write too, and this pass no longer knows what is wanted.
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.stale).To(BeTrue())
+		Expect(result.deferDaemonSets).To(BeFalse())
+	})
+
+	It("should fail when a node a claim needs cannot be read at all", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return(nil, nil)
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "unreadable"}, gomock.AssignableToTypeOf(&v1.Node{})).
+			Return(fmt.Errorf("some error"))
+
+		_, err := drh.reconcileDRATargetLabel(ctx, mod,
+			utils.GetDRATargetNodeLabel(namespace, draModuleName),
+			driverUsage{nodes: sets.New("unreadable")}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should ask to come back when a node a claim needs cannot be read", func() {
+		// Nothing else puts the label back: a node event for it maps to no Module at all.
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return(nil, nil)
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "vanished"}, gomock.AssignableToTypeOf(&v1.Node{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "vanished"))
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod,
+			utils.GetDRATargetNodeLabel(namespace, draModuleName),
+			driverUsage{nodes: sets.New("vanished")}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should correct a wrong value while holding back a missing one", func() {
+		// Two DaemonSets, one of each kind: the claim gates only the disruptive half.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "wrong-value"},
+				Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: "wrong"}},
+				}},
+			},
+			{ObjectMeta: metav1.ObjectMeta{Name: "legacy"}},
+		}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		expectFreshModule(clnt, mod)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", "in-use")}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		patched := []string{}
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ds *appsv1.DaemonSet, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				patched = append(patched, ds.Name)
+				return nil
+			},
+		)
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeTrue())
+		Expect(patched).To(ConsistOf("wrong-value"))
+	})
+
+	It("should come back when a correction it wanted to make no longer applies", func() {
+		// The recovery-only path: no missing key, so the claims are never consulted.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-value"},
+			Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: "wrong"}},
+			}},
+		}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewInvalid(schema.GroupKind{Kind: "DaemonSet"}, "wrong-value", nil))
+		expectMovedSelector(clnt, targetLabel, "moved")
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).NotTo(BeZero())
+		// The classification the DaemonSet work below reads is void, so it does not run.
+		Expect(result.deferDaemonSets).To(BeTrue())
+	})
+
+	It("should fail when the claims cannot be confirmed before migrating", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "legacy"}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		expectFreshModule(clnt, mod)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).
+			Return(fmt.Errorf("some error"))
+
+		_, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should come back when the migration itself no longer applies", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "legacy"}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		expectFreshUsage(clnt, mod)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewInvalid(schema.GroupKind{Kind: "DaemonSet"}, "legacy", nil))
+
+		// The migration patch has no test operation, so its rejection is a real one.
+		_, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should leave a DaemonSet that is already being deleted alone", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		now := metav1.Now()
+		existing := []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{Name: "going", DeletionTimestamp: &now,
+				Finalizers: []string{"keep"}},
+		}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+
+		// No Patch and no claim read: there is no drift to act on.
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeFalse())
+	})
+
+	It("should correct a wrong target selector value even while a claim is reserved", func() {
+		// The driver is already gone, and the claim waiting on it cannot clear without it.
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-value"},
+			Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: "wrong"}},
+			}},
+		}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", "in-use")}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer")).AnyTimes()
+		// The node has to come back too: correcting the selector alone leaves the DaemonSet with no
+		// node to run on, which is the state the claim is stuck behind.
+		inUse := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "in-use"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "in-use"}, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				inUse.DeepCopyInto(o.(*v1.Node))
+				return nil
+			},
+		)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ds *appsv1.DaemonSet, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				data, err := p.Data(ds)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring(`"op":"replace"`))
+				return nil
+			},
+		)
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeFalse())
+	})
+
+	It("should say why the migration is held", func() {
+		// A drain that does not converge is otherwise only visible in the controller's own logs.
+		recorder := record.NewFakeRecorder(4)
+		withRecorder := draReconcilerHelper{client: clnt, apiReader: clnt, nodeAPI: nm, recorder: recorder}
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "legacy"}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		expectFreshModule(clnt, mod)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", "in-use")}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		_, err := withRecorder.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recorder.Events).To(Receive(ContainSubstring("DRAMigrationDeferred")))
+	})
+
+	It("should hold the DaemonSet migration while a claim is still reserved", func() {
+		// Cordoned and still selected, which is what a drain in progress looks like.
+		label := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		n := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "in-use", Labels: map[string]string{label: ""}},
+			Spec:       v1.NodeSpec{Taints: []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}},
+		}
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "old-version"}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(false)
+		// Twice: the label pass and the migration each take their own snapshot.
+		expectFreshModule(clnt, mod)
+		expectFreshModule(clnt, mod)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", n.Name)}
+				return nil
+			},
+		).AnyTimes()
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer")).AnyTimes()
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeTrue())
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should hold the DaemonSet migration while a reservation cannot be placed", func() {
+		// The node the claim is on cannot be named, so it may be one this migration would empty.
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "old-version"}}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return(nil, nil)
+		expectFreshModule(clnt, mod)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", "")}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeTrue())
+	})
+
+	It("should not hold a DaemonSet that already selects on the target label", func() {
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "in-use", Labels: map[string]string{targetLabel: ""}}}
+		existing := []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{Name: "current"},
+			Spec: appsv1.DaemonSetSpec{Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{NodeSelector: map[string]string{targetLabel: ""}},
+			}},
+		}}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		result, err := drh.handleDRATargetLabels(ctx, mod, existing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.deferDaemonSets).To(BeFalse())
+	})
+
+	It("should fail when an existing DaemonSet cannot be given the target selector", func() {
+		existing := []appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{Name: "old-version"}}}
+
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{}),
+			ctrlclient.MatchingFields{draClaimDriverIndex: mod.Spec.DRA.DriverName}).Return(nil)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).Return(nil)
+		expectFreshModule(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return(nil, nil)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		Expect(handleTargets(&drh, ctx, mod, existing)).NotTo(Succeed())
+	})
+})
+
+var _ = Describe("draReconcilerHelper_removeDRATargetLabels", func() {
+	const draModuleName = "dra-module"
+
+	It("should remove the dra-target label", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		nm := node.NewMockNode(ctrl)
+		ctx := context.Background()
+		drh := draReconcilerHelper{nodeAPI: nm}
+		mod := &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName}}
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().UpdateLabels(ctx, &n, nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(drh.removeDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("should return an error when the labeled nodes cannot be listed", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		nm := node.NewMockNode(ctrl)
+		ctx := context.Background()
+		drh := draReconcilerHelper{nodeAPI: nm}
+		mod := &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName}}
+
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, gomock.Any()).Return(nil, fmt.Errorf("some error"))
+
+		Expect(drh.removeDRATargetLabels(ctx, mod)).NotTo(Succeed())
+	})
+
+	It("should keep going past a node that has gone and report the rest", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		nm := node.NewMockNode(ctrl)
+		ctx := context.Background()
+		drh := draReconcilerHelper{nodeAPI: nm}
+		mod := &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName}}
+		targetLabel := utils.GetDRATargetNodeLabel(namespace, draModuleName)
+		gone := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "gone"}}
+		failing := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "failing"}}
+
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{gone, failing}, nil)
+		nm.EXPECT().UpdateLabels(ctx, &gone, nil, map[string]string{targetLabel: ""}).
+			Return(apierrors.NewNotFound(v1.Resource("nodes"), "gone"))
+		nm.EXPECT().UpdateLabels(ctx, &failing, nil, map[string]string{targetLabel: ""}).
+			Return(fmt.Errorf("some error"))
+
+		Expect(drh.removeDRATargetLabels(ctx, mod)).NotTo(Succeed())
+	})
+})
+
 var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 	var (
 		ctrl         *gomock.Controller
@@ -315,14 +1324,14 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		drh = newDRAReconcilerHelper(clnt, mn, nil)
+		drh = newDRAReconcilerHelper(clnt, clnt, mn, nil, nil)
 	})
 
 	ctx := context.Background()
 
 	It("DRA not defined in the module", func() {
 		mod := kmmv1beta1.Module{}
-		err := drh.moduleUpdateDRAStatus(ctx, &mod, nil)
+		err := drh.moduleUpdateDRAStatus(ctx, &mod, nil, 0)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -335,8 +1344,36 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 
 		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		err := drh.moduleUpdateDRAStatus(ctx, &mod, nil)
+		err := drh.moduleUpdateDRAStatus(ctx, &mod, nil, 0)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should count a pressure-tainted node the same way the target pass does", func() {
+		// The DaemonSet controller tolerates the pressure taints on its own, so counting the node
+		// out here would contradict the desired number next to it.
+		mod := kmmv1beta1.Module{Spec: kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{}}}
+		tainted := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "under-pressure"},
+			Spec: v1.NodeSpec{Taints: []v1.Taint{{
+				Key: v1.TaintNodeMemoryPressure, Effect: v1.TaintEffectNoSchedule,
+			}}},
+		}
+
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, list *v1.NodeList, _ ...ctrlclient.ListOption) error {
+				list.Items = []v1.Node{tainted}
+				return nil
+			},
+		)
+		clnt.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, _ ctrlclient.Patch, _ ...ctrlclient.SubResourcePatchOption) error {
+				Expect(o.(*kmmv1beta1.Module).Status.DRA.NodesMatchingSelectorNumber).To(Equal(int32(1)))
+				return nil
+			},
+		)
+
+		Expect(drh.moduleUpdateDRAStatus(ctx, &mod, nil, 1)).To(Succeed())
 	})
 
 	DescribeTable("DRA status update",
@@ -366,7 +1403,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 			}
 
 			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *v1.NodeList, _ ...interface{}) error {
+				func(_ any, list *v1.NodeList, _ ...any) error {
 					list.Items = nodesList
 					return nil
 				},
@@ -374,7 +1411,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 			clnt.EXPECT().Status().Return(statusWriter)
 			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
 
-			err := drh.moduleUpdateDRAStatus(ctx, &mod, daemonSetsList)
+			err := drh.moduleUpdateDRAStatus(ctx, &mod, daemonSetsList, 0)
 			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("0 target node, 0 ds", 0, nil, 0, 0),
@@ -398,7 +1435,8 @@ var _ = Describe("DRAReconciler_clearDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		drh = draReconcilerHelper{
-			client: clnt,
+			client:    clnt,
+			apiReader: clnt,
 		}
 	})
 
@@ -839,6 +1877,50 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(
 			utils.GetKernelModuleReadyNodeLabel(namespace, draModuleName), "",
 		))
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(
+			utils.GetDRATargetNodeLabel(namespace, draModuleName), "",
+		))
+	})
+
+	It("should require both the ready and target labels when a ModuleLoader is defined", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: draModuleName, Namespace: namespace},
+			Spec: kmmv1beta1.ModuleSpec{
+				Selector:     map[string]string{"kubernetes.io/hostname": "node1"},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+				DRA: &kmmv1beta1.DRASpec{
+					Container:  kmmv1beta1.CommonContainerSpec{Image: draImage},
+					DriverName: "test.driver",
+				},
+			},
+		}
+
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}
+		Expect(dsc.setDRAAsDesired(context.Background(), &ds, &mod)).To(Succeed())
+
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{
+			utils.GetKernelModuleReadyNodeLabel(namespace, draModuleName): "",
+			utils.GetDRATargetNodeLabel(namespace, draModuleName):         "",
+		}))
+	})
+
+	It("should fall back to the Module selector when no ModuleLoader is defined", func() {
+		selector := map[string]string{"kubernetes.io/hostname": "node1"}
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: draModuleName, Namespace: namespace},
+			Spec: kmmv1beta1.ModuleSpec{
+				Selector: selector,
+				DRA: &kmmv1beta1.DRASpec{
+					Container:  kmmv1beta1.CommonContainerSpec{Image: draImage},
+					DriverName: "test.driver",
+				},
+			},
+		}
+
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}
+		Expect(dsc.setDRAAsDesired(context.Background(), &ds, &mod)).To(Succeed())
+
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(selector))
 	})
 })
 
@@ -854,7 +1936,7 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		drh = draReconcilerHelper{client: clnt}
+		drh = draReconcilerHelper{client: clnt, apiReader: clnt}
 	})
 
 	mod := &kmmv1beta1.Module{
@@ -919,6 +2001,102 @@ var _ = Describe("DRAReconciler_garbageCollectDRADaemonSets", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should migrate every leftover version and collect only the settled one", func() {
+		// Ordered upgrade can leave more than one older DaemonSet behind, each selecting on it.
+		settled := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-v1",
+				Namespace:  "namespace",
+				Generation: 3,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "v1"},
+			},
+			Status: appsv1.DaemonSetStatus{ObservedGeneration: 3},
+		}
+		migrating := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-v2",
+				Namespace:  "namespace",
+				Generation: 4,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "v2"},
+			},
+			Status: appsv1.DaemonSetStatus{ObservedGeneration: 3},
+		}
+
+		clnt.EXPECT().Delete(context.Background(), &settled).Return(nil)
+
+		err := drh.garbageCollectDRADaemonSets(context.Background(), mod, []appsv1.DaemonSet{settled, migrating})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should keep a former DaemonSet whose status has not caught up with its spec", func() {
+		// Migrating the node selector bumps the generation, so a zero desired count still
+		// describes the DaemonSet as it was before the patch.
+		migratedDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-former",
+				Namespace:  "namespace",
+				Generation: 2,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "former"},
+			},
+			Status: appsv1.DaemonSetStatus{ObservedGeneration: 1},
+		}
+
+		err := drh.garbageCollectDRADaemonSets(context.Background(), mod, []appsv1.DaemonSet{migratedDS})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should keep a former DaemonSet whose Pods have not gone yet", func() {
+		// Wanting no Pods is not the same as having none, and deleting the DaemonSet takes the
+		// ones still on the node with it.
+		draining := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-former",
+				Namespace:  "namespace",
+				Generation: 1,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "former"},
+			},
+			Status: appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 0,
+				CurrentNumberScheduled: 1,
+			},
+		}
+
+		// No Delete: the DaemonSet still has a Pod on a node.
+		Expect(drh.garbageCollectDRADaemonSets(context.Background(), mod, []appsv1.DaemonSet{draining})).To(Succeed())
+	})
+
+	It("should keep a former DaemonSet whose Pod outlived the selector that placed it", func() {
+		// Once the selector stops matching, the DaemonSet controller counts the Pod still on the
+		// node in NumberMisscheduled alone; desired, current and ready are all zero beside it.
+		misscheduled := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-former",
+				Namespace:  "namespace",
+				Generation: 1,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "former"},
+			},
+			Status: appsv1.DaemonSetStatus{ObservedGeneration: 1, NumberMisscheduled: 1},
+		}
+
+		// No Delete: deleting the DaemonSet would take that Pod with it.
+		Expect(drh.garbageCollectDRADaemonSets(context.Background(), mod, []appsv1.DaemonSet{misscheduled})).To(Succeed())
+	})
+
+	It("should keep a former DaemonSet that still reports a ready Pod", func() {
+		ready := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "dra-former",
+				Namespace:  "namespace",
+				Generation: 1,
+				Labels:     map[string]string{constants.ModuleNameLabel: mod.Name, schedulePodVersionLabel: "former"},
+			},
+			Status: appsv1.DaemonSetStatus{ObservedGeneration: 1, NumberReady: 1},
+		}
+
+		Expect(drh.garbageCollectDRADaemonSets(context.Background(), mod, []appsv1.DaemonSet{ready})).To(Succeed())
+	})
+
 	It("should pass if moduleLoader is not defined", func() {
 		modWithoutModuleLoader := mod.DeepCopy()
 		modWithoutModuleLoader.Spec.ModuleLoader = nil
@@ -946,7 +2124,8 @@ var _ = Describe("DRAReconciler_getModuleDRADaemonSets", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		drh = draReconcilerHelper{
-			client: clnt,
+			client:    clnt,
+			apiReader: clnt,
 		}
 	})
 
@@ -1003,7 +2182,8 @@ var _ = Describe("DRAReconciler_getModuleDeviceClasses", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		drh = draReconcilerHelper{
-			client: clnt,
+			client:    clnt,
+			apiReader: clnt,
 		}
 	})
 
@@ -1062,7 +2242,8 @@ var _ = Describe("DRAReconciler_handleDeviceClasses", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		drh = draReconcilerHelper{
-			client: clnt,
+			client:    clnt,
+			apiReader: clnt,
 		}
 	})
 
@@ -1281,7 +2462,8 @@ var _ = Describe("DRAReconciler_deleteDRAResources", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		drh = draReconcilerHelper{
-			client: clnt,
+			client:    clnt,
+			apiReader: clnt,
 		}
 	})
 
@@ -1321,5 +2503,1048 @@ var _ = Describe("DRAReconciler_deleteDRAResources", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
 		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+	})
+})
+
+var _ = Describe("draReconcilerHelper_nodesUsingDRADriver", func() {
+	const (
+		driverName = "gpu.example.com"
+		claimNS    = "workloads"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		drh  draReconcilerHelper
+		ctx  context.Context
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		ctx = context.Background()
+		drh = draReconcilerHelper{client: clnt, apiReader: clnt}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "dra-module"},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{DriverName: driverName}},
+		}
+	})
+
+	claim := func(driver string, consumers ...resourcev1.ResourceClaimConsumerReference) resourcev1.ResourceClaim {
+		c := resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: claimNS},
+		}
+		if driver != "" {
+			c.Status.Allocation = &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{{Driver: driver}},
+				},
+			}
+		}
+		c.Status.ReservedFor = consumers
+		return c
+	}
+
+	podConsumer := func(name string, uid types.UID) resourcev1.ResourceClaimConsumerReference {
+		return resourcev1.ResourceClaimConsumerReference{Resource: "pods", Name: name, UID: uid}
+	}
+
+	expectClaims := func(claims ...resourcev1.ResourceClaim) {
+		clnt.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+			func(_ any, list *resourcev1.ResourceClaimList, _ ...any) error {
+				list.Items = claims
+				return nil
+			},
+		)
+	}
+
+	expectPod := func(name string, uid types.UID, nodeName string) {
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Namespace: claimNS, Name: name}, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ types.NamespacedName, p *v1.Pod, _ ...ctrlclient.GetOption) error {
+				p.UID = uid
+				p.Spec.NodeName = nodeName
+				return nil
+			},
+		)
+	}
+
+	It("should return the node of a Pod still holding a claim for this driver", func() {
+		expectClaims(claim(driverName, podConsumer("consumer", "uid-1")))
+		expectPod("consumer", "uid-1", "node1")
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes.UnsortedList()).To(ConsistOf("node1"))
+	})
+
+	// A kubelet plugin only gets node-local devices, so the allocation names the node the driver
+	// has to stay on even when the consumer cannot be resolved to one.
+	onNode := func(c resourcev1.ResourceClaim, nodeName string) resourcev1.ResourceClaim {
+		c.Status.Allocation.NodeSelector = &v1.NodeSelector{
+			NodeSelectorTerms: []v1.NodeSelectorTerm{{
+				MatchFields: []v1.NodeSelectorRequirement{{
+					Key:      "metadata.name",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{nodeName},
+				}},
+			}},
+		}
+		return c
+	}
+
+	It("should keep the allocated node while the consumer is not bound yet", func() {
+		expectClaims(onNode(claim(driverName, podConsumer("consumer", "uid-1")), "node1"))
+		expectPod("consumer", "uid-1", "")
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes.UnsortedList()).To(ConsistOf("node1"))
+	})
+
+	It("should keep the allocated node while a reservation outlives its Pod", func() {
+		expectClaims(onNode(claim(driverName, podConsumer("consumer", "uid-1")), "node1"))
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Namespace: claimNS, Name: "consumer"}, gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes.UnsortedList()).To(ConsistOf("node1"))
+	})
+
+	// A claim this driver does not back must not hold every removable label on the Module.
+	It("should ignore claims allocated from another driver", func() {
+		expectClaims(claim("other.example.com", podConsumer("consumer", "uid-1")))
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeFalse())
+	})
+
+	It("should ignore claims that were never allocated", func() {
+		expectClaims(claim("", podConsumer("consumer", "uid-1")))
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeFalse())
+	})
+
+	It("should leave a reservation unresolved when its Pod was recreated under the same name", func() {
+		expectClaims(claim(driverName, podConsumer("consumer", "uid-1")))
+		expectPod("consumer", "uid-2", "node1")
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeTrue())
+	})
+
+	It("should leave a reservation unresolved when its Pod is already gone", func() {
+		expectClaims(claim(driverName, podConsumer("consumer", "uid-1")))
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(v1.Resource("pods"), "consumer"))
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeTrue())
+	})
+
+	It("should leave a reservation unresolved while its Pod is not scheduled", func() {
+		expectClaims(claim(driverName, podConsumer("consumer", "uid-1")))
+		expectPod("consumer", "uid-1", "")
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeTrue())
+	})
+
+	It("should leave a reservation unresolved when the consumer is not a Pod", func() {
+		expectClaims(claim(driverName, resourcev1.ResourceClaimConsumerReference{
+			APIGroup: "apps", Resource: "deployments", Name: "d", UID: "uid-1",
+		}))
+
+		usage, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage.nodes).To(BeEmpty())
+		Expect(usage.unresolved).To(BeTrue())
+	})
+
+	It("should return an error when getting the consumer Pod fails", func() {
+		expectClaims(claim(driverName, podConsumer("consumer", "uid-1")))
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		_, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when listing claims fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any()).Return(fmt.Errorf("some error"))
+
+		_, err := drh.nodesUsingDRADriver(ctx, clnt, mod)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+const targetLabel = "kmm.node.kubernetes.io/namespace.module.some-target"
+
+func labeledNode(name string) v1.Node {
+	return v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{targetLabel: ""}},
+	}
+}
+
+var _ = Describe("allocatedNodeName", func() {
+	nameTerm := func(names ...string) v1.NodeSelectorTerm {
+		return v1.NodeSelectorTerm{MatchFields: []v1.NodeSelectorRequirement{{
+			Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: names,
+		}}}
+	}
+
+	allocatedWith := func(terms ...v1.NodeSelectorTerm) *resourcev1.ResourceClaim {
+		c := &resourcev1.ResourceClaim{}
+		c.Status.Allocation = &resourcev1.AllocationResult{}
+		if terms != nil {
+			c.Status.Allocation.NodeSelector = &v1.NodeSelector{NodeSelectorTerms: terms}
+		}
+		return c
+	}
+
+	DescribeTable("should only name a node every term pins",
+		func(claim *resourcev1.ResourceClaim, expected string) {
+			Expect(allocatedNodeName(claim)).To(Equal(expected))
+		},
+		Entry("one exact term", allocatedWith(nameTerm("node-a")), "node-a"),
+		Entry("two terms naming the same node", allocatedWith(nameTerm("node-a"), nameTerm("node-a")), "node-a"),
+		Entry("two terms naming different nodes", allocatedWith(nameTerm("node-a"), nameTerm("node-b")), ""),
+		Entry("one term naming two nodes", allocatedWith(nameTerm("node-a", "node-b")), ""),
+		Entry("an exact term beside one matching on labels", allocatedWith(nameTerm("node-a"), v1.NodeSelectorTerm{
+			MatchExpressions: []v1.NodeSelectorRequirement{{Key: "zone", Operator: v1.NodeSelectorOpExists}},
+		}), ""),
+		Entry("a term excluding a name", allocatedWith(v1.NodeSelectorTerm{
+			MatchFields: []v1.NodeSelectorRequirement{{
+				Key: "metadata.name", Operator: v1.NodeSelectorOpNotIn, Values: []string{"node-a"},
+			}},
+		}), ""),
+		Entry("one term pinning two different names", allocatedWith(v1.NodeSelectorTerm{
+			MatchFields: []v1.NodeSelectorRequirement{
+				{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{"node-a"}},
+				{Key: "metadata.name", Operator: v1.NodeSelectorOpIn, Values: []string{"node-b"}},
+			},
+		}), ""),
+		Entry("devices available on every node", allocatedWith(), ""),
+		Entry("nothing allocated", &resourcev1.ResourceClaim{}, ""),
+	)
+})
+
+// reconcileTargets drops the target count so the assertions below can stay on the error alone.
+func reconcileTargets(drh *draReconcilerHelper, ctx context.Context, mod *kmmv1beta1.Module,
+	targetLabel string, names ...string) error {
+	_, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New(names...)},
+		drh.newDriverRecheck(ctx, mod))
+	return err
+}
+
+var _ = Describe("draReconcilerHelper_reconcileDRATargetLabel", func() {
+	var (
+		ctrl        *gomock.Controller
+		clnt        *client.MockClient
+		nm          *node.MockNode
+		drh         draReconcilerHelper
+		ctx         context.Context
+		mod         *kmmv1beta1.Module
+		tolerations []v1.Toleration
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		nm = node.NewMockNode(ctrl)
+		ctx = context.Background()
+		drh = draReconcilerHelper{client: clnt, apiReader: clnt, nodeAPI: nm}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "module", UID: "module-uid", Generation: 7},
+			Spec:       kmmv1beta1.ModuleSpec{Selector: map[string]string{"worker": "true"}},
+		}
+		tolerations = module.EffectiveTolerations(mod.Spec.Tolerations)
+	})
+
+	It("should return an error when listing selected nodes fails", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, fmt.Errorf("some error"))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).NotTo(Succeed())
+	})
+
+	It("should return an error when listing labeled nodes fails", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, fmt.Errorf("some error"))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).NotTo(Succeed())
+	})
+
+	It("should add the label to a selected, schedulable node", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(&n, tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, &n, map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should remove the label from a selected but unschedulable node", func() {
+		n := labeledNode("node1")
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).Return(false)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should remove the label from a node the selector no longer matches", func() {
+		stale := labeledNode("stale-node")
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{stale}, nil)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should remove the label from an unselected node even while it is unschedulable", func() {
+		stale := labeledNode("cordoned-stale-node")
+		stale.Spec.Taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{stale}, nil)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should restore the label once a node matches the selector again", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"worker": "true"}}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should put the label back when the node becomes schedulable again", func() {
+		// A cordon followed quickly by an uncordon arrives as two passes over the same node, and
+		// the second has to undo the first. #1333 is the other half of that window, on NMC's side.
+		cordoned := labeledNode("cycled")
+		cordoned.Spec.Taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{cordoned}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{cordoned}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).Return(false)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+
+		uncordoned := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cycled"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{uncordoned}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should not patch any node once the cluster has converged", func() {
+		labeled := labeledNode("labeled-and-selected")
+		unlabeled := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "unlabeled-and-unschedulable"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{labeled, unlabeled}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{labeled}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).DoAndReturn(
+			func(n *v1.Node, _ []v1.Toleration) bool { return n.Name == labeled.Name },
+		).Times(2)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	DescribeTable("should keep the label on a node whose taint does not make it a non-target",
+		func(taint v1.Taint, modTolerations []v1.Toleration) {
+			mod.Spec.Tolerations = modTolerations
+			taintedNode := v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "tainted-node"},
+				Spec:       v1.NodeSpec{Taints: []v1.Taint{taint}},
+			}
+
+			gomock.InOrder(
+				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ any, list *v1.NodeList, _ ...any) error {
+						list.Items = []v1.Node{taintedNode}
+						return nil
+					},
+				),
+				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil),
+				clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, n *v1.Node, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+						Expect(n.Labels).To(HaveKeyWithValue(targetLabel, ""))
+						return nil
+					},
+				),
+			)
+
+			Expect(reconcileTargets(&draReconcilerHelper{nodeAPI: node.NewNode(clnt), client: clnt, apiReader: clnt}, ctx, mod, targetLabel)).To(Succeed())
+		},
+		Entry(
+			"cordoned, but the Module tolerates it",
+			v1.Taint{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule},
+			[]v1.Toleration{{Key: v1.TaintNodeUnschedulable, Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}},
+		),
+		Entry(
+			"under memory pressure, which the module reconciler tolerates internally",
+			v1.Taint{Key: v1.TaintNodeMemoryPressure, Effect: v1.TaintEffectNoSchedule},
+			nil,
+		),
+		Entry(
+			"under disk pressure, which the module reconciler tolerates internally",
+			v1.Taint{Key: v1.TaintNodeDiskPressure, Effect: v1.TaintEffectNoSchedule},
+			nil,
+		),
+		Entry(
+			"under PID pressure, which the module reconciler tolerates internally",
+			v1.Taint{Key: v1.TaintNodePIDPressure, Effect: v1.TaintEffectNoSchedule},
+			nil,
+		),
+	)
+
+	It("should remove the label from a node carrying an untolerated taint", func() {
+		taintedNode := labeledNode("tainted-node")
+		taintedNode.Labels["worker"] = "true"
+		taintedNode.Spec.Taints = []v1.Taint{{Key: "dedicated", Effect: v1.TaintEffectNoSchedule}}
+
+		expectFreshUsage(clnt, mod)
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ any, list *v1.NodeList, _ ...any) error {
+					list.Items = []v1.Node{taintedNode}
+					return nil
+				},
+			),
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, n *v1.Node, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					Expect(n.Labels).NotTo(HaveKey(targetLabel))
+					return nil
+				},
+			),
+		)
+
+		Expect(reconcileTargets(&draReconcilerHelper{nodeAPI: node.NewNode(clnt), client: clnt, apiReader: clnt}, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should normalize a target label whose value is not empty", func() {
+		n := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{targetLabel: "corrupted"}},
+		}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should remove a non-empty target label from a node the selector no longer matches", func() {
+		n := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "stale", Labels: map[string]string{targetLabel: "corrupted"}},
+		}
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should continue processing nodes if one fails and return a combined error", func() {
+		node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+		node2 := labeledNode("node2")
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{node1, node2}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{node2}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), tolerations).DoAndReturn(
+			func(n *v1.Node, _ []v1.Toleration) bool { return n.Name == "node1" },
+		).Times(2)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(fmt.Errorf("conflict"))
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(fmt.Errorf("conflict"))
+
+		err := reconcileTargets(&drh, ctx, mod, targetLabel)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("node1"))
+		Expect(err.Error()).To(ContainSubstring("node2"))
+	})
+})
+
+var _ = Describe("draReconcilerHelper_reconcileDRATargetLabel node deletion race", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		ctx  context.Context
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		ctx = context.Background()
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "module", UID: "module-uid", Generation: 7},
+			Spec:       kmmv1beta1.ModuleSpec{Selector: map[string]string{"worker": "true"}},
+		}
+	})
+
+	// These go through the real node API, so the error wrapping they rely on is covered too.
+	DescribeTable("should not fail the reconciliation when a node disappears mid-flight",
+		func(selected, labeled []v1.Node) {
+			// Only the removal entry reaches the uncached confirmation.
+			clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+				DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+					current := o.(*kmmv1beta1.Module)
+					current.UID = mod.UID
+					current.Generation = mod.Generation
+					return nil
+				}).AnyTimes()
+			clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).
+				Return(nil).AnyTimes()
+
+			gomock.InOrder(
+				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ any, list *v1.NodeList, _ ...any) error {
+						list.Items = selected
+						return nil
+					},
+				),
+				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ any, list *v1.NodeList, _ ...any) error {
+						list.Items = labeled
+						return nil
+					},
+				),
+				clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+					Return(apierrors.NewNotFound(v1.Resource("nodes"), "going-away")),
+			)
+
+			Expect(reconcileTargets(&draReconcilerHelper{nodeAPI: node.NewNode(clnt), client: clnt, apiReader: clnt}, ctx, mod, targetLabel)).To(Succeed())
+		},
+		Entry("while the label is being added",
+			[]v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "going-away"}}},
+			nil,
+		),
+		Entry("while the label is being removed",
+			nil,
+			[]v1.Node{labeledNode("going-away")},
+		),
+	)
+})
+
+var _ = Describe("draReconcilerHelper_ensureDRATargetNodeSelector", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		drh  draReconcilerHelper
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{client: clnt, apiReader: clnt}
+		ctx = context.Background()
+	})
+
+	dsWithSelector := func(name string, selector map[string]string) appsv1.DaemonSet {
+		return appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: appsv1.DaemonSetSpec{
+				Template: v1.PodTemplateSpec{Spec: v1.PodSpec{NodeSelector: selector}},
+			},
+		}
+	}
+
+	It("should add the target selector to every DaemonSet missing it", func() {
+		const (
+			readyLabel   = "kmm.node.kubernetes.io/namespace.module.ready"
+			versionLabel = "beta.kmm.node.kubernetes.io/version-schedule-pod.namespace.module"
+		)
+
+		existing := []appsv1.DaemonSet{
+			dsWithSelector("old-version", map[string]string{readyLabel: "", versionLabel: "1"}),
+			dsWithSelector("current-version", map[string]string{readyLabel: "", versionLabel: "2"}),
+		}
+
+		patched := make(map[string]map[string]string)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ds *appsv1.DaemonSet, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				patched[ds.Name] = ds.Spec.Template.Spec.NodeSelector
+				return nil
+			},
+		).Times(2)
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(selErr).To(Succeed())
+
+		Expect(patched).To(Equal(map[string]map[string]string{
+			"old-version":     {readyLabel: "", versionLabel: "1", targetLabel: ""},
+			"current-version": {readyLabel: "", versionLabel: "2", targetLabel: ""},
+		}))
+	})
+
+	It("should populate an empty node selector", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ds *appsv1.DaemonSet, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				Expect(ds.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{targetLabel: ""}))
+				return nil
+			},
+		)
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, []appsv1.DaemonSet{dsWithSelector("no-selector", nil)}, targetLabel, false)
+		Expect(selErr).To(Succeed())
+	})
+
+	It("should normalize a target selector whose value is not empty", func() {
+		// A replace, so that the key going away in the meantime fails the patch rather than
+		// quietly performing the migration the claims may be holding back.
+		existing := []appsv1.DaemonSet{dsWithSelector("corrupted", map[string]string{targetLabel: "wrong"})}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, ds *appsv1.DaemonSet, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				Expect(p.Type()).To(Equal(types.JSONPatchType))
+				data, err := p.Data(ds)
+				Expect(err).NotTo(HaveOccurred())
+				// The guard, not just the write: a bare replace is accepted for a key that has gone.
+				Expect(string(data)).To(ContainSubstring(`"op":"test"`))
+				Expect(string(data)).To(ContainSubstring(`"value":"wrong"`))
+				Expect(string(data)).To(ContainSubstring(jsonPointerEscape(targetLabel)))
+				return nil
+			},
+		)
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(selErr).To(Succeed())
+	})
+
+	It("should come back rather than fail when the selector changed under the correction", func() {
+		existing := []appsv1.DaemonSet{dsWithSelector("corrupted", map[string]string{targetLabel: "wrong"})}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewInvalid(schema.GroupKind{Kind: "DaemonSet"}, "corrupted", nil))
+		expectMovedSelector(clnt, targetLabel, "moved")
+
+		retry, err := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(retry).To(BeTrue())
+	})
+
+	It("should fail when a guarded correction is rejected for another reason", func() {
+		// 422 also carries ordinary validation, and the tested value is still in place.
+		existing := []appsv1.DaemonSet{dsWithSelector("corrupted", map[string]string{targetLabel: "wrong"})}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewInvalid(schema.GroupKind{Kind: "DaemonSet"}, "corrupted", nil))
+		expectMovedSelector(clnt, targetLabel, "wrong")
+
+		retry, err := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(err).To(HaveOccurred())
+		Expect(retry).To(BeFalse())
+	})
+
+	It("should fail rather than retry when the migration patch is rejected", func() {
+		existing := []appsv1.DaemonSet{dsWithSelector("legacy", nil)}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewInvalid(schema.GroupKind{Kind: "DaemonSet"}, "legacy", nil))
+
+		retry, err := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(err).To(HaveOccurred())
+		Expect(retry).To(BeFalse())
+	})
+
+	It("should skip a DaemonSet that is already being deleted", func() {
+		ds := dsWithSelector("going-away", nil)
+		ds.SetDeletionTimestamp(&metav1.Time{})
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, []appsv1.DaemonSet{ds}, targetLabel, false)
+		Expect(selErr).To(Succeed())
+	})
+
+	It("should not fail when a DaemonSet disappears mid-flight", func() {
+		existing := []appsv1.DaemonSet{dsWithSelector("going-away", nil)}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(appsv1.Resource("daemonsets"), "going-away"))
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(selErr).To(Succeed())
+	})
+
+	It("should not patch a DaemonSet that already has the target selector", func() {
+		existing := []appsv1.DaemonSet{dsWithSelector("already-migrated", map[string]string{targetLabel: ""})}
+
+		_, selErr := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(selErr).To(Succeed())
+	})
+
+	It("should keep going and aggregate errors when a patch fails", func() {
+		existing := []appsv1.DaemonSet{dsWithSelector("first", nil), dsWithSelector("second", nil)}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
+		_, err := drh.ensureDRATargetNodeSelector(ctx, existing, targetLabel, false)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("first"))
+		Expect(err.Error()).NotTo(ContainSubstring("second"))
+	})
+})
+
+var _ = Describe("draReconcilerHelper_reconcileDRATargetLabel in-use override", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		nm   *node.MockNode
+		drh  draReconcilerHelper
+		ctx  context.Context
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		nm = node.NewMockNode(ctrl)
+		ctx = context.Background()
+		drh = draReconcilerHelper{client: clnt, apiReader: clnt, nodeAPI: nm}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "module", UID: "module-uid", Generation: 7},
+			Spec:       kmmv1beta1.ModuleSpec{Selector: map[string]string{"worker": "true"}},
+		}
+	})
+
+	It("should keep the label on a cordoned node that is still in use", func() {
+		n := labeledNode("cordoned-but-in-use")
+		n.Spec.Taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(false)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel, n.Name)).To(Succeed())
+	})
+
+	It("should keep the label on a node the selector no longer matches while it is still in use", func() {
+		n := labeledNode("unselected-but-in-use")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel, n.Name)).To(Succeed())
+	})
+
+	It("should add the label back to an in-use node that has lost it", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "in-use-unlabeled"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel, n.Name)).To(Succeed())
+	})
+
+	It("should add the label back to an in-use node that neither list returns", func() {
+		// Narrowing the selector after the label was already lost leaves the node out of both
+		// lists, so it has to be fetched by name for its label to come back.
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "in-use-only"}, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ ctrlclient.ObjectKey, obj ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				obj.SetName("in-use-only")
+				return nil
+			},
+		)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel, "in-use-only")).To(Succeed())
+	})
+
+	It("should keep a label the cache cannot yet prove is unused", func() {
+		// The claim informer can lag a Node event, and re-adding the label later would not call
+		// back a Pod deletion the DaemonSet controller has already started.
+		mod.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "gpu.example.com"}
+		n := labeledNode("stale-cache")
+
+		expectFreshModule(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				list.Items = []resourcev1.ResourceClaim{reservedClaimOn("gpu.example.com", "stale-cache")}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should keep every label while a reservation cannot be placed on a node", func() {
+		mod.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "gpu.example.com"}
+		n := labeledNode("unresolved")
+
+		expectFreshModule(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).DoAndReturn(
+			func(_ context.Context, list *resourcev1.ResourceClaimList, _ ...ctrlclient.ListOption) error {
+				c := reservedClaimOn("gpu.example.com", "")
+				list.Items = []resourcev1.ResourceClaim{c}
+				return nil
+			},
+		)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&v1.Pod{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "consumer"))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should keep the label when the uncached confirmation fails", func() {
+		mod.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "gpu.example.com"}
+		// Two candidates, so a failure that is not remembered would list the claims twice.
+		first := labeledNode("unconfirmed-a")
+		second := labeledNode("unconfirmed-b")
+
+		expectFreshModule(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{first, second}, nil)
+		clnt.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&resourcev1.ResourceClaimList{})).
+			Return(fmt.Errorf("some error")).Times(1)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).NotTo(Succeed())
+	})
+
+	It("should ignore an in-use node that no longer exists", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "gone"}, gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "gone"))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel, "gone")).To(Succeed())
+	})
+
+	It("should keep every label when the Module changed under the pass", func() {
+		// A selector or toleration this pass never saw can make the node eligible again.
+		n := labeledNode("stale-module")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				current := o.(*kmmv1beta1.Module)
+				current.UID = mod.UID
+				current.Generation = mod.Generation + 1
+				return nil
+			})
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should keep every label once the Module has entered deletion", func() {
+		// Deletion leaves the generation alone, so the comparison has to look at it separately.
+		n := labeledNode("deleting-module")
+		now := metav1.Now()
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				current := o.(*kmmv1beta1.Module)
+				current.UID, current.Generation = mod.UID, mod.Generation
+				current.DeletionTimestamp = &now
+				return nil
+			})
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New[string]()},
+			drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.stale).To(BeTrue())
+	})
+
+	It("should keep every label when the Module was replaced under the pass", func() {
+		n := labeledNode("recreated-module")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			DoAndReturn(func(_ context.Context, _ types.NamespacedName, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				current := o.(*kmmv1beta1.Module)
+				current.UID = "another-uid"
+				current.Generation = mod.Generation
+				return nil
+			})
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
+	})
+
+	It("should keep every label when the Module cannot be re-read", func() {
+		// Two candidates, so a failure that is not remembered would re-read the Module twice.
+		first := labeledNode("unread-a")
+		second := labeledNode("unread-b")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{first, second}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			Return(fmt.Errorf("some error")).Times(1)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).NotTo(Succeed())
+	})
+
+	It("should stop the pass when the Module is gone by the time it is re-read", func() {
+		// Deletion has its own branch, so NotFound here means the object went away mid-pass and the
+		// error is what stops the rest of the reconcile.
+		n := labeledNode("orphaned")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(&kmmv1beta1.Module{})).
+			Return(apierrors.NewNotFound(schema.GroupResource{Resource: "modules"}, mod.Name))
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).NotTo(Succeed())
+	})
+
+	It("should leave the driver alone when the node changed since it was read", func() {
+		// The node may have been uncordoned between the list and the patch, and the DaemonSet
+		// controller does not put back a Pod it has already been told to delete.
+		n := labeledNode("raced")
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).
+			Return(apierrors.NewConflict(v1.Resource("nodes"), n.Name, fmt.Errorf("modified")))
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New[string]()}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).NotTo(BeZero())
+		Expect(result.targeted).To(Equal(1))
+	})
+
+	It("should ask to be woken again while a reservation cannot be placed", func() {
+		// A Pod binding is what settles this, and nothing here watches Pods.
+		n := labeledNode("held")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true)
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{
+			nodes: sets.New[string](), unresolved: true,
+		}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should ask to be woken again for a cordoned node the claim is holding", func() {
+		// The node the whole feature exists for: still selected, no longer schedulable, and kept
+		// only because a claim is reserved on it.
+		n := labeledNode("cordoned-in-use")
+		n.Spec.Taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New(n.Name)}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.targeted).To(Equal(1))
+		Expect(result.requeueAfter).NotTo(BeZero())
+	})
+
+	It("should ask to be woken again while a node is held only by a claim", func() {
+		// The release comes from a ResourceClaim event, and one lost mapper list would strand it.
+		n := labeledNode("claim-only")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New(n.Name)}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).NotTo(BeZero())
+		Expect(result.targeted).To(Equal(1))
+	})
+
+	It("should not ask to be woken again once the cluster has converged", func() {
+		n := labeledNode("settled")
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true)
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New[string]()}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.requeueAfter).To(BeZero())
+	})
+
+	It("should leave a node deleted while being labeled out of the desired count", func() {
+		n := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "vanishing"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return(nil, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).
+			Return(apierrors.NewNotFound(v1.Resource("nodes"), n.Name))
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New[string]()}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.targeted).To(BeZero())
+	})
+
+	It("should count a node it labels and one that already carries the label", func() {
+		labeled := labeledNode("already")
+		fresh := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "newly"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{labeled, fresh}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{labeled}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true).Times(2)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		result, err := drh.reconcileDRATargetLabel(ctx, mod, targetLabel, driverUsage{nodes: sets.New[string]()}, drh.newDriverRecheck(ctx, mod))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.targeted).To(Equal(2))
+	})
+
+	It("should drop the label once the node stops being in use", func() {
+		n := labeledNode("no-longer-in-use")
+		n.Spec.Taints = []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}
+
+		expectFreshUsage(clnt, mod)
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+		nm.EXPECT().GetAllNodesByLabelKey(ctx, targetLabel).Return([]v1.Node{n}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(false)
+		nm.EXPECT().UpdateLabelsWithOptimisticLock(ctx, gomock.Any(), nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		Expect(reconcileTargets(&drh, ctx, mod, targetLabel)).To(Succeed())
 	})
 })

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -55,6 +55,21 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) clearDRAStatus(ctx, mod any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "clearDRAStatus", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).clearDRAStatus), ctx, mod)
 }
 
+// confirmCurrentModule mocks base method.
+func (m *MockdraReconcilerHelperAPI) confirmCurrentModule(ctx context.Context, mod *v1beta1.Module) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "confirmCurrentModule", ctx, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// confirmCurrentModule indicates an expected call of confirmCurrentModule.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) confirmCurrentModule(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "confirmCurrentModule", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).confirmCurrentModule), ctx, mod)
+}
+
 // deleteDRAResources mocks base method.
 func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
 	m.ctrl.T.Helper()
@@ -127,6 +142,21 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRA(ctx, mod, existingDR
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRA", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRA), ctx, mod, existingDRADS)
 }
 
+// handleDRATargetLabels mocks base method.
+func (m *MockdraReconcilerHelperAPI) handleDRATargetLabels(ctx context.Context, mod *v1beta1.Module, existingDRADS []v1.DaemonSet) (draTargetResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDRATargetLabels", ctx, mod, existingDRADS)
+	ret0, _ := ret[0].(draTargetResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// handleDRATargetLabels indicates an expected call of handleDRATargetLabels.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRATargetLabels(ctx, mod, existingDRADS any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRATargetLabels", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRATargetLabels), ctx, mod, existingDRADS)
+}
+
 // handleDeviceClasses mocks base method.
 func (m *MockdraReconcilerHelperAPI) handleDeviceClasses(ctx context.Context, mod *v1beta1.Module, existingDCs []v10.DeviceClass) error {
 	m.ctrl.T.Helper()
@@ -142,17 +172,31 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDeviceClasses(ctx, mod, 
 }
 
 // moduleUpdateDRAStatus mocks base method.
-func (m *MockdraReconcilerHelperAPI) moduleUpdateDRAStatus(ctx context.Context, mod *v1beta1.Module, existingDRADS []v1.DaemonSet) error {
+func (m *MockdraReconcilerHelperAPI) moduleUpdateDRAStatus(ctx context.Context, mod *v1beta1.Module, existingDRADS []v1.DaemonSet, targetedNodes int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "moduleUpdateDRAStatus", ctx, mod, existingDRADS)
+	ret := m.ctrl.Call(m, "moduleUpdateDRAStatus", ctx, mod, existingDRADS, targetedNodes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // moduleUpdateDRAStatus indicates an expected call of moduleUpdateDRAStatus.
-func (mr *MockdraReconcilerHelperAPIMockRecorder) moduleUpdateDRAStatus(ctx, mod, existingDRADS any) *gomock.Call {
+func (mr *MockdraReconcilerHelperAPIMockRecorder) moduleUpdateDRAStatus(ctx, mod, existingDRADS, targetedNodes any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "moduleUpdateDRAStatus", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).moduleUpdateDRAStatus), ctx, mod, existingDRADS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "moduleUpdateDRAStatus", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).moduleUpdateDRAStatus), ctx, mod, existingDRADS, targetedNodes)
+}
+
+// removeDRATargetLabels mocks base method.
+func (m *MockdraReconcilerHelperAPI) removeDRATargetLabels(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "removeDRATargetLabels", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// removeDRATargetLabels indicates an expected call of removeDRATargetLabels.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) removeDRATargetLabels(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeDRATargetLabels", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).removeDRATargetLabels), ctx, mod)
 }
 
 // MockdraDaemonSetCreator is a mock of draDaemonSetCreator interface.

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -52,6 +52,8 @@ import (
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=preflightvalidations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=preflightvalidations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=create;delete;deletecollection;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 const (
 	ModuleReconcilerName = "ModuleReconciler"

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/util/podutils"
@@ -206,6 +207,34 @@ func DevicePluginReconcilerNodePredicate() predicate.Predicate {
 	)
 }
 
+// DRAReconcilerNodePredicate matches the node events the DRA reconciler acts on: creations, taint
+// changes, and label changes. Label changes matter because a node that stops matching a Module's
+// selector has to lose its dra-target label.
+func DRAReconcilerNodePredicate() predicate.Predicate {
+	return predicate.And(
+		skipDeletions,
+		predicate.Or(nodeTaintsChanged, predicate.LabelChangedPredicate{}),
+	)
+}
+
+// ResourceClaimUsageChanged drops the ResourceClaim updates that cannot change whether a node still
+// needs its DRA driver, keeping the ones where the allocation appears or names different devices or
+// the set of consumers changes. Creations and deletions always pass: both change which claims exist.
+func ResourceClaimUsageChanged() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldClaim, okOld := e.ObjectOld.(*resourcev1.ResourceClaim)
+			newClaim, okNew := e.ObjectNew.(*resourcev1.ResourceClaim)
+			if !okOld || !okNew {
+				return false
+			}
+
+			return !reflect.DeepEqual(oldClaim.Status.Allocation, newClaim.Status.Allocation) ||
+				!reflect.DeepEqual(oldClaim.Status.ReservedFor, newClaim.Status.ReservedFor)
+		},
+	}
+}
+
 func ModuleReconcilePodPredicate() predicate.Predicate {
 	return predicate.And(
 		skipDeletions,
@@ -278,6 +307,98 @@ func (f *Filter) FindModulesForNode(ctx context.Context, node client.Object) []r
 
 	logger.Info("Adding reconciliation requests", "count", len(reqs))
 	logger.V(1).Info("New requests", "requests", reqs)
+
+	return reqs
+}
+
+// FindDRAModulesForNode enqueues the Modules whose selector matches the node and those still owning
+// a dra-target label on it, so a node that stopped matching still gets its stale label cleaned up.
+func (f *Filter) FindDRAModulesForNode(ctx context.Context, node client.Object) []reconcile.Request {
+	logger := ctrl.LoggerFrom(ctx).WithValues("node", node.GetName())
+
+	reqSet := sets.New[reconcile.Request]()
+
+	// A dra-target label names the Module that owns it, so these do not need a Module list and are
+	// found even when the Module no longer selects this node.
+	for label := range node.GetLabels() {
+		if ok, ns, name := utils.IsDRATargetNodeLabel(label); ok {
+			reqSet.Insert(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ns, Name: name}})
+		}
+	}
+
+	mods := kmmv1beta1.ModuleList{}
+
+	if err := f.client.List(ctx, &mods); err != nil {
+		logger.Error(err, "could not list modules")
+		return reqSet.UnsortedList()
+	}
+
+	for i := range mods.Items {
+		mod := &mods.Items[i]
+
+		if mod.Spec.DRA == nil {
+			continue
+		}
+
+		selected, err := utils.IsObjectSelectedByLabels(node.GetLabels(), mod.Spec.Selector)
+		if err != nil {
+			logger.Error(err, "could not determine if node is selected by module", "module", mod.Name)
+			continue
+		}
+
+		if !selected {
+			continue
+		}
+
+		reqSet.Insert(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: mod.Namespace, Name: mod.Name}})
+	}
+
+	reqs := reqSet.UnsortedList()
+
+	logger.Info("Adding reconciliation requests", "count", len(reqs))
+	logger.V(1).Info("New requests", "requests", reqs)
+
+	return reqs
+}
+
+// FindDRAModulesForResourceClaim enqueues the Modules whose DRA driver this claim was allocated
+// from. Without it nothing would notice the last consumer on a node letting go, and the driver
+// would be held there indefinitely.
+func (f *Filter) FindDRAModulesForResourceClaim(ctx context.Context, obj client.Object) []reconcile.Request {
+	claim, ok := obj.(*resourcev1.ResourceClaim)
+	if !ok || claim.Status.Allocation == nil {
+		return nil
+	}
+
+	logger := ctrl.LoggerFrom(ctx).WithValues("resourceclaim", claim.Name)
+
+	drivers := sets.New[string]()
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		drivers.Insert(result.Driver)
+	}
+
+	if drivers.Len() == 0 {
+		return nil
+	}
+
+	mods := kmmv1beta1.ModuleList{}
+	if err := f.client.List(ctx, &mods); err != nil {
+		logger.Error(err, "could not list modules")
+		return nil
+	}
+
+	reqs := make([]reconcile.Request, 0)
+	for i := range mods.Items {
+		mod := &mods.Items[i]
+
+		if mod.Spec.DRA == nil || !drivers.Has(mod.Spec.DRA.DriverName) {
+			continue
+		}
+
+		reqs = append(reqs, reconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: mod.Namespace, Name: mod.Name},
+		})
+	}
 
 	return reqs
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -10,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -355,6 +357,81 @@ var _ = Describe("ModuleReconcilerNodePredicate", func() {
 	})
 })
 
+var _ = Describe("DRAReconcilerNodePredicate", func() {
+	It("should return true for creations", func() {
+		ev := event.CreateEvent{
+			Object: &v1.Node{},
+		}
+
+		Expect(
+			DRAReconcilerNodePredicate().Create(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true when taints change", func() {
+		ev := event.UpdateEvent{
+			ObjectOld: &v1.Node{},
+			ObjectNew: &v1.Node{
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}},
+				},
+			},
+		}
+
+		Expect(
+			DRAReconcilerNodePredicate().Update(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true when labels change", func() {
+		ev := event.UpdateEvent{
+			ObjectOld: &v1.Node{},
+			ObjectNew: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"some label": "some value"},
+				},
+			},
+		}
+
+		Expect(
+			DRAReconcilerNodePredicate().Update(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return false when neither taints nor labels change", func() {
+		ev := event.UpdateEvent{
+			ObjectOld: &v1.Node{},
+			ObjectNew: &v1.Node{
+				Status: v1.NodeStatus{NodeInfo: v1.NodeSystemInfo{KernelVersion: "6.1.0"}},
+			},
+		}
+
+		Expect(
+			DRAReconcilerNodePredicate().Update(ev),
+		).To(
+			BeFalse(),
+		)
+	})
+
+	It("should return false for deletions", func() {
+		ev := event.DeleteEvent{
+			Object: &v1.Node{},
+		}
+
+		Expect(
+			DRAReconcilerNodePredicate().Delete(ev),
+		).To(
+			BeFalse(),
+		)
+	})
+})
+
 var _ = Describe("NodeUpdateKernelChangedPredicate", func() {
 	updateFunc := NodeUpdateKernelChangedPredicate().Update
 
@@ -460,6 +537,219 @@ var _ = Describe("FindModulesForNode", func() {
 
 		reqs := f.FindModulesForNode(ctx, &node)
 		Expect(reqs).To(Equal([]reconcile.Request{expectedReq}))
+	})
+})
+
+var _ = Describe("FindDRAModulesForNode", func() {
+	const (
+		modName   = "dra-module"
+		modNS     = "some-namespace"
+		draTarget = "kmm.node.kubernetes.io/some-namespace.dra-module.dra-target"
+	)
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		clnt = mockClient.NewMockClient(mockCtrl)
+		f = New(clnt, nil)
+	})
+
+	ctx := context.Background()
+
+	draModule := func(selector map[string]string) kmmv1beta1.Module {
+		return kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: modName, Namespace: modNS},
+			Spec: kmmv1beta1.ModuleSpec{
+				Selector: selector,
+				DRA:      &kmmv1beta1.DRASpec{},
+			},
+		}
+	}
+
+	expectModules := func(mods ...kmmv1beta1.Module) {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *kmmv1beta1.ModuleList, _ ...interface{}) error {
+				list.Items = mods
+				return nil
+			},
+		)
+	}
+
+	It("should return the module selecting the node", func() {
+		expectModules(draModule(map[string]string{"worker": "true"}))
+
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"worker": "true"}}}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: modNS, Name: modName}},
+		))
+	})
+
+	It("should ignore modules without a DRA spec", func() {
+		mod := draModule(map[string]string{"worker": "true"})
+		mod.Spec.DRA = nil
+		expectModules(mod)
+
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"worker": "true"}}}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(BeEmpty())
+	})
+
+	It("should return the module owning a target label even when its selector no longer matches", func() {
+		expectModules(draModule(map[string]string{"worker": "true"}))
+
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{draTarget: ""}}}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: modNS, Name: modName}},
+		))
+	})
+
+	It("should not return a module twice when it both selects the node and owns its label", func() {
+		expectModules(draModule(map[string]string{"worker": "true"}))
+
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"worker": "true", draTarget: ""}},
+		}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(HaveLen(1))
+	})
+
+	It("should keep processing modules after one with an invalid selector", func() {
+		bad := draModule(map[string]string{"$invalid key": "value"})
+		bad.Name = "bad-module"
+		expectModules(bad, draModule(map[string]string{"worker": "true"}))
+
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"worker": "true"}}}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: modNS, Name: modName}},
+		))
+	})
+
+	It("should still return label owners when listing modules fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{draTarget: ""}}}
+
+		Expect(f.FindDRAModulesForNode(ctx, &node)).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: modNS, Name: modName}},
+		))
+	})
+})
+
+var _ = Describe("FindDRAModulesForResourceClaim", func() {
+	const driverName = "gpu.example.com"
+
+	BeforeEach(func() {
+		mockCtrl = gomock.NewController(GinkgoT())
+		clnt = mockClient.NewMockClient(mockCtrl)
+		f = New(clnt, nil)
+	})
+
+	ctx := context.Background()
+
+	allocated := func(driver string) *resourcev1.ResourceClaim {
+		return &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "workloads"},
+			Status: resourcev1.ResourceClaimStatus{
+				Allocation: &resourcev1.AllocationResult{
+					Devices: resourcev1.DeviceAllocationResult{
+						Results: []resourcev1.DeviceRequestAllocationResult{{Driver: driver}},
+					},
+				},
+			},
+		}
+	}
+
+	expectModules := func(mods ...kmmv1beta1.Module) {
+		clnt.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *kmmv1beta1.ModuleList, _ ...interface{}) error {
+				list.Items = mods
+				return nil
+			},
+		)
+	}
+
+	draModule := func(name, driver string) kmmv1beta1.Module {
+		return kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{DriverName: driver}},
+		}
+	}
+
+	It("should return nothing for an unallocated claim", func() {
+		Expect(f.FindDRAModulesForResourceClaim(ctx, &resourcev1.ResourceClaim{})).To(BeEmpty())
+	})
+
+	It("should return nothing when the allocation names no driver", func() {
+		claim := &resourcev1.ResourceClaim{}
+		claim.Status.Allocation = &resourcev1.AllocationResult{}
+
+		Expect(f.FindDRAModulesForResourceClaim(ctx, claim)).To(BeEmpty())
+	})
+
+	It("should return nothing for a non-claim object", func() {
+		Expect(f.FindDRAModulesForResourceClaim(ctx, &v1.Node{})).To(BeEmpty())
+	})
+
+	It("should enqueue the Module owning the driver the claim was allocated from", func() {
+		expectModules(draModule("mine", driverName), draModule("theirs", "other.example.com"))
+
+		Expect(f.FindDRAModulesForResourceClaim(ctx, allocated(driverName))).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "mine"}},
+		))
+	})
+
+	It("should ignore Modules without a DRA spec", func() {
+		mod := draModule("no-dra", driverName)
+		mod.Spec.DRA = nil
+		expectModules(mod)
+
+		Expect(f.FindDRAModulesForResourceClaim(ctx, allocated(driverName))).To(BeEmpty())
+	})
+
+	It("should return nothing when listing modules fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any()).Return(errors.New("some error"))
+
+		Expect(f.FindDRAModulesForResourceClaim(ctx, allocated(driverName))).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ResourceClaimUsageChanged", func() {
+	p := ResourceClaimUsageChanged()
+
+	withReservation := func(name string) *resourcev1.ResourceClaim {
+		c := &resourcev1.ResourceClaim{}
+		if name != "" {
+			c.Status.ReservedFor = []resourcev1.ResourceClaimConsumerReference{{Resource: "pods", Name: name}}
+		}
+		return c
+	}
+
+	It("should return true when the reservation set changes", func() {
+		ev := event.UpdateEvent{ObjectOld: withReservation("consumer"), ObjectNew: withReservation("")}
+		Expect(p.Update(ev)).To(BeTrue())
+	})
+
+	It("should return true when the allocation appears", func() {
+		newClaim := &resourcev1.ResourceClaim{}
+		newClaim.Status.Allocation = &resourcev1.AllocationResult{}
+		ev := event.UpdateEvent{ObjectOld: &resourcev1.ResourceClaim{}, ObjectNew: newClaim}
+		Expect(p.Update(ev)).To(BeTrue())
+	})
+
+	It("should return false for objects that are not ResourceClaims", func() {
+		ev := event.UpdateEvent{ObjectOld: &v1.Node{}, ObjectNew: &v1.Node{}}
+		Expect(p.Update(ev)).To(BeFalse())
+	})
+
+	It("should return false when neither changes", func() {
+		ev := event.UpdateEvent{ObjectOld: withReservation("consumer"), ObjectNew: withReservation("consumer")}
+		Expect(p.Update(ev)).To(BeFalse())
+	})
+
+	It("should return true for deletions, which release the claim", func() {
+		Expect(p.Delete(event.DeleteEvent{Object: &resourcev1.ResourceClaim{}})).To(BeTrue())
 	})
 })
 

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -25,6 +25,15 @@ var InternalTolerations = []v1.Toleration{
 	},
 }
 
+// EffectiveTolerations returns the tolerations KMM uses to decide whether a node is a target of a
+// Module: the ones the user declared, plus the pressure taints KMM always tolerates. It always
+// returns a new slice, so the Module's own tolerations are never appended to in place.
+func EffectiveTolerations(userTolerations []v1.Toleration) []v1.Toleration {
+	tolerations := make([]v1.Toleration, 0, len(userTolerations)+len(InternalTolerations))
+	tolerations = append(tolerations, userTolerations...)
+	return append(tolerations, InternalTolerations...)
+}
+
 // AppendToTag adds the specified tag to the image name cleanly, i.e. by avoiding messing up
 // the name or getting "name:-tag"
 func AppendToTag(name string, tag string) string {

--- a/internal/module/helper_test.go
+++ b/internal/module/helper_test.go
@@ -3,6 +3,7 @@ package module
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("AppendToTag", func() {
@@ -26,5 +27,35 @@ var _ = Describe("AppendToTag", func() {
 		).To(
 			Equal(name + "_" + tag),
 		)
+	})
+})
+
+var _ = Describe("EffectiveTolerations", func() {
+	It("should append the internal tolerations to the user's", func() {
+		userToleration := v1.Toleration{
+			Key:      v1.TaintNodeUnschedulable,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		}
+
+		res := EffectiveTolerations([]v1.Toleration{userToleration})
+
+		Expect(res).To(HaveLen(1 + len(InternalTolerations)))
+		Expect(res[0]).To(Equal(userToleration))
+		Expect(res).To(ContainElements(InternalTolerations))
+	})
+
+	It("should work with no user tolerations", func() {
+		Expect(EffectiveTolerations(nil)).To(Equal(InternalTolerations))
+	})
+
+	It("should not write into the slice it is given", func() {
+		userTolerations := make([]v1.Toleration, 1, 8)
+		userTolerations[0] = v1.Toleration{Key: "dedicated"}
+
+		_ = EffectiveTolerations(userTolerations)
+
+		Expect(userTolerations).To(HaveLen(1))
+		Expect(userTolerations[:cap(userTolerations)][1]).To(Equal(v1.Toleration{}))
 	})
 })

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -39,6 +39,21 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 	return m.recorder
 }
 
+// GetAllNodesByLabelKey mocks base method.
+func (m *MockNode) GetAllNodesByLabelKey(ctx context.Context, labelKey string) ([]v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllNodesByLabelKey", ctx, labelKey)
+	ret0, _ := ret[0].([]v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllNodesByLabelKey indicates an expected call of GetAllNodesByLabelKey.
+func (mr *MockNodeMockRecorder) GetAllNodesByLabelKey(ctx, labelKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllNodesByLabelKey", reflect.TypeOf((*MockNode)(nil).GetAllNodesByLabelKey), ctx, labelKey)
+}
+
 // GetAllNodesBySelector mocks base method.
 func (m *MockNode) GetAllNodesBySelector(ctx context.Context, selector map[string]string) ([]v1.Node, error) {
 	m.ctrl.T.Helper()
@@ -124,4 +139,18 @@ func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, t
 func (mr *MockNodeMockRecorder) UpdateLabels(ctx, node, toBeAdded, toBeRemoved any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabels", reflect.TypeOf((*MockNode)(nil).UpdateLabels), ctx, node, toBeAdded, toBeRemoved)
+}
+
+// UpdateLabelsWithOptimisticLock mocks base method.
+func (m *MockNode) UpdateLabelsWithOptimisticLock(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLabelsWithOptimisticLock", ctx, node, toBeAdded, toBeRemoved)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateLabelsWithOptimisticLock indicates an expected call of UpdateLabelsWithOptimisticLock.
+func (mr *MockNodeMockRecorder) UpdateLabelsWithOptimisticLock(ctx, node, toBeAdded, toBeRemoved any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabelsWithOptimisticLock", reflect.TypeOf((*MockNode)(nil).UpdateLabelsWithOptimisticLock), ctx, node, toBeAdded, toBeRemoved)
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -15,9 +15,11 @@ import (
 type Node interface {
 	IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool
 	GetAllNodesBySelector(ctx context.Context, selector map[string]string) ([]v1.Node, error)
+	GetAllNodesByLabelKey(ctx context.Context, labelKey string) ([]v1.Node, error)
 	GetSchedulableNodesBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
 	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error
+	UpdateLabelsWithOptimisticLock(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error
 	IsNodeRebooted(node *v1.Node, statusBootId string) bool
 }
 
@@ -59,6 +61,19 @@ func (n *node) GetAllNodesBySelector(ctx context.Context, selector map[string]st
 	return selectedNodes.Items, nil
 }
 
+// GetAllNodesByLabelKey lists the nodes carrying labelKey whatever its value, unlike
+// GetAllNodesBySelector, which matches on the value too.
+func (n *node) GetAllNodesByLabelKey(ctx context.Context, labelKey string) ([]v1.Node, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Listing nodes", "label key", labelKey)
+
+	selectedNodes := v1.NodeList{}
+	if err := n.client.List(ctx, &selectedNodes, client.HasLabels{labelKey}); err != nil {
+		return nil, fmt.Errorf("could not list nodes: %v", err)
+	}
+	return selectedNodes.Items, nil
+}
+
 func (n *node) GetSchedulableNodesBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error) {
 	allNodes, err := n.GetAllNodesBySelector(ctx, selector)
 	if err != nil {
@@ -83,13 +98,28 @@ func (n *node) GetNumTargetedNodes(ctx context.Context, selector map[string]stri
 }
 
 func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
-	patchFrom := client.MergeFrom(node.DeepCopy())
+	return n.patchLabels(ctx, node, toBeAdded, toBeRemoved, client.MergeFrom(node.DeepCopy()))
+}
 
+// UpdateLabelsWithOptimisticLock is UpdateLabels for a caller whose decision would be wrong if the
+// node had changed since it was read: the patch then fails with a conflict instead of landing.
+func (n *node) UpdateLabelsWithOptimisticLock(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
+	patchFrom := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
+
+	return n.patchLabels(ctx, node, toBeAdded, toBeRemoved, patchFrom)
+}
+
+func (n *node) patchLabels(
+	ctx context.Context,
+	node *v1.Node,
+	toBeAdded, toBeRemoved map[string]string,
+	patchFrom client.Patch,
+) error {
 	addLabels(node, toBeAdded)
 	removeLabels(node, toBeRemoved)
 
 	if err := n.client.Patch(ctx, node, patchFrom); err != nil {
-		return fmt.Errorf("could not patch node: %v", err)
+		return fmt.Errorf("could not patch node: %w", err)
 	}
 	return nil
 }

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -2,13 +2,16 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("IsNodeSchedulable", func() {
@@ -226,6 +229,67 @@ var _ = Describe("UpdateLabels", func() {
 		n = NewNode(clnt)
 	})
 
+	It("Should return an error callers can inspect", func() {
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(k8serrors.NewNotFound(v1.Resource("nodes"), node.Name))
+
+		err := n.UpdateLabels(ctx, &node, map[string]string{"label": ""}, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	// The lock is what makes the patch fail rather than land when the node moved on, so what is
+	// checked is that the resourceVersion actually reaches the API server.
+	It("Should send the resourceVersion when the caller asks for a lock", func() {
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "42",
+				Labels: map[string]string{"label": ""}},
+		}
+		var data []byte
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				var err error
+				data, err = p.Data(o)
+				return err
+			},
+		)
+
+		Expect(n.UpdateLabelsWithOptimisticLock(ctx, &node, nil, map[string]string{"label": ""})).To(Succeed())
+		Expect(string(data)).To(ContainSubstring(`"resourceVersion":"42"`))
+	})
+
+	It("Should not send the resourceVersion without a lock", func() {
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1", ResourceVersion: "42",
+				Labels: map[string]string{"label": ""}},
+		}
+		var data []byte
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				var err error
+				data, err = p.Data(o)
+				return err
+			},
+		)
+
+		Expect(n.UpdateLabels(ctx, &node, nil, map[string]string{"label": ""})).To(Succeed())
+		Expect(string(data)).NotTo(ContainSubstring("resourceVersion"))
+	})
+
+	It("Should let a caller inspect a conflict from a locked patch", func() {
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(k8serrors.NewConflict(v1.Resource("nodes"), node.Name, fmt.Errorf("modified")))
+
+		err := n.UpdateLabelsWithOptimisticLock(ctx, &node, nil, map[string]string{"label": ""})
+		Expect(k8serrors.IsConflict(err)).To(BeTrue())
+	})
+
 	It("Should work as expected", func() {
 		node := v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -378,5 +442,47 @@ var _ = Describe("removeLabels", func() {
 		labels := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
 		removeLabels(&node, labels)
 		Expect(node.Labels).ToNot(HaveKey(firstloadedKernelModuleReadyNodeLabel))
+	})
+})
+
+var _ = Describe("GetAllNodesByLabelKey", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		n    Node
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		ctx = context.TODO()
+		n = NewNode(clnt)
+	})
+
+	It("should list by key existence, whatever the label value", func() {
+		const labelKey = "kmm.node.kubernetes.io/namespace.module.some-target"
+
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, list *v1.NodeList, opts ...ctrlclient.ListOption) error {
+				Expect(opts).To(Equal([]ctrlclient.ListOption{ctrlclient.HasLabels{labelKey}}))
+				list.Items = []v1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "empty", Labels: map[string]string{labelKey: ""}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "corrupted", Labels: map[string]string{labelKey: "x"}}},
+				}
+				return nil
+			},
+		)
+
+		nodes, err := n.GetAllNodesByLabelKey(ctx, labelKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodes).To(HaveLen(2))
+	})
+
+	It("should return an error when the list fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+
+		_, err := n.GetAllNodesByLabelKey(ctx, "some-label")
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -14,6 +14,7 @@ import (
 var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.ready$`)
 var reKernelModuleVersionReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.version\.ready$`)
 var reDeprecatedKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/[a-zA-Z0-9-]+\.ready$`)
+var reDRATargetLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.dra-target$`)
 
 func GetModuleVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
@@ -90,6 +91,21 @@ func GetDRANodeLabel(namespace, moduleName string) string {
 
 func GetDevicePluginTargetNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-target", namespace, moduleName)
+}
+
+func GetDRATargetNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.dra-target", namespace, moduleName)
+}
+
+// IsDRATargetNodeLabel returns whether label is a dra-target label and, if so, the namespace and
+// name of the Module owning it.
+func IsDRATargetNodeLabel(label string) (bool, string, string) {
+	matches := reDRATargetLabel.FindStringSubmatch(label)
+	if len(matches) != 3 {
+		return false, "", ""
+	}
+
+	return true, matches[1], matches[2]
 }
 
 func IsDeprecatedKernelModuleReadyNodeLabel(label string) bool {

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -33,6 +33,29 @@ var _ = Describe("GetDRANodeLabel", func() {
 	})
 })
 
+var _ = Describe("GetDRATargetNodeLabel", func() {
+	It("should work as expected", func() {
+		res := GetDRATargetNodeLabel("some-namespace", "some-name")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-name.dra-target"))
+	})
+})
+
+var _ = Describe("IsDRATargetNodeLabel", func() {
+	DescribeTable("should work as expected",
+		func(label string, expectedOK bool, expectedNS, expectedName string) {
+			ok, ns, name := IsDRATargetNodeLabel(label)
+			Expect(ok).To(Equal(expectedOK))
+			Expect(ns).To(Equal(expectedNS))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry("dra-target label", "kmm.node.kubernetes.io/some-namespace.some-name.dra-target", true, "some-namespace", "some-name"),
+		Entry("dra-ready label", "kmm.node.kubernetes.io/some-namespace.some-name.dra-ready", false, "", ""),
+		Entry("device-plugin-target label", "kmm.node.kubernetes.io/some-namespace.some-name.device-plugin-target", false, "", ""),
+		Entry("kernel module ready label", "kmm.node.kubernetes.io/some-namespace.some-name.ready", false, "", ""),
+		Entry("unrelated label", "some-label", false, "", ""),
+	)
+})
+
 var _ = Describe("IsSchedulePodVersionLabel", func() {
 	DescribeTable("should work as expected",
 		func(input string, expected bool) {

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -94,6 +94,17 @@ func (m *ModuleValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		}
 	}
 
+	// Renaming the driver stops matching the claims allocated under the old name, and dropping
+	// spec.dra then putting it back is how a rename would otherwise get through.
+	if oldMod.Spec.DRA != nil {
+		if newMod.Spec.DRA == nil {
+			return nil, errors.New("spec.dra cannot be removed; delete the Module once no ResourceClaim consumer is left")
+		}
+		if oldMod.Spec.DRA.DriverName != newMod.Spec.DRA.DriverName {
+			return nil, errors.New("spec.dra.driverName is immutable; delete the Module once no ResourceClaim consumer is left")
+		}
+	}
+
 	return validateModule(newMod, m.kubeVersion)
 }
 

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -559,6 +559,62 @@ var _ = Describe("ValidateUpdate", func() {
 	})
 
 	DescribeTable(
+		"DRA driver name updates",
+		func(oldDriver, newDriver string, errorExpected bool) {
+			old := validModule
+			old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: oldDriver}
+
+			new := validModule
+			new.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: newDriver}
+
+			_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+			if errorExpected {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// Renaming stops matching the claims allocated under the old name, so the driver would be
+		// removed from nodes that are still using it.
+		Entry(nil, "a.example.com", "b.example.com", true),
+		Entry(nil, "a.example.com", "a.example.com", false),
+	)
+
+	DescribeTable(
+		"DRA presence updates",
+		func(oldHasDRA, newHasDRA, errorExpected bool) {
+			old := validModule
+			new := validModule
+			if oldHasDRA {
+				old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+			} else {
+				old.Spec.DRA = nil
+			}
+			if newHasDRA {
+				new.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+			} else {
+				new.Spec.DRA = nil
+			}
+
+			_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+			if errorExpected {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// Dropping spec.dra deletes the driver without checking for reserved claims, and putting it
+		// back under another name is how a rename would otherwise get through. Adding it to a
+		// Module that never had one has no driver to pull out from under a claim.
+		Entry(nil, true, false, true),
+		Entry(nil, false, true, false),
+		Entry(nil, true, true, false),
+		Entry(nil, false, false, false),
+	)
+
+	DescribeTable(
 		"version updates",
 		func(oldVersion, newVersion string, errorExpected bool) {
 			old := validModule


### PR DESCRIPTION
DaemonSet Pods tolerate the unschedulable taint, so cordoning a node does not remove the DRA driver Pod. Its nodeSelector only requires the kernel-module-ready label, and that label stays on the node until the unloader succeeds, which it cannot do while the driver still holds the kernel module. So the Pod never leaves and the unloader keeps retrying.

#1274 fixed exactly this for device plugin by introducing a `device-plugin-target` node label, but the DRA reconciler never got the counterpart. This patch adds a `dra-target` node label maintained by the DRA reconciler, which now watches nodes, and the DRA DaemonSet nodeSelector requires it beside the kernel-module-ready label. Removing the label lets the DaemonSet controller delete the DRA Pod, and then the unloader converges on a later retry.

Fixes #1328
Refs #1332

## Why the ResourceClaim part is here

Whether the driver may stop is a different question from whether the node can accept new Pods. Cordoning leaves the running Pods where they are, and the DRA driver is what kubelet calls for `NodeUnprepareResources` on the devices those Pods hold. The upstream guidance is explicit about it:

> When draining a node, drain the DRA driver as late as possible [...] If you implement custom drain logic for nodes, consider checking that there are no allocated/reserved ResourceClaim or ResourceClaimTemplates before terminating the DRA driver itself.

So the label is also kept on any node where a ResourceClaim allocated from this Module's `spec.dra.driverName` is still reserved by a Pod, and this overrides both the selector and the schedulability. The reconciler watches ResourceClaims, so the last reservation going away is what releases the driver. This needs `resource.k8s.io/resourceclaims` with `list;watch`.

Without this part, the naive version of the fix, which is dropping the label as soon as the node is cordoned, is a smaller change but known to be unsafe.

## What it guarantees

A node carries `dra-target` while the Module selects it and it is schedulable, or while a ResourceClaim allocated from the Module's driver is still reserved by a consumer on it. The second overrides the first, which is what keeps a cordoned node's driver up until its consumers are done.

The rest is about not acting on something that has already moved:

- A reservation that cannot be placed on a node, because its Pod is gone and the allocation names no single node, holds every label the pass would otherwise drop. `allocatedNodeName` only names a node when every ORed selector term pins the same one.
- The Module is confirmed against the API server, uncached, before anything in the pass writes. UID, generation and deletion are all compared, since deletion leaves the generation alone. The node labels are then decided in full before any of them is written, so a pass that learns partway through that the Module has moved on leaves every node as it was rather than half moved to a spec that is gone. Nothing cleans up after one: the DRA resources have no finalizer of their own (#1331).
- Dropping a label is confirmed against a second uncached read of the reservations, and the patch itself takes an optimistic lock, so a node uncordoned between the read and the write gets a conflict rather than losing its driver.
- Adding the target selector to a DaemonSet that predates it rolls its Pods, so that migration waits while any claim is reserved or unplaceable, and `handleDRA` and garbage collection wait with it. Correcting a selector whose value is wrong does not wait: that value already selects no node, so it is what took the driver away, and it is patched with a JSON Patch guarded on the value this pass saw, so a key that has since gone or changed again is left to the next pass instead. Adding that key to an existing DaemonSet belongs to the claim-gated pass alone: ordinary convergence carries over whatever the live object holds rather than asserting it, and a pass whose classification is invalidated stops touching DaemonSets altogether, so neither a stale snapshot nor `CreateOrPatch` re-reading the live object can complete a held migration. A rejected patch counts as that guard only once a re-read shows the value really moved, since 422 also carries ordinary validation and the migration's own merge patch has no test operation at all.
- The migration takes its own uncached read rather than reusing the one the label removals used, since a reservation can appear between the two.
- A DaemonSet is looked for uncached before one is created. The list a pass starts from is cached and writing a node label queues this Module again, so a pass can run before the DaemonSet the last one created is visible, and a generated name would produce a second one for the same version rather than a conflict.
- Garbage collection waits for an old version's Pods to be gone, not only for its counts to say none are wanted. Once its selector stops matching, the Pod still on the node is counted in `numberMisscheduled` alone, while desired, current and ready all read zero.
- A held migration and a reservation that cannot be placed are reported as Warning events on the Module, so a drain that will not converge names the claim holding it rather than only showing up in the controller's log.
- A pass that cannot settle on an event asks to come back on a timer: an unplaceable reservation waits on a Pod binding, a node held only by a claim waits on a release event that a failed mapper list would swallow, a held migration waits on the claims, and a node a claim needs that cannot be read waits on the node itself.

## What it does not guarantee

The DRA DaemonSet selects on `kernel-module-ready` as well as `dra-target`, and this PR only owns the second one. `nmc_reconciler.go:112` drops the ready labels for any Module still in a cordoned node's NMC spec, with no claim check at all, so whether the driver survives a cordon comes down to which of `NMCReconciler` and `ModuleReconciler` reaches it first. #1328 describes both orderings; this fixes the one where the unloader runs with the driver still up. The other one needs a hold the NMC side respects, which is #1332. So this stops the DRA reconciler dropping the driver itself; it does not make the drain claim-safe on its own.

- A Module without a `spec.moduleLoader` has no kernel module to sequence against, so it keeps selecting on the Module selector and gets none of this.
- The target label keeps a node in the DaemonSet's selector, it does not make the Pod tolerate anything: an untolerated `NoExecute` taint still evicts the driver, a `NoExecute` toleration with a `tolerationSeconds` still expires, and an untolerated `NoSchedule` one still stops it coming back.
- The guard covers the automatic selector migration. Once the selector is present, an explicit Module update to the image, env, probes or security context still rolls the driver through `handleDRA`, so a driver that cannot be restarted under load needs seamless upgrade support.
- Garbage collection of an older version's DaemonSet waits for its Pods to be gone, not only for the count of wanted ones to reach zero, since deleting the DaemonSet takes whatever is left with it.
- Deleting the Module removes the label from every node without looking for claims. The DRA reconciler has no finalizer of its own, so cleanup can also be cut short: #1331.
- Uncached reads close the informer lag, not the whole race. Nothing puts a ResourceClaim and a Node in one transaction, so a reservation created after the read still lands after the check.
- `spec.dra.driverName` must identify one Module in the cluster. Retention is keyed by it, so two Modules sharing a name hold each other's labels and defer each other's migrations.
- The migration is held for the whole Module, not per node, because a DaemonSet's pod template is cluster-wide. One long-lived claim can therefore keep a legacy DaemonSet on the old selector while an unrelated node is drained.
- Upgrading to this changes the pod template of every DRA DaemonSet the Module already owns, not only the current version's, so each DRA Pod restarts once.

## Testing

`ci/prow/e2e-dra` runs the guard from both sides. First it repairs a missing target selector on the live DaemonSet before a consumer takes a claim, waits for that rollout to settle, and then keeps `dra-consumer` running across a cordon. Once the claim is reserved it checks that the DaemonSet generation does not move, and through the cordon window it asserts the label on `node/minikube` specifically alongside the reservation still naming the consumer, so a claim released early cannot make the label check pass for the wrong reason. The label going away afterwards is tied to the reservation clearing, not just to the consumer disappearing.

Then it does the same thing the other way round. Taking the selector off rolls the DaemonSet itself, so that happens with the controller scaled to zero and is left to settle before any claim is taken. The other order would replace the driver Pod under an active claim, which is the thing the window is meant to prove does not happen. A second consumer then takes a claim, the controller comes back to a migration already pending, and for 45 seconds the selector, the DaemonSet generation, the driver Pod's UID and readiness, and the reservation are all checked to hold. Releasing the claim is what lets the migration through, and that is a normal delete rather than a forced one, so the eviction only finishes if `NodeUnprepareResources` does.

`dra-example-driver` does not hold `kmm_ci_a`, so CI cannot reproduce an `rmmod` that really fails. Making it do so means giving `kmm_ci_a` something a process can hold open, and `ci/kmm-kmod-dockerfile.yaml` builds that module by cloning the default branch and is shared with `e2e-incluster-build` and `e2e-helm-incluster-build`, so it is a fixture change with its own blast radius rather than something to fold in here. As it stands the unload succeeds during the cordon, `removeOrphanedLabels` drops the ready label, and the driver Pod goes with it. That is why the cordon scenario force deletes its consumer rather than draining it, and why it covers the target label's lifecycle rather than a graceful `NodeUnprepareResources`. The migration scenario keeps the driver up throughout, so it deletes its consumer normally.

Unit tests cover selector narrowing, a node losing and regaining a selector label, a stale label on a node which is also cordoned, a converged cluster patching nothing, tolerated and untolerated taints, a node deleted in the middle, the in-use override in both directions, a cordon followed by an uncordon, the DaemonSet migration and its skip conditions, missing versus wrong selector values, a stale and a deleting Module, `spec.dra` immutability, Module deletion, and the new mapper and predicates.

Every line this adds to `dra_reconciler.go` is covered, and every fix has a test that fails without it, checked by mutating the fix and confirming which spec goes red. That is worth saying because more than one of them looked right and was not: swallowing a patch conflict is only safe when something is guaranteed to come back, and reading the node predicate is what showed nothing was.

Since everything here is mock based like the rest of the repo, I also ran the assumptions under it against a real API server with envtest, and did not commit that harness since there is no envtest suite here. It is what confirmed rather than argued the two worst findings: with a real ResourceClaim allocated to two ORed `metadata.name` terms, the old `allocatedNodeName` reports the first node and the reconcile takes the target label off the second one; and a plain merge patch removes a label from a node that was uncordoned after the read, where the optimistic one gets a conflict and leaves it alone. I checked there too that writing Module status leaves `.metadata.generation` alone, which is what the re-read depends on.

For `allocatedNodeName` itself I cross checked against the node affinity matcher in `k8s.io/component-helpers` over every selector buildable from a small pool of terms, asserting that whenever it names a node, no other node in the universe matches the selector. 584 selectors, no violation, and the previous version fails it.

## Not in this PR

Sequencing the unload against the driver Pod's exit is not here. I tried it by making `ModuleReconciler` hold the module in NMC desired state until the driver Pod is gone, and the e2e showed it makes `NMCReconciler` remove the kernel-module-ready label instead, since the module is then still in the spec of an unschedulable node, so the Pod is deleted for the opposite reason. It belongs to `NMCReconciler` where the ready label lives.

The device plugin's own target label hardening, adopting `module.EffectiveTolerations` in the existing call sites, extracting the shared reconciler after both controllers are settled, the generic `FindModulesForNode` fix and some e2e wait hardening are split into separate branches. #1330, #1331 and #1333 stay separated.

#1333 is worth naming because it meets this change head on. A reserved claim keeps the target label up while the node is cordoned, so the unloader keeps failing and retrying, and if the node is uncordoned in that window the label comes straight back, which is covered by a unit test here. What does not come back is `ProcessModuleSpec` cancelling the unloader still on the node, so it can succeed later and take the module off a node that is back in service. That half is NMC's and stays in #1333. #1331 is the other one to watch at release time: this adds more node labels to clean up and the DRA reconciler still has no finalizer of its own, so a Module can go away before the cleanup finishes.

<details>
<summary>What earlier review rounds changed</summary>

Kept for anyone following the history. Everything here is already in the code above.

- `reconcileDRATargetLabel` only visited nodes the selector returns or that already carry the label, so a node still in use, no longer selected and already stripped of its label was never looked at and could not get it back. Those are now fetched by name.
- Garbage collection read `desiredNumberScheduled == 0` from the DaemonSet list taken before the selector migration patched it, so an older DaemonSet could be repaired and deleted in the same reconcile. It now waits for `status.observedGeneration` to catch up.
- A reservation that cannot be placed on a node was read as proof the driver was free. `nodesUsingDRADriver` now resolves the node from the claim's allocation when the consumer cannot answer for one, and reports anything still unplaceable so the pass keeps every label it would otherwise drop.
- Dropping a label deletes the driver Pod, and no later event can call that termination back, so a removal is now confirmed against uncached reads rather than the informer: the Module the decision came from, then the reservations. Both happen once per pass and only when there is something to drop. That closes the informer lag, not the whole race. A reservation created after the read still lands after the check, and there is no transaction spanning a ResourceClaim and a Node.
- `spec.dra` cannot be removed and `spec.dra.driverName` cannot be changed. Retention is keyed by the driver name, and removing `spec.dra` took the cleanup path without any claim check, which is also how a rename would otherwise have got through. Adding `spec.dra` to a Module that never had one is still allowed, since there is no driver there to pull out from under a claim.
- `status.dra.desiredNumber` is now the number of nodes the reconciled target label leaves selected, rather than the raw selector count, so a node held for a reserved claim is counted. A node whose label patch comes back `NotFound` is left out of it, since it no longer exists.
- `allocatedNodeName` returned the first exact `metadata.name` requirement it found, but `NodeSelectorTerms` are ORed, so an allocation naming two nodes was read as naming the first. The second then looked unused and could lose its driver with the claim still reserved. It now answers only when every term pins the same name, and leaves the reservation unresolved otherwise.
- The removal patch carried no resourceVersion precondition, so a node uncordoned between the list and the patch still lost its label from stale state. Removals now take an optimistic lock and skip on conflict, leaving the decision to the reconcile that change queues. The Module is re-read for the same reason: a selector or toleration this pass never saw can make a node it wants to drop eligible again.
- The user and developer docs claimed the driver outlives its consumers and described removing `spec.dra`. They now say what the label controls, what it does not, and that admission rejects that removal.
- A conflict on the removal patch was treated as success on the grounds that the change causing it would come back as an event. It does not: the node predicate takes taints and labels, and a status update is neither. Conflicts now ask for a requeue and leave the node in the desired count until one lands.
- Nothing woke the reconciler when a reservation that could not be placed finally got its Pod scheduled, or when the only thing holding a node was a claim whose release event was lost. Both now requeue on a timer, since the state they wait on is not watched.
- Adding the target selector to a DaemonSet that predates it rolls its Pods, which takes the driver off the node long enough for a retrying unloader to win. That migration is now judged against an uncached read and held while any claim is reserved or unplaceable. `setDRAAsDesired` applies the same selector, so the rest of the DaemonSet reconciliation waits with it.
- `status.dra.nodesMatchingSelectorNumber` was still counted with the Module's raw tolerations while the desired number next to it used the effective ones, so a node under memory pressure could appear in one and not the other.
- Reviewing my own version of the above found two more. The requeue for a node held only by a claim keyed off the node not matching the selector, but the case it exists for is a node that still matches and is cordoned, so it never fired where it mattered, and the test I wrote for it had been shaped to the same mistake. And the requeue was being set on the result before the remaining steps could fail, which hands controller-runtime a result next to an error, something it ignores and warns about.
- CI then found the guard breaking the e2e: it removed the target selector from the live DaemonSet after the claim was reserved and waited two minutes for a repair the guard is there to withhold. The test was doing the thing the guard exists to prevent, so the drift check now runs before a consumer takes a claim, and what happens under an active claim is asserted instead: the DaemonSet generation does not move.
- I had also shared one uncached read between the label removals and the migration to save a call. That is wrong: a reservation can appear in between, and the migration would then roll the driver on the strength of what the removal saw. Each takes its own read again.
- Deletion does not bump `metadata.generation`, so a pass that started before it was still treated as current. It is compared separately now, and a Module that moved on stops the whole pass rather than only the DaemonSet work, since garbage collection reads the version off the object the pass started from. Deferred migration holds garbage collection back for the same reason.
- I had the node predicate watch `spec.unschedulable` as well, to see a cordon without waiting for the node lifecycle controller to turn it into a taint. `IsNodeSchedulable` only reads taints, so all that bought was an earlier reconcile that decides nothing. Making it count would mean teaching the shared helper about it, which the device plugin and NMC also use, so it is out again rather than left as a claim the code does not make good on.
- The e2e asserted that some node carried the target label. The cluster has two, so a stale label on the wrong one could hide a missing one on the right one.
- The freshness check was still conditional: it only ran when a label was about to come off or a DaemonSet needed the selector. A converged pass never reaches it, and a DRA-only Module never enters that pass at all, so an older generation could still write its DaemonSet template back or garbage-collect the version the current one wants. The Module is now confirmed against the API server before anything in the pass writes, and the checks immediately before the destructive steps stay where they are.
- A DaemonSet asking for the wrong target label value was treated like one missing it, so both waited for the claims. That one is the wrong way round: a wrong value already selects no node, which is what took the driver away, and the claim waiting on that driver cannot clear until it is back. Only a missing key waits now; a wrong value is corrected straight away, including on a pass that is holding a migration.
- Finding the Module has moved on was recorded but not acted on: the same branch still corrected wrong-value selectors before handing the result back, and the node loop could apply an addition before it got as far as looking. It is a write barrier now, and nothing after it touches a node or a DaemonSet.
- The correction itself was an unconditional merge patch, so a selector going from wrong to missing between the read and the write turned a recovery into the migration the claims are holding back. It is a JSON Patch now, with a `test` on the value this pass classified. I had it as a bare `replace` first, on the assumption that RFC 6902 makes that fail for a path that is not there; against a real API server it is accepted and simply adds the key, which is the bypass it was meant to close.
- Coverage of the lines this adds went from 13 uncovered to none, which is what turned up the untested paths above: a failed Module confirmation, a correction that no longer applies, a claims read that fails before a migration, and a DaemonSet already being deleted.
- A node kept only by a claim was looked up in the cache and forgotten on `NotFound`. Nothing else can put that label back: the node matches neither the selector nor an existing target label, so no node event maps to this Module. It is an uncached read now, and a node that really is gone leaves a requeue behind.

</details>

This PR was written in part with the assistance of generative AI.

---

/cc @yevgeny-shnaidman @ybettan @TomerNewman

