### PR TITLE
Apply worker.runAsUser to privileged firmware loader pods

### DIFF
--- a/internal/pod/workerpodmanager.go
+++ b/internal/pod/workerpodmanager.go
@@ -584,9 +584,10 @@ func setWorkerSecurityContext(pod *v1.Pod, workerCfg *config.Worker, privileged 
 		sc.Capabilities = &v1.Capabilities{
 			Add: []v1.Capability{"SYS_MODULE"},
 		}
-		sc.RunAsUser = workerCfg.RunAsUser
 		sc.SELinuxOptions = &v1.SELinuxOptions{Type: workerCfg.SELinuxType}
 	}
+
+	sc.RunAsUser = workerCfg.RunAsUser
 
 	container.SecurityContext = sc
 

--- a/internal/pod/workerpodmanager_test.go
+++ b/internal/pod/workerpodmanager_test.go
@@ -201,6 +201,7 @@ var _ = Describe("CreateLoaderPod", func() {
 			if withFirmwareLoading && firmwareHostPath != nil {
 				container.SecurityContext = &v1.SecurityContext{
 					Privileged: ptr.To(true),
+					RunAsUser:  workerCfg.RunAsUser,
 				}
 			} else {
 				container.SecurityContext = &v1.SecurityContext{


### PR DESCRIPTION
On containerd, a privileged non-root container gets an empty effective capability set, so the firmware loader (which runs privileged) could not write to the root-owned /sys/module/firmware_class/parameters/path, even with worker.runAsUser set to 0.
 CRI-O masked this since it grants privileged non-root containers a full effective capability set.
 
 ---
 
 /cc @yevgeny-shnaidman @abyrne55
 fix #1337