### PR TITLE
Switch to server-side apply for kubectl install/deploy commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ KUSTOMIZE_CONFIG_CRD ?= config/crd
 
 .PHONY: install
 install: manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	kubectl apply -k $(KUSTOMIZE_CONFIG_CRD)
+	kubectl apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_CRD)
 
 .PHONY: uninstall
 uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -220,14 +220,14 @@ deploy: deploy-cert-manager manifests kustomize ## Deploy controller to the K8s 
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) worker=$(WORKER_IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image signer=$(SIGNER_IMG)
 	cd config/webhook-server && $(KUSTOMIZE) edit set image webhook-server=$(WEBHOOK_IMG)
-	kubectl apply -k $(KUSTOMIZE_CONFIG_DEFAULT)
+	kubectl apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_DEFAULT)
 
 .PHONY: deploy-hub
 deploy-hub: deploy-cert-manager manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager-hub && $(KUSTOMIZE) edit set image controller=$(HUB_IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image signer=$(SIGNER_IMG)
 	cd config/webhook-server && $(KUSTOMIZE) edit set image webhook-server=$(WEBHOOK_IMG)
-	kubectl apply -k $(KUSTOMIZE_CONFIG_HUB_DEFAULT)
+	kubectl apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_HUB_DEFAULT)
 
 .PHONY: undeploy-kmm
 undeploy-kmm: kustomize

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment \
 
 Install KMM.
 ```shell
-kubectl apply -k https://github.com/kubernetes-sigs/kernel-module-management/config/default
+kubectl apply --server-side --force-conflicts -k https://github.com/kubernetes-sigs/kernel-module-management/config/default
 ```
 
 ## Documentation and lab

--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -28,7 +28,7 @@ First, [install the cert-manager dependency](./install.md#installing-the-cert-ma
 Then, run the following command:
 
 ```shell
-kubectl apply -k https://github.com/kubernetes-sigs/kernel-module-management/config/default-hub
+kubectl apply --server-side --force-conflicts -k https://github.com/kubernetes-sigs/kernel-module-management/config/default-hub
 ```
 
 This installs the operator in the `kmm-operator-system` namespace.

--- a/docs/mkdocs/documentation/install.md
+++ b/docs/mkdocs/documentation/install.md
@@ -74,7 +74,7 @@ kubectl -n cert-manager wait --for=condition=Available deployment \
 ### Installing KMM
 
 ```shell
-kubectl apply -k https://github.com/kubernetes-sigs/kernel-module-management/config/default
+kubectl apply --server-side --force-conflicts -k https://github.com/kubernetes-sigs/kernel-module-management/config/default
 ```
 
 This installs the operator in the `kmm-operator-system` namespace.


### PR DESCRIPTION
Client-side apply stores the full manifest in the last-applied-configuration annotation, capped at 256KB.
The Module and ManagedClusterModule CRDs haven't hit that limit yet, but the pending configurable SecurityContext change (#1323) will push them over it and break kubectl apply.

Switch to --server-side --force-conflicts preemptively, since it tracks field ownership on the API server instead and isn't subject to this limit.


---

/cc @ybettan 