### PR TITLE
Validate modprobedDir in Module admission webhook

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -176,8 +176,8 @@ type ModprobeSpec struct {
 
 	// ModprobedDir is an absolute path in the driver container image that contains
 	// modprobe.d configuration files (flat directory only; no subdirectories).
-	// When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-	// before modprobe load/unload.
+	// When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+	// pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
 	// +optional
 	ModprobedDir string `json:"modprobedDir,omitempty"`
 

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -7026,8 +7026,8 @@ spec:
                                 description: |-
                                   ModprobedDir is an absolute path in the driver container image that contains
                                   modprobe.d configuration files (flat directory only; no subdirectories).
-                                  When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                  before modprobe load/unload.
+                                  When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                  pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                                 type: string
                               moduleName:
                                 description: |-

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -6986,8 +6986,8 @@ spec:
                             description: |-
                               ModprobedDir is an absolute path in the driver container image that contains
                               modprobe.d configuration files (flat directory only; no subdirectories).
-                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                              before modprobe load/unload.
+                              When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                              pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                             type: string
                           moduleName:
                             description: |-

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -108,8 +108,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-
@@ -313,8 +313,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -6986,8 +6986,8 @@ spec:
                             description: |-
                               ModprobedDir is an absolute path in the driver container image that contains
                               modprobe.d configuration files (flat directory only; no subdirectories).
-                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                              before modprobe load/unload.
+                              When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                              pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                             type: string
                           moduleName:
                             description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -108,8 +108,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-
@@ -313,8 +313,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-

--- a/deployment/helm/kmm-hub/crds/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/deployment/helm/kmm-hub/crds/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -7026,8 +7026,8 @@ spec:
                                 description: |-
                                   ModprobedDir is an absolute path in the driver container image that contains
                                   modprobe.d configuration files (flat directory only; no subdirectories).
-                                  When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                  before modprobe load/unload.
+                                  When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                  pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                                 type: string
                               moduleName:
                                 description: |-

--- a/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_modules.yaml
+++ b/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_modules.yaml
@@ -6986,8 +6986,8 @@ spec:
                             description: |-
                               ModprobedDir is an absolute path in the driver container image that contains
                               modprobe.d configuration files (flat directory only; no subdirectories).
-                              When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                              before modprobe load/unload.
+                              When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                              pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                             type: string
                           moduleName:
                             description: |-

--- a/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/deployment/helm/kmm/crds/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -108,8 +108,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-
@@ -313,8 +313,8 @@ spec:
                               description: |-
                                 ModprobedDir is an absolute path in the driver container image that contains
                                 modprobe.d configuration files (flat directory only; no subdirectories).
-                                When set, KMM copies those files into /etc/modprobe.d/ in the worker pod
-                                before modprobe load/unload.
+                                When set, KMM copies those files as-is into /etc/modprobe.d/ in the worker
+                                pod before modprobe load/unload. May be set together with ModulesLoadingOrder.
                               type: string
                             moduleName:
                               description: |-

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -327,7 +327,24 @@ func validateModprobe(modprobe kmmv1beta1.ModprobeSpec) error {
 		}
 	}
 
+	if modprobe.ModprobedDir != "" {
+		if !isWellFormedAbsolutePath(modprobe.ModprobedDir) {
+			return fmt.Errorf("modprobedDir %q must be a well-formed absolute path", modprobe.ModprobedDir)
+		}
+	}
+
 	return nil
+}
+
+func isWellFormedAbsolutePath(p string) bool {
+	if !filepath.IsAbs(p) {
+		return false
+	}
+	trimmed := strings.TrimSuffix(p, "/")
+	if trimmed == "" {
+		trimmed = "/"
+	}
+	return filepath.Clean(trimmed) == trimmed
 }
 
 func validateSignSection(sign *kmmv1beta1.Sign, dirName string) error {

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -400,6 +400,77 @@ var _ = Describe("validateModprobe", func() {
 			HaveOccurred(),
 		)
 	})
+
+	DescribeTable(
+		"modprobedDir validation",
+		func(modprobe kmmv1beta1.ModprobeSpec, errSubstrs []string) {
+			err := validateModprobe(modprobe)
+			if len(errSubstrs) == 0 {
+				Expect(err).NotTo(HaveOccurred())
+				return
+			}
+			for _, substr := range errSubstrs {
+				Expect(err).To(MatchError(ContainSubstring(substr)))
+			}
+		},
+		Entry(
+			"should fail when modprobedDir is relative",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "opt/driver/modprobe.d",
+			},
+			[]string{"well-formed absolute path"},
+		),
+		Entry(
+			"should fail when modprobedDir contains ..",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "/opt/../driver/modprobe.d",
+			},
+			[]string{"well-formed absolute path"},
+		),
+		Entry(
+			"should fail when modprobedDir contains .",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "/opt/./driver/modprobe.d",
+			},
+			[]string{"well-formed absolute path"},
+		),
+		Entry(
+			"should fail when modprobedDir contains an empty segment",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "/opt//driver/modprobe.d",
+			},
+			[]string{"well-formed absolute path"},
+		),
+		Entry(
+			"should pass when modprobedDir is a well-formed absolute path",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "/opt/driver/modprobe.d",
+			},
+			nil,
+		),
+		Entry(
+			"should pass when modprobedDir has a trailing slash",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:   "module-name",
+				ModprobedDir: "/opt/driver/modprobe.d/",
+			},
+			nil,
+		),
+		Entry(
+			"should pass when modprobedDir and modulesLoadingOrder are both set",
+			kmmv1beta1.ModprobeSpec{
+				ModuleName:          "module-name",
+				ModprobedDir:        "/opt/driver/modprobe.d",
+				ModulesLoadingOrder: []string{"module-name", "dep"},
+			},
+			nil,
+		),
+	)
 })
 
 var _ = Describe("validateModule", func() {


### PR DESCRIPTION
Reject non-absolute or malformed modprobedDir in the webhook. 

A Module may set `modprobedDir` and `modulesLoadingOrder` together.
That combination is not rejected at admission.