### PR TITLE
Add optional modprobedDir to ModprobeSpec

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -174,6 +174,13 @@ type ModprobeSpec struct {
 	// +optional
 	FirmwarePath string `json:"firmwarePath,omitempty"`
 
+	// ModprobedDir is an absolute path in the driver container image that contains
+	// modprobe.d configuration files (flat directory only; no subdirectories).
+	// When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+	// before modprobe load/unload.
+	// +optional
+	ModprobedDir string `json:"modprobedDir,omitempty"`
+
 	// ModulesLoadingOrder defines the dependency between kernel modules loading, in case
 	// it was not created by depmod (independent kernel modules).
 	// The list order should be: upmost module, then the module it depends on and so on.

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -7022,6 +7022,13 @@ spec:
                                   FirmwarePath is the path of the firmware(s).
                                   The firmware(s) will be copied to the host for the kernel to find them.
                                 type: string
+                              modprobedDir:
+                                description: |-
+                                  ModprobedDir is an absolute path in the driver container image that contains
+                                  modprobe.d configuration files (flat directory only; no subdirectories).
+                                  When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                  before modprobe load/unload.
+                                type: string
                               moduleName:
                                 description: |-
                                   ModuleName is the name of the Module to be loaded.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -6982,6 +6982,13 @@ spec:
                               FirmwarePath is the path of the firmware(s).
                               The firmware(s) will be copied to the host for the kernel to find them.
                             type: string
+                          modprobedDir:
+                            description: |-
+                              ModprobedDir is an absolute path in the driver container image that contains
+                              modprobe.d configuration files (flat directory only; no subdirectories).
+                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                              before modprobe load/unload.
+                            type: string
                           moduleName:
                             description: |-
                               ModuleName is the name of the Module to be loaded.

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -104,6 +104,13 @@ spec:
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
                               type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
+                              type: string
                             moduleName:
                               description: |-
                                 ModuleName is the name of the Module to be loaded.
@@ -301,6 +308,13 @@ spec:
                               description: |-
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
+                              type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
                               type: string
                             moduleName:
                               description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -6982,6 +6982,13 @@ spec:
                               FirmwarePath is the path of the firmware(s).
                               The firmware(s) will be copied to the host for the kernel to find them.
                             type: string
+                          modprobedDir:
+                            description: |-
+                              ModprobedDir is an absolute path in the driver container image that contains
+                              modprobe.d configuration files (flat directory only; no subdirectories).
+                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                              before modprobe load/unload.
+                            type: string
                           moduleName:
                             description: |-
                               ModuleName is the name of the Module to be loaded.

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -104,6 +104,13 @@ spec:
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
                               type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
+                              type: string
                             moduleName:
                               description: |-
                                 ModuleName is the name of the Module to be loaded.
@@ -301,6 +308,13 @@ spec:
                               description: |-
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
+                              type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
                               type: string
                             moduleName:
                               description: |-

--- a/deployment/helm/kmm-hub/crds/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/deployment/helm/kmm-hub/crds/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -7022,6 +7022,13 @@ spec:
                                   FirmwarePath is the path of the firmware(s).
                                   The firmware(s) will be copied to the host for the kernel to find them.
                                 type: string
+                              modprobedDir:
+                                description: |-
+                                  ModprobedDir is an absolute path in the driver container image that contains
+                                  modprobe.d configuration files (flat directory only; no subdirectories).
+                                  When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                  before modprobe load/unload.
+                                type: string
                               moduleName:
                                 description: |-
                                   ModuleName is the name of the Module to be loaded.

--- a/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_modules.yaml
+++ b/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_modules.yaml
@@ -6982,6 +6982,13 @@ spec:
                               FirmwarePath is the path of the firmware(s).
                               The firmware(s) will be copied to the host for the kernel to find them.
                             type: string
+                          modprobedDir:
+                            description: |-
+                              ModprobedDir is an absolute path in the driver container image that contains
+                              modprobe.d configuration files (flat directory only; no subdirectories).
+                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                              before modprobe load/unload.
+                            type: string
                           moduleName:
                             description: |-
                               ModuleName is the name of the Module to be loaded.

--- a/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -104,6 +104,13 @@ spec:
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
                               type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
+                              type: string
                             moduleName:
                               description: |-
                                 ModuleName is the name of the Module to be loaded.
@@ -301,6 +308,13 @@ spec:
                               description: |-
                                 FirmwarePath is the path of the firmware(s).
                                 The firmware(s) will be copied to the host for the kernel to find them.
+                              type: string
+                            modprobedDir:
+                              description: |-
+                                ModprobedDir is an absolute path in the driver container image that contains
+                                modprobe.d configuration files (flat directory only; no subdirectories).
+                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
+                                before modprobe load/unload.
                               type: string
                             moduleName:
                               description: |-

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -784,6 +784,9 @@ var _ = Describe("enableModuleOnNode", func() {
 			Namespace:             moduleNamespace,
 			InTreeModulesToRemove: []string{"InTreeModuleToRemove"},
 			ContainerImage:        containerImage,
+			Modprobe: kmmv1beta1.ModprobeSpec{
+				ModprobedDir: "/opt/driver/modprobe.d",
+			},
 		}
 
 		expectedModuleConfig = &kmmv1beta1.ModuleConfig{


### PR DESCRIPTION
Add an optional modprobedDir field so Modules can point at modprobe.d files in the driver image.
Regenerate CRDs and add unit tests.