### PR TITLE
Fix DRA and device plugin cleanup finalization

### DIFF
--- a/ci/module-kmm-ci-device-plugin-only.yaml
+++ b/ci/module-kmm-ci-device-plugin-only.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci-device-plugin-only
+spec:
+  devicePlugin:
+    container:
+      image: registry.k8s.io/pause:3.10
+  selector:
+    kubernetes.io/hostname: minikube

--- a/ci/module-kmm-ci-dra-only.yaml
+++ b/ci/module-kmm-ci-dra-only.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci-dra-only
+spec:
+  dra:
+    driverName: cleanup.example.com
+    serviceAccountName: dra-example-driver
+    container:
+      image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0
+      command: ["dra-example-kubeletplugin"]
+      env:
+        - name: DRIVER_NAME
+          value: cleanup.example.com
+    deviceClasses:
+      - name: kmm-ci-cleanup-device
+  selector:
+    kubernetes.io/hostname: minikube

--- a/ci/prow/e2e-dra
+++ b/ci/prow/e2e-dra
@@ -78,3 +78,100 @@ timeout 1m bash -c 'until ! minikube ssh -- lsmod | grep kmm_ci_a; do sleep 3; d
 
 echo "Wait for the Module to be deleted"
 kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci-dra
+
+# Without a moduleLoader there is no NMC, so ModuleFinalizer goes on the first pass and only the
+# DRA one holds the Module. A DeviceClass is cluster scoped, so nothing else would collect it.
+source "$(dirname "$0")/finalizer-test-lib.sh"
+
+echo "Deploy a Module with a DRA spec and no moduleLoader"
+kubectl apply -f ci/module-kmm-ci-dra-only.yaml
+
+echo "Wait for the DRA finalizer and the DeviceClass"
+timeout 2m bash -c 'until kubectl get module kmm-ci-dra-only -o json | jq -e ".metadata.finalizers | index(\"kmm.node.kubernetes.io/dra-cleanup\")" > /dev/null; do sleep 3; done'
+timeout 2m bash -c 'until kubectl get deviceclass kmm-ci-cleanup-device; do sleep 3; done'
+
+# Beside anything already there, never over it. The trap lets it go if anything below fails.
+echo "Hold the DeviceClass so its deletion cannot complete"
+hold_with_test_finalizer deviceclass/kmm-ci-cleanup-device
+# Pinned, so a DeviceClass that goes and comes back under the same name fails rather than passes.
+DC_UID=$(kubectl get deviceclass kmm-ci-cleanup-device -o jsonpath='{.metadata.uid}')
+trap 'release_test_finalizer deviceclass/kmm-ci-cleanup-device || true' EXIT
+
+kubectl delete module kmm-ci-dra-only --wait=false
+
+# Everything else has to be gone first, or it would hold the Module by itself and this would pass
+# even with the DeviceClass wait broken. Nothing holds these Pods, so they do go.
+echo "Wait until the held DeviceClass is the only thing the Module waits for"
+DRA_DEADLINE=$(( SECONDS + 120 ))
+while true; do
+  if ! DRA_MODULE_JSON=$(kubectl get module kmm-ci-dra-only --ignore-not-found -o json); then
+    echo "could not read the Module"
+    exit 1
+  fi
+  if [ -z "${DRA_MODULE_JSON}" ]; then
+    echo "the Module was released before the DeviceClass was let go"
+    exit 1
+  fi
+
+  if ! DRA_DC_JSON=$(kubectl get deviceclass kmm-ci-cleanup-device --ignore-not-found -o json); then
+    echo "could not read the DeviceClass"
+    exit 1
+  fi
+  if [ -z "${DRA_DC_JSON}" ]; then
+    echo "the held DeviceClass went while the Module was still here"
+    exit 1
+  fi
+
+  # Read before the test, so that a failed query is a failure rather than an empty cluster.
+  if ! DRA_DS=$(kubectl get daemonset -l kmm.node.kubernetes.io/module.name=kmm-ci-dra-only -o name); then
+    echo "could not list the DRA DaemonSets"
+    exit 1
+  fi
+  if ! DRA_PODS=$(kubectl get pod -l kmm.node.kubernetes.io/module.name=kmm-ci-dra-only -o name); then
+    echo "could not list the DRA Pods"
+    exit 1
+  fi
+
+  if jq -e '
+        .metadata.deletionTimestamp != null
+        and (.metadata.finalizers == ["kmm.node.kubernetes.io/dra-cleanup"])' <<< "${DRA_MODULE_JSON}" > /dev/null &&
+     jq -e --arg uid "${DC_UID}" '
+        .metadata.uid == $uid
+        and .metadata.deletionTimestamp != null
+        and ((.metadata.finalizers // []) | index("tests.kmm.sigs.x-k8s.io/hold") != null)' <<< "${DRA_DC_JSON}" > /dev/null &&
+     [ -z "${DRA_DS}" ] && [ -z "${DRA_PODS}" ]; then
+    break
+  fi
+
+  if [ "${SECONDS}" -ge "${DRA_DEADLINE}" ]; then
+    echo "timed out waiting for the held DeviceClass to be the only thing the Module waits for"
+    jq -c '.metadata | {deletionTimestamp, finalizers}' <<< "${DRA_MODULE_JSON}" || true
+    jq -c '.metadata | {uid, deletionTimestamp, finalizers}' <<< "${DRA_DC_JSON}" || true
+    exit 1
+  fi
+
+  sleep 3
+done
+
+# --ignore-not-found so a Module that has gone reads as empty here rather than as a kubectl error.
+echo "Check that the Module is not released while the DeviceClass is still there"
+for _ in $(seq 10); do
+  MODULE_FINALIZERS=$(kubectl get module kmm-ci-dra-only --ignore-not-found -o jsonpath='{.metadata.finalizers}')
+  case "${MODULE_FINALIZERS}" in
+    *kmm.node.kubernetes.io/dra-cleanup*) ;;
+    *) echo "the Module was released with finalizers ${MODULE_FINALIZERS:-none} while its DeviceClass was still there"; exit 1 ;;
+  esac
+  if [ "$(kubectl get deviceclass kmm-ci-cleanup-device --ignore-not-found -o jsonpath='{.metadata.uid}')" != "${DC_UID}" ]; then
+    echo "the held DeviceClass went or was replaced while the Module was still here"
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "Release the DeviceClass"
+release_test_finalizer deviceclass/kmm-ci-cleanup-device
+trap - EXIT
+
+echo "Check that the DeviceClass and the Module then go"
+timeout 2m bash -c 'until out=$(kubectl get deviceclass kmm-ci-cleanup-device --ignore-not-found -o name) && [ -z "${out}" ]; do sleep 3; done'
+kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci-dra-only --timeout=2m

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -60,3 +60,133 @@ check_module_not_loaded "kmm_ci_b"
 
 echo "Wait for the Module to be deleted..."
 kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci
+
+# Without a moduleLoader there is no NMC, so only device-plugin-cleanup holds the Module. What it
+# waits for is a Pod, which is the half the DRA test does not reach.
+source "$(dirname "$0")/finalizer-test-lib.sh"
+
+echo "Deploy a Module with a device plugin and no moduleLoader..."
+kubectl apply -f ci/module-kmm-ci-device-plugin-only.yaml
+
+echo "Wait for the device plugin finalizer and its Pod..."
+timeout 2m bash -c 'until kubectl get module kmm-ci-device-plugin-only -o json | jq -e ".metadata.finalizers | index(\"kmm.node.kubernetes.io/device-plugin-cleanup\")" > /dev/null; do sleep 3; done'
+timeout 5m bash -c 'until [ -n "$(kubectl get pod -l kmm.node.kubernetes.io/module.name=kmm-ci-device-plugin-only -o name)" ]; do sleep 3; done'
+
+# Beside the operator's finalizer, never over it: KMM puts NodeLabelerFinalizer on the Pod, and a
+# merge patch carrying only this one would take that off. The trap lets it go if anything fails.
+DP_POD=pod/$(kubectl get pod -l kmm.node.kubernetes.io/module.name=kmm-ci-device-plugin-only -o jsonpath='{.items[0].metadata.name}')
+DP_UID=$(kubectl get "${DP_POD}" -o jsonpath='{.metadata.uid}')
+DP_READY_LABEL=kmm.node.kubernetes.io/default.kmm-ci-device-plugin-only.device-plugin-ready
+DP_TARGET_LABEL=kmm.node.kubernetes.io/default.kmm-ci-device-plugin-only.device-plugin-target
+
+# Start from a state where KMM has set both labels, so that neither going missing later can read
+# as cleanup when it was never there.
+echo "Wait for the Pod to be ready and for both of its node labels..."
+kubectl wait --for=condition=Ready "${DP_POD}" --timeout=5m
+DP_LABEL_DEADLINE=$(( SECONDS + 120 ))
+until kubectl get node minikube -o json |
+  jq -e --arg r "${DP_READY_LABEL}" --arg t "${DP_TARGET_LABEL}" '
+    (.metadata.labels | has($r)) and (.metadata.labels | has($t))' > /dev/null; do
+  if [ "${SECONDS}" -ge "${DP_LABEL_DEADLINE}" ]; then
+    echo "the device plugin node labels never appeared"
+    exit 1
+  fi
+  sleep 3
+done
+kubectl get "${DP_POD}" -o json |
+  jq -e '(.metadata.finalizers // []) | index("kmm.node.kubernetes.io/node-labeler")' > /dev/null
+echo "Hold ${DP_POD} so its deletion cannot complete..."
+hold_with_test_finalizer "${DP_POD}"
+trap 'release_test_finalizer "${DP_POD}" || true' EXIT
+
+kubectl delete module kmm-ci-device-plugin-only --wait=false
+
+# The DaemonSet goes with foreground propagation, so holding one of its Pods holds it too: what is
+# asked of it is that it has been asked to go. KMM taking its finalizer off the Pod is the signal.
+echo "Wait until the held Pod is the only thing the Module waits for..."
+DP_DEADLINE=$(( SECONDS + 120 ))
+while true; do
+  if ! DP_MODULE_JSON=$(kubectl get module kmm-ci-device-plugin-only --ignore-not-found -o json); then
+    echo "could not read the Module"
+    exit 1
+  fi
+  if [ -z "${DP_MODULE_JSON}" ]; then
+    echo "the Module was released before its Pod was let go"
+    exit 1
+  fi
+
+  if ! DP_POD_JSON=$(kubectl get "${DP_POD}" --ignore-not-found -o json); then
+    echo "could not read ${DP_POD}"
+    exit 1
+  fi
+  if [ -z "${DP_POD_JSON}" ]; then
+    echo "the held Pod went while the Module was still here"
+    exit 1
+  fi
+
+  if ! DP_DS_JSON=$(kubectl get daemonset -l kmm.node.kubernetes.io/module.name=kmm-ci-device-plugin-only -o json); then
+    echo "could not list the device plugin DaemonSets"
+    exit 1
+  fi
+
+  if jq -e '
+        .metadata.deletionTimestamp != null
+        and (.metadata.finalizers == ["kmm.node.kubernetes.io/device-plugin-cleanup"])' <<< "${DP_MODULE_JSON}" > /dev/null &&
+     jq -e --arg uid "${DP_UID}" '
+        .metadata.uid == $uid
+        and .metadata.deletionTimestamp != null
+        and ((.metadata.finalizers // []) | index("tests.kmm.sigs.x-k8s.io/hold") != null)
+        and ((.metadata.finalizers // []) | index("kmm.node.kubernetes.io/node-labeler") == null)' <<< "${DP_POD_JSON}" > /dev/null &&
+     jq -e '[.items[] | select(.metadata.deletionTimestamp == null)] | length == 0' <<< "${DP_DS_JSON}" > /dev/null &&
+     kubectl get node minikube -o json |
+       jq -e --arg r "${DP_READY_LABEL}" '.metadata.labels | has($r) | not' > /dev/null; then
+    break
+  fi
+
+  if [ "${SECONDS}" -ge "${DP_DEADLINE}" ]; then
+    echo "timed out waiting for the held Pod to be the only thing the Module waits for"
+    jq -c '.metadata | {deletionTimestamp, finalizers}' <<< "${DP_MODULE_JSON}" || true
+    jq -c '.metadata | {uid, deletionTimestamp, finalizers}' <<< "${DP_POD_JSON}" || true
+    exit 1
+  fi
+
+  sleep 3
+done
+
+echo "Check that the Module is not released while its Pod is still there..."
+for _ in $(seq 10); do
+  MODULE_FINALIZERS=$(kubectl get module kmm-ci-device-plugin-only --ignore-not-found -o jsonpath='{.metadata.finalizers}')
+  case "${MODULE_FINALIZERS}" in
+    *kmm.node.kubernetes.io/device-plugin-cleanup*) ;;
+    *) echo "the Module was released with finalizers ${MODULE_FINALIZERS:-none} while its Pod was still there"; exit 1 ;;
+  esac
+  if [ "$(kubectl get "${DP_POD}" --ignore-not-found -o jsonpath='{.metadata.uid}')" != "${DP_UID}" ]; then
+    echo "the held Pod went or was replaced while the Module was still here"
+    exit 1
+  fi
+  sleep 2
+done
+
+echo "Release the Pod..."
+release_test_finalizer "${DP_POD}"
+trap - EXIT
+
+# A failed query is not the Pod having gone: only a call that came back, with nothing in it, is.
+echo "Check that the Pod, the Module and the node target label then go..."
+DP_GONE_DEADLINE=$(( SECONDS + 120 ))
+while true; do
+  if ! DP_LEFT=$(kubectl get "${DP_POD}" --ignore-not-found -o name); then
+    echo "could not read ${DP_POD}"
+    exit 1
+  fi
+  [ -z "${DP_LEFT}" ] && break
+  if [ "${SECONDS}" -ge "${DP_GONE_DEADLINE}" ]; then
+    echo "the held Pod did not go once the test finalizer was released"
+    exit 1
+  fi
+  sleep 3
+done
+
+kubectl wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci-device-plugin-only --timeout=2m
+kubectl get node minikube -o json |
+  jq -e --arg t "${DP_TARGET_LABEL}" '.metadata.labels | has($t) | not' > /dev/null

--- a/ci/prow/finalizer-test-lib.sh
+++ b/ci/prow/finalizer-test-lib.sh
@@ -1,0 +1,48 @@
+# Helpers for a test that holds an object with a finalizer of its own.
+#
+# metadata.finalizers is a list and a merge patch sends a list whole, so these read it back and
+# write it with only the test's entry added or taken out, under the resourceVersion they read.
+
+TEST_HOLD_FINALIZER=tests.kmm.sigs.x-k8s.io/hold
+
+edit_test_finalizer () {
+  local target=$1 action=$2 obj rv finalizers attempt
+
+  for attempt in 1 2 3 4 5; do
+    if ! obj=$(kubectl get "${target}" --ignore-not-found -o json); then
+      return 1
+    fi
+
+    if [ -z "${obj}" ]; then
+      # Only a read that came back empty says it has gone; it holds nothing, but cannot be held.
+      [ "${action}" = remove ] && return 0
+      return 1
+    fi
+
+    rv=$(jq -r '.metadata.resourceVersion' <<< "${obj}")
+    finalizers=$(jq -c --arg f "${TEST_HOLD_FINALIZER}" --arg a "${action}" '
+      (.metadata.finalizers // []) as $current
+      | if $a == "add" then
+          (if $current | index($f) then $current else $current + [$f] end)
+        else
+          [$current[] | select(. != $f)]
+        end' <<< "${obj}")
+
+    if kubectl patch "${target}" --type=merge \
+        -p "{\"metadata\":{\"resourceVersion\":\"${rv}\",\"finalizers\":${finalizers}}}" > /dev/null; then
+      return 0
+    fi
+
+    sleep 2
+  done
+
+  return 1
+}
+
+hold_with_test_finalizer () {
+  edit_test_finalizer "$1" add
+}
+
+release_test_finalizer () {
+  edit_test_finalizer "$1" remove
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -146,6 +146,7 @@ func main() {
 
 	dpc := controllers.NewDevicePluginReconciler(
 		client,
+		mgr.GetAPIReader(),
 		metricsAPI,
 		filterAPI,
 		nodeAPI,
@@ -181,7 +182,7 @@ func main() {
 	}
 
 	if kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
-		if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+		if err = controllers.NewDRAReconciler(client, mgr.GetAPIReader(), nodeAPI, scheme).SetupWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 		}
 	} else {

--- a/docs/mkdocs/documentation/troubleshooting.md
+++ b/docs/mkdocs/documentation/troubleshooting.md
@@ -52,3 +52,40 @@ Events:
   Normal  ModuleLoaded    4m17s  kmm   Module default/kmm-ci-a loaded into the kernel
   Normal  ModuleUnloaded  2s     kmm   Module default/kmm-ci-a unloaded from the kernel
 ```
+
+## A Module that stays in `Terminating`
+
+KMM holds a `Module` until the resources it created for that `Module` have gone.
+Deleting a `Module` therefore does not remove it straight away.
+
+| Finalizer                                      | Waits for                                                      |
+|------------------------------------------------|----------------------------------------------------------------|
+| `kmm.node.kubernetes.io/module-finalizer`      | no `NodeModulesConfig` still lists the kernel module as in use  |
+| `kmm.node.kubernetes.io/dra-cleanup`           | the DRA DaemonSets, their Pods and the `DeviceClass` objects    |
+| `kmm.node.kubernetes.io/device-plugin-cleanup` | the device plugin DaemonSets, their Pods and their node labels  |
+
+The finalizers still on the object say which of those has not finished:
+
+```shell
+kubectl get module "$name" -n "$namespace" -o jsonpath='{.metadata.finalizers}'
+```
+
+A `Module` that keeps `dra-cleanup` is often waiting on a `DeviceClass` that cannot
+finish being deleted. That one is worth checking first, because a `DeviceClass` is
+cluster scoped and is not garbage collected along with the `Module`:
+
+```shell
+kubectl get deviceclass -l "kmm.node.kubernetes.io/module.name=$name,kmm.node.kubernetes.io/module.namespace=$namespace" -o yaml
+```
+
+A `Module` that keeps `device-plugin-cleanup` is usually waiting on a Pod. The
+DaemonSet is deleted in the foreground, so it stays listed with a deletion
+timestamp until the Pods it owns have gone, and a Pod goes only once its
+`NodeLabelerFinalizer` has been released.
+
+The operator logs what each pass is still waiting for, under `Waiting for the ...
+resources to go before releasing the Module`: the DaemonSet count, whether any Pod
+is still there (`podsLeft`), and for DRA the DeviceClass count.
+
+Removing a finalizer by hand leaves those resources behind with nothing left to
+clean them up, so prefer clearing whatever is holding the resource itself.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -19,6 +19,11 @@ const (
 	ModuleFinalizer   = "kmm.node.kubernetes.io/module-finalizer"
 	JobEventFinalizer = "kmm.node.kubernetes.io/job-event-finalizer"
 
+	// Each plugin holds the Module itself, because ModuleFinalizer is released as soon as no NMC
+	// lists the Module as in use, which says nothing about whether the plugin has finished.
+	DRAFinalizer          = "kmm.node.kubernetes.io/dra-cleanup"
+	DevicePluginFinalizer = "kmm.node.kubernetes.io/device-plugin-cleanup"
+
 	ManagedClusterModuleNameLabel  = "kmm.node.kubernetes.io/managedclustermodule.name"
 	KernelVersionsClusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 	DockerfileCMKey                = "dockerfile"

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -57,12 +57,13 @@ type DevicePluginReconciler struct {
 
 func NewDevicePluginReconciler(
 	client client.Client,
+	apiReader client.Reader,
 	metricsAPI metrics.Metrics,
 	filter *filter.Filter,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) *DevicePluginReconciler {
-	reconHelperAPI := newDevicePluginReconcilerHelper(client, metricsAPI, nodeAPI, scheme)
+	reconHelperAPI := newDevicePluginReconcilerHelper(client, apiReader, metricsAPI, nodeAPI, scheme)
 	return &DevicePluginReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -91,31 +92,49 @@ func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.
 
 	logger := log.FromContext(ctx)
 
+	deleting := mod.GetDeletionTimestamp() != nil
+
+	// Goes on before anything it protects is written; one cannot be added once deletion has started.
+	if !deleting && mod.Spec.DevicePlugin != nil {
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DevicePluginFinalizer, true); err != nil {
+			return res, err
+		}
+	}
+
+	if !deleting {
+		r.reconHelperAPI.setKMMOMetrics(ctx)
+	}
+
+	// Ahead of the reads the normal path needs, so that a failure there cannot strand the Module.
+	if deleting || mod.Spec.DevicePlugin == nil {
+		done, err := r.reconHelperAPI.deleteDevicePluginResources(ctx, mod)
+		if err != nil {
+			return res, fmt.Errorf("could not delete device plugin resources: %v", err)
+		}
+
+		if !done {
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		// A status write moves the resourceVersion, so the release waits for the next pass.
+		if mod.Status.DevicePlugin != (kmmv1beta1.DaemonSetStatus{}) {
+			if err := r.reconHelperAPI.clearDevicePluginStatus(ctx, mod.DeepCopy()); err != nil {
+				return res, fmt.Errorf("could not clear the device plugin status: %v", err)
+			}
+
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DevicePluginFinalizer, false); err != nil {
+			return res, err
+		}
+
+		return res, nil
+	}
+
 	existingDevicePluginDS, err := r.reconHelperAPI.getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("could not get DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
-	}
-
-	if mod.GetDeletionTimestamp() != nil {
-		if err = r.reconHelperAPI.removeDevicePluginTargetLabels(ctx, mod); err != nil {
-			return ctrl.Result{}, fmt.Errorf("could not remove device-plugin-target labels on deletion: %v", err)
-		}
-		err = r.reconHelperAPI.deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS)
-		return ctrl.Result{}, err
-	}
-
-	r.reconHelperAPI.setKMMOMetrics(ctx)
-
-	if mod.Spec.DevicePlugin == nil {
-		if err = r.reconHelperAPI.removeDevicePluginTargetLabels(ctx, mod); err != nil {
-			return ctrl.Result{}, fmt.Errorf("could not remove device-plugin-target labels: %v", err)
-		}
-		if len(existingDevicePluginDS) > 0 {
-			if err = r.reconHelperAPI.deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		return ctrl.Result{}, r.reconHelperAPI.clearDevicePluginStatus(ctx, mod)
 	}
 
 	if err = r.reconHelperAPI.handleDevicePluginTargetLabels(ctx, mod); err != nil {
@@ -151,7 +170,7 @@ type devicePluginReconcilerHelperAPI interface {
 	handleDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 	removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
-	deleteDevicePluginDaemonSets(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error
+	deleteDevicePluginResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error)
 	moduleUpdateDevicePluginStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
 	clearDevicePluginStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	getModuleDevicePluginDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
@@ -159,12 +178,14 @@ type devicePluginReconcilerHelperAPI interface {
 
 type devicePluginReconcilerHelper struct {
 	client          client.Client
+	apiReader       client.Reader
 	metricsAPI      metrics.Metrics
 	daemonSetHelper daemonSetCreator
 	nodeAPI         node.Node
 }
 
 func newDevicePluginReconcilerHelper(client client.Client,
+	apiReader client.Reader,
 	metricsAPI metrics.Metrics,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
@@ -172,6 +193,7 @@ func newDevicePluginReconcilerHelper(client client.Client,
 	daemonSetHelper := newDaemonSetCreator(scheme)
 	return &devicePluginReconcilerHelper{
 		client:          client,
+		apiReader:       apiReader,
 		metricsAPI:      metricsAPI,
 		daemonSetHelper: daemonSetHelper,
 		nodeAPI:         nodeAPI,
@@ -261,20 +283,7 @@ func (dprh *devicePluginReconcilerHelper) handleDevicePluginTargetLabels(ctx con
 func (dprh *devicePluginReconcilerHelper) removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
 	targetLabel := utils.GetDevicePluginTargetNodeLabel(mod.Namespace, mod.Name)
 
-	nodes, err := dprh.nodeAPI.GetAllNodesBySelector(ctx, map[string]string{targetLabel: ""})
-	if err != nil {
-		return fmt.Errorf("could not list nodes with device-plugin-target label: %v", err)
-	}
-
-	var errs []error
-	for i := range nodes {
-		node := &nodes[i]
-		if err := dprh.nodeAPI.UpdateLabels(ctx, node, nil, map[string]string{targetLabel: ""}); err != nil {
-			errs = append(errs, fmt.Errorf("could not remove device-plugin-target label from node %s: %v", node.Name, err))
-		}
-	}
-
-	return errors.Join(errs...)
+	return removeNodeLabel(ctx, dprh.client, dprh.apiReader, targetLabel)
 }
 
 func (dprh *devicePluginReconcilerHelper) garbageCollect(ctx context.Context,
@@ -301,15 +310,54 @@ func (dprh *devicePluginReconcilerHelper) garbageCollect(ctx context.Context,
 	return nil
 }
 
-func (dprh *devicePluginReconcilerHelper) deleteDevicePluginDaemonSets(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error {
-	// delete all the Device Plugin Daemonset, in order to allow worker pods to delete kernel modules
-	for _, ds := range existingDevicePluginDS {
-		err := dprh.client.Delete(ctx, &ds)
-		if err != nil {
-			return fmt.Errorf("failed to delete device-plugin Daemonset %s/%s: %v", ds.Namespace, ds.Name, err)
+// deleteDevicePluginResources asks for the Module's device plugin resources to go and reports
+// whether they have, reading through the API reader since a stale cache reads as an empty cluster.
+func (dprh *devicePluginReconcilerHelper) deleteDevicePluginResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error) {
+	var errs []error
+
+	remaining := 0
+
+	dsList := appsv1.DaemonSetList{}
+	dsOpts := []client.ListOption{
+		client.MatchingLabels{constants.ModuleNameLabel: mod.Name},
+		client.InNamespace(mod.Namespace),
+	}
+	if err := dprh.apiReader.List(ctx, &dsList, dsOpts...); err != nil {
+		return false, fmt.Errorf("could not list device plugin DaemonSets for module %s/%s: %v", mod.Namespace, mod.Name, err)
+	}
+
+	daemonSets := make([]client.Object, 0, len(dsList.Items))
+	for i := range dsList.Items {
+		if devicePluginRole(dsList.Items[i].GetLabels()[constants.DaemonSetRole]) {
+			daemonSets = append(daemonSets, &dsList.Items[i])
 		}
 	}
-	return nil
+
+	stillThere, err := deletePluginObjects(ctx, dprh.client, daemonSets)
+	remaining += stillThere
+	errs = append(errs, err)
+
+	podsLeft, err := pluginPodsRemain(ctx, dprh.apiReader, mod.Namespace, mod.Name, devicePluginRole)
+	errs = append(errs, err)
+	if podsLeft {
+		remaining++
+	}
+
+	errs = append(errs, dprh.removeDevicePluginTargetLabels(ctx, mod))
+
+	joined := errors.Join(errs...)
+	if joined == nil && remaining > 0 {
+		log.FromContext(ctx).Info("Waiting for the device plugin resources to go before releasing the Module",
+			"daemonSets", len(daemonSets), "podsLeft", podsLeft)
+	}
+
+	return joined == nil && remaining == 0, joined
+}
+
+// devicePluginRole reports whether a role label belongs to the device plugin. Resources written
+// before the role label existed carry none, so anything that is not another plugin counts.
+func devicePluginRole(role string) bool {
+	return role != constants.ModuleLoaderRoleLabelValue && role != constants.DRARoleLabelValue
 }
 
 func (dprh *devicePluginReconcilerHelper) setKMMOMetrics(ctx context.Context) {

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -31,6 +32,7 @@ import (
 var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 	var (
 		ctrl            *gomock.Controller
+		clnt            *client.MockClient
 		mockReconHelper *MockdevicePluginReconcilerHelperAPI
 		mod             *kmmv1beta1.Module
 		dpr             *DevicePluginReconciler
@@ -38,16 +40,25 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
 		mockReconHelper = NewMockdevicePluginReconcilerHelperAPI(ctrl)
 
+		// The finalizer is already there, so these specs exercise the handlers rather than the
+		// pass that registers it. Registration has its own specs below.
 		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       namespace,
+				Name:            moduleName,
+				ResourceVersion: "1",
+				Finalizers:      []string{constants.DevicePluginFinalizer},
+			},
 			Spec: kmmv1beta1.ModuleSpec{
 				DevicePlugin: &kmmv1beta1.DevicePluginSpec{},
 			},
 		}
 
 		dpr = &DevicePluginReconciler{
+			client:         clnt,
 			reconHelperAPI: mockReconHelper,
 		}
 	})
@@ -57,12 +68,12 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 	DescribeTable("check error flows", func(getDSError, handleTargetLabelsError, handlePluginError, gcError bool) {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		returnedError := fmt.Errorf("some error")
+		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
 		if getDSError {
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, returnedError)
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil)
-		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
 		if handleTargetLabelsError {
 			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(returnedError)
 			goto executeTestFunction
@@ -97,8 +108,8 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 	It("Good flow", func() {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
+			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(nil),
@@ -113,48 +124,117 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 	It("module deletion flow", func() {
 		mod.SetDeletionTimestamp(&metav1.Time{})
-		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 
 		By("good flow")
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
-			mockReconHelper.EXPECT().deleteDevicePluginDaemonSets(ctx, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dpr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 
-		By("error flow - removeDevicePluginTargetLabels fails")
-		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
-		)
-
-		res, err = dpr.Reconcile(ctx, mod)
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).To(HaveOccurred())
-
-		By("error flow - deleteDevicePluginDaemonSets fails")
-		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
-			mockReconHelper.EXPECT().deleteDevicePluginDaemonSets(ctx, devicePluginDS).Return(fmt.Errorf("some error")),
-		)
+		By("error flow - cleanup fails")
+		mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(false, fmt.Errorf("some error"))
 
 		res, err = dpr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("keeps the finalizer while the device plugin resources are still there", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		// No Patch: nothing releases the Module until the cleanup says it is done.
+		mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(false, nil)
+
+		res, err := dpr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("registers its finalizer before it writes anything the finalizer protects", func() {
+		mod.Finalizers = nil
+		devicePluginDS := []appsv1.DaemonSet{{}}
+
+		gomock.InOrder(
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(constants.DevicePluginFinalizer))
+					Expect(string(data)).To(ContainSubstring(`"resourceVersion":"1"`))
+					return nil
+				},
+			),
+			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
+			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, mod, devicePluginDS).Return(nil),
+		)
+
+		_, err := dpr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("clears a leftover status in its own pass before releasing the Module", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+		mod.Status.DevicePlugin = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
+
+		// No Patch: a status write moves the resourceVersion, so the release waits for the
+		// next pass, which decides again from the spec.
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, gomock.Any()).Return(nil),
+		)
+
+		res, err := dpr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("does not touch the resources when its finalizer cannot be written", func() {
+		mod.Finalizers = nil
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		_, err := dpr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("writes nothing when the Module goes before its finalizer lands", func() {
+		mod.Finalizers = nil
+
+		// No helper expectations: a Module that has gone cannot be cleaned up later, so
+		// nothing may be written for it. Any call below is an unexpected call here.
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, mod.Name))
+
+		_, err := dpr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("keeps hold of the Module when the release cannot be written", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict")),
+		)
+
+		_, err := dpr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("no-op when spec.devicePlugin is nil and no existing DaemonSets", func() {
 		mod.Spec.DevicePlugin = nil
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
-			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dpr.Reconcile(ctx, mod)
@@ -165,14 +245,11 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 	It("cleanup when spec.devicePlugin is nil but existing DaemonSets present", func() {
 		mod.Spec.DevicePlugin = nil
-		devicePluginDS := []appsv1.DaemonSet{{}}
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
-			mockReconHelper.EXPECT().deleteDevicePluginDaemonSets(ctx, devicePluginDS).Return(nil),
-			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dpr.Reconcile(ctx, mod)
@@ -185,9 +262,8 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		mod.Spec.DevicePlugin = nil
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(false, fmt.Errorf("some error")),
 		)
 
 		res, err := dpr.Reconcile(ctx, mod)
@@ -200,11 +276,11 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		mod.Spec.DevicePlugin = nil
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
-			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
-			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(fmt.Errorf("some error")),
+			mockReconHelper.EXPECT().deleteDevicePluginResources(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, gomock.Any()).Return(fmt.Errorf("some error")),
 		)
+		mod.Status.DevicePlugin = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
 
 		res, err := dpr.Reconcile(ctx, mod)
 
@@ -319,7 +395,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil)
+		dprh = newDevicePluginReconcilerHelper(clnt, clnt, nil, mn, nil)
 	})
 
 	mod := &kmmv1beta1.Module{
@@ -405,39 +481,174 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 	})
 })
 
-var _ = Describe("DevicePluginReconciler_deleteDevicePluginDaemonSets", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		dprh devicePluginReconcilerHelperAPI
-		mn   node.Node
+var _ = Describe("DevicePluginReconciler_deleteDevicePluginResources", func() {
+	const (
+		modName = "my-mod"
+		modNS   = "my-ns"
 	)
 
+	var (
+		ctrl   *gomock.Controller
+		clnt   *client.MockClient
+		reader *client.MockClient
+		dprh   devicePluginReconcilerHelperAPI
+		mod    *kmmv1beta1.Module
+	)
+
+	// A separate mock for the API reader, so a read that went to the cached client instead shows
+	// up here as an unexpected call rather than passing.
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil)
+		reader = client.NewMockClient(ctrl)
+		dprh = newDevicePluginReconcilerHelper(clnt, reader, nil, nil, nil)
+		mod = &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: modName}}
 	})
 
-	existingDevicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 	ctx := context.Background()
 
-	It("good flow", func() {
-		clnt.EXPECT().Delete(ctx, &existingDevicePluginDS[0]).Return(nil)
+	listing := func(dss []appsv1.DaemonSet, pods []v1.Pod, nodes []v1.Node) {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				switch typed := l.(type) {
+				case *appsv1.DaemonSetList:
+					typed.Items = dss
+				case *v1.PodList:
+					typed.Items = pods
+				case *v1.NodeList:
+					typed.Items = nodes
+				}
+				return nil
+			},
+		).AnyTimes()
+	}
 
-		err := dprh.deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS)
+	It("is not done while a DaemonSet it asked for is still finalizing", func() {
+		now := metav1.Now()
+		listing([]appsv1.DaemonSet{{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS, Name: "ds", DeletionTimestamp: &now,
+			Finalizers: []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}}, nil, nil)
+
+		// No Delete: it has been asked for, and asking again would wake this controller each pass.
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
 	})
 
-	It("error flow", func() {
-		clnt.EXPECT().Delete(ctx, &existingDevicePluginDS[0]).Return(fmt.Errorf("some error"))
+	It("is done once nothing is left", func() {
+		listing(nil, nil, nil)
 
-		err := dprh.deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS)
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
+	})
+
+	It("still cleans up a DaemonSet written before the role label existed", func() {
+		legacy := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS, Name: "legacy-dp", UID: "uid", ResourceVersion: "3",
+		}}
+		listing([]appsv1.DaemonSet{legacy}, nil, nil)
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("leaves the other plugins alone", func() {
+		other := []appsv1.DaemonSet{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: "loader",
+				Labels: map[string]string{constants.DaemonSetRole: constants.ModuleLoaderRoleLabelValue}}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: "dra",
+				Labels: map[string]string{constants.DaemonSetRole: constants.DRARoleLabelValue}}},
+		}
+		listing(other, nil, nil)
+
+		// No Delete: neither belongs to the device plugin.
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
+	})
+
+	It("waits for a device plugin Pod that is still an object", func() {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS,
+			Name:      "dp-pod",
+			Labels: map[string]string{
+				constants.ModuleNameLabel: modName,
+				constants.DaemonSetRole:   constants.DevicePluginRoleLabelValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true)}},
+		}}
+		listing(nil, []v1.Pod{pod}, nil)
+
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("takes the target label off a node whose value was edited", func() {
+		targetLabel := utils.GetDevicePluginTargetNodeLabel(modNS, modName)
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:   "node1",
+			Labels: map[string]string{targetLabel: "not-empty", "keep": "me"},
+		}}
+		// The node is only returned for a key-existence selector, so a value match would find
+		// nothing here and the label would survive the Module.
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+				switch typed := l.(type) {
+				case *v1.NodeList:
+					Expect(opts).To(HaveLen(1))
+					Expect(opts[0]).To(Equal(ctrlclient.HasLabels{targetLabel}))
+					typed.Items = []v1.Node{node}
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				data, err := p.Data(o)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring(`"` + targetLabel + `":null`))
+				Expect(string(data)).NotTo(ContainSubstring("keep"))
+				return nil
+			},
+		)
+
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
+	})
+
+	It("is not done when a read fails", func() {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
 		Expect(err).To(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+	It("does not wait for another namespace's Module of the same name", func() {
+		// Same module.name label, different namespace: the list is namespaced, so nothing here
+		// belongs to this Module.
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+				switch l.(type) {
+				case *appsv1.DaemonSetList, *v1.PodList:
+					Expect(opts).To(ContainElement(ctrlclient.InNamespace(modNS)))
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		done, err := dprh.deleteDevicePluginResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
 	})
 })
-
 var _ = Describe("DevicePluginReconciler_setKMMOMetrics", func() {
 	var (
 		ctrl        *gomock.Controller
@@ -452,7 +663,7 @@ var _ = Describe("DevicePluginReconciler_setKMMOMetrics", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockMetrics = metrics.NewMockMetrics(ctrl)
 		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, mockMetrics, mn, nil)
+		dprh = newDevicePluginReconcilerHelper(clnt, clnt, mockMetrics, mn, nil)
 	})
 
 	ctx := context.Background()
@@ -563,7 +774,7 @@ var _ = Describe("DevicePluginReconciler_moduleUpdateDevicePluginStatus", func()
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil)
+		dprh = newDevicePluginReconcilerHelper(clnt, clnt, nil, mn, nil)
 	})
 
 	ctx := context.Background()

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -62,10 +62,11 @@ type DRAReconciler struct {
 
 func NewDRAReconciler(
 	client client.Client,
+	apiReader client.Reader,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) *DRAReconciler {
-	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, scheme)
+	reconHelperAPI := newDRAReconcilerHelper(client, apiReader, nodeAPI, scheme)
 	return &DRAReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -92,6 +93,42 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 
 	logger := log.FromContext(ctx)
 
+	deleting := mod.GetDeletionTimestamp() != nil
+
+	// Goes on before anything it protects is written; one cannot be added once deletion has started.
+	if !deleting && mod.Spec.DRA != nil {
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DRAFinalizer, true); err != nil {
+			return res, err
+		}
+	}
+
+	// Ahead of the reads the normal path needs, so that a failure there cannot strand the Module.
+	if deleting || mod.Spec.DRA == nil {
+		done, err := r.reconHelperAPI.deleteDRAResources(ctx, mod)
+		if err != nil {
+			return res, fmt.Errorf("could not delete DRA resources: %v", err)
+		}
+
+		if !done {
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		// A status write moves the resourceVersion, so the release waits for the next pass.
+		if mod.Status.DRA != (kmmv1beta1.DaemonSetStatus{}) {
+			if err := r.reconHelperAPI.clearDRAStatus(ctx, mod.DeepCopy()); err != nil {
+				return res, fmt.Errorf("could not clear the DRA status: %v", err)
+			}
+
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DRAFinalizer, false); err != nil {
+			return res, err
+		}
+
+		return res, nil
+	}
+
 	existingDRADS, err := r.reconHelperAPI.getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("could not get DRA DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
@@ -100,17 +137,6 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 	existingDCs, err := r.reconHelperAPI.getModuleDeviceClasses(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("could not get DeviceClasses for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
-	}
-
-	if mod.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace)
-	}
-
-	if mod.Spec.DRA == nil {
-		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, r.reconHelperAPI.clearDRAStatus(ctx, mod)
 	}
 
 	err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS)
@@ -144,7 +170,7 @@ type draReconcilerHelperAPI interface {
 	getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
 	garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
-	deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error
+	deleteDRAResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error)
 	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
 	clearDRAStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error)
@@ -153,17 +179,20 @@ type draReconcilerHelperAPI interface {
 
 type draReconcilerHelper struct {
 	client          client.Client
+	apiReader       client.Reader
 	daemonSetHelper draDaemonSetCreator
 	nodeAPI         node.Node
 }
 
 func newDRAReconcilerHelper(client client.Client,
+	apiReader client.Reader,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) draReconcilerHelperAPI {
 	daemonSetHelper := newDRADaemonSetCreator(scheme)
 	return &draReconcilerHelper{
 		client:          client,
+		apiReader:       apiReader,
 		daemonSetHelper: daemonSetHelper,
 		nodeAPI:         nodeAPI,
 	}
@@ -256,32 +285,71 @@ func isOlderVersionUnusedDRADaemonSet(ds *appsv1.DaemonSet, moduleNamespace, mod
 	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
 }
 
-// deleteDRAResources deletes all DRA-owned DaemonSets and DeviceClasses using label-based bulk deletion.
-func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
+// deleteDRAResources asks for the Module's DRA resources to go and reports whether they have,
+// reading through the API reader since a stale cache reads as an empty cluster.
+func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error) {
 	var errs []error
 
-	dsDeleteOpts := []client.DeleteAllOfOption{
+	remaining := 0
+
+	dsList := appsv1.DaemonSetList{}
+	dsOpts := []client.ListOption{
 		client.MatchingLabels{
-			constants.ModuleNameLabel: moduleName,
+			constants.ModuleNameLabel: mod.Name,
 			constants.DaemonSetRole:   constants.DRARoleLabelValue,
 		},
-		client.InNamespace(moduleNamespace),
+		client.InNamespace(mod.Namespace),
 	}
-	if err := drh.client.DeleteAllOf(ctx, &appsv1.DaemonSet{}, dsDeleteOpts...); err != nil {
-		errs = append(errs, fmt.Errorf("failed to delete DRA DaemonSets for module %s/%s: %v", moduleNamespace, moduleName, err))
+	if err := drh.apiReader.List(ctx, &dsList, dsOpts...); err != nil {
+		return false, fmt.Errorf("could not list DRA DaemonSets for module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
-	dcDeleteOpts := []client.DeleteAllOfOption{
+	daemonSets := make([]client.Object, 0, len(dsList.Items))
+	for i := range dsList.Items {
+		daemonSets = append(daemonSets, &dsList.Items[i])
+	}
+
+	stillThere, err := deletePluginObjects(ctx, drh.client, daemonSets)
+	remaining += stillThere
+	errs = append(errs, err)
+
+	podsLeft, err := pluginPodsRemain(ctx, drh.apiReader, mod.Namespace, mod.Name, func(role string) bool {
+		return role == constants.DRARoleLabelValue
+	})
+	errs = append(errs, err)
+	if podsLeft {
+		remaining++
+	}
+
+	// A DeviceClass is cluster scoped, so a namespaced Module cannot own it and the namespace is
+	// carried as a label instead. InNamespace would match nothing here.
+	dcList := resourcev1.DeviceClassList{}
+	dcOpts := []client.ListOption{
 		client.MatchingLabels{
-			constants.ModuleNameLabel:      moduleName,
-			constants.ModuleNamespaceLabel: moduleNamespace,
+			constants.ModuleNameLabel:      mod.Name,
+			constants.ModuleNamespaceLabel: mod.Namespace,
 		},
 	}
-	if err := drh.client.DeleteAllOf(ctx, &resourcev1.DeviceClass{}, dcDeleteOpts...); err != nil {
-		errs = append(errs, fmt.Errorf("failed to delete DeviceClasses for module %s/%s: %v", moduleNamespace, moduleName, err))
+	if err := drh.apiReader.List(ctx, &dcList, dcOpts...); err != nil {
+		return false, fmt.Errorf("could not list DeviceClasses for module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
-	return errors.Join(errs...)
+	deviceClasses := make([]client.Object, 0, len(dcList.Items))
+	for i := range dcList.Items {
+		deviceClasses = append(deviceClasses, &dcList.Items[i])
+	}
+
+	stillThere, err = deletePluginObjects(ctx, drh.client, deviceClasses)
+	remaining += stillThere
+	errs = append(errs, err)
+
+	joined := errors.Join(errs...)
+	if joined == nil && remaining > 0 {
+		log.FromContext(ctx).Info("Waiting for the DRA resources to go before releasing the Module",
+			"daemonSets", len(daemonSets), "podsLeft", podsLeft, "deviceClasses", len(deviceClasses))
+	}
+
+	return joined == nil && remaining == 0, joined
 }
 
 func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -47,6 +48,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	var (
 		ctrl            *gomock.Controller
+		clnt            *client.MockClient
 		mockReconHelper *MockdraReconcilerHelperAPI
 		mod             *kmmv1beta1.Module
 		dr              *DRAReconciler
@@ -54,16 +56,25 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
 		mockReconHelper = NewMockdraReconcilerHelperAPI(ctrl)
 
+		// The finalizer is already there, so these specs exercise the handlers rather than the
+		// pass that registers it. Registration has its own specs below.
 		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       namespace,
+				Name:            draModuleName,
+				ResourceVersion: "1",
+				Finalizers:      []string{constants.DRAFinalizer},
+			},
 			Spec: kmmv1beta1.ModuleSpec{
 				DRA: &kmmv1beta1.DRASpec{},
 			},
 		}
 
 		dr = &DRAReconciler{
+			client:         clnt,
 			reconHelperAPI: mockReconHelper,
 		}
 	})
@@ -134,14 +145,11 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	It("module deletion flow", func() {
 		mod.SetDeletionTimestamp(&metav1.Time{})
-		draDS := []appsv1.DaemonSet{{}}
-		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		By("good flow")
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -149,24 +157,103 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("error flow - deleteDRAResources fails")
-		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(fmt.Errorf("some error")),
-		)
+		mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(false, fmt.Errorf("some error"))
 
 		res, err = dr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("clears a leftover status in its own pass before releasing the Module", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+		mod.Status.DRA = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
+
+		// No Patch: a status write moves the resourceVersion, so the release waits for the
+		// next pass, which decides again from the spec.
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().clearDRAStatus(ctx, gomock.Any()).Return(nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("keeps the finalizer while the DRA resources are still there", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		// No Patch: nothing releases the Module until the cleanup says it is done.
+		mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(false, nil)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("registers its finalizer before it writes anything the finalizer protects", func() {
+		mod.Finalizers = nil
+
+		gomock.InOrder(
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(constants.DRAFinalizer))
+					Expect(string(data)).To(ContainSubstring(`"resourceVersion":"1"`))
+					return nil
+				},
+			),
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRA(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, nil).Return(nil),
+		)
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("does not touch the resources when its finalizer cannot be written", func() {
+		mod.Finalizers = nil
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("writes nothing when the Module goes before its finalizer lands", func() {
+		mod.Finalizers = nil
+
+		// No helper expectations: a Module that has gone cannot be cleaned up later, so
+		// nothing may be written for it. Any call below is an unexpected call here.
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, mod.Name))
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("keeps hold of the Module when the release cannot be written", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict")),
+		)
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("no-op when spec.dra is nil and no existing DaemonSets or DeviceClasses", func() {
 		mod.Spec.DRA = nil
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
-			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -177,14 +264,10 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	It("cleanup when spec.dra is nil but existing DaemonSets and DeviceClasses present", func() {
 		mod.Spec.DRA = nil
-		draDS := []appsv1.DaemonSet{{}}
-		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
-			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -197,11 +280,10 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		mod.Spec.DRA = nil
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(fmt.Errorf("some error")),
 		)
+		mod.Status.DRA = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
 
 		res, err := dr.Reconcile(ctx, mod)
 
@@ -315,7 +397,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		drh = newDRAReconcilerHelper(clnt, mn, nil)
+		drh = newDRAReconcilerHelper(clnt, clnt, mn, nil)
 	})
 
 	ctx := context.Background()
@@ -1271,55 +1353,169 @@ var _ = Describe("DRAReconciler_handleDeviceClasses", func() {
 })
 
 var _ = Describe("DRAReconciler_deleteDRAResources", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		drh  draReconcilerHelper
+	const (
+		modName = "my-mod"
+		modNS   = "my-ns"
 	)
 
+	var (
+		ctrl   *gomock.Controller
+		clnt   *client.MockClient
+		reader *client.MockClient
+		drh    draReconcilerHelper
+		mod    *kmmv1beta1.Module
+	)
+
+	// A separate mock for the API reader, so a read that went to the cached client instead shows
+	// up here as an unexpected call rather than passing.
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		drh = draReconcilerHelper{
-			client: clnt,
-		}
+		reader = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{client: clnt, apiReader: reader}
+		mod = &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: modName}}
 	})
 
 	ctx := context.Background()
 
-	It("should delete all DaemonSets and DeviceClasses via DeleteAllOf", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+	// listing feeds one call per list type, so a spec only has to name what it wants back.
+	listing := func(dss []appsv1.DaemonSet, pods []v1.Pod, dcs []resourcev1.DeviceClass) {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				switch typed := l.(type) {
+				case *appsv1.DaemonSetList:
+					typed.Items = dss
+				case *v1.PodList:
+					typed.Items = pods
+				case *resourcev1.DeviceClassList:
+					typed.Items = dcs
+				}
+				return nil
+			},
+		).AnyTimes()
+	}
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+	draPod := func(name string, owned bool) v1.Pod {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS,
+			Name:      name,
+			Labels: map[string]string{
+				constants.ModuleNameLabel: modName,
+				constants.DaemonSetRole:   constants.DRARoleLabelValue,
+			},
+		}}
+		if owned {
+			pod.OwnerReferences = []metav1.OwnerReference{{
+				Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true),
+			}}
+		}
+		return pod
+	}
+
+	It("is done once nothing is left", func() {
+		listing(nil, nil, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
 	})
 
-	It("should return error when DaemonSet DeleteAllOf fails", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds delete failed"))
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+	It("is not done while a DeviceClass it asked for is still finalizing", func() {
+		now := metav1.Now()
+		listing(nil, nil, []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{
+			Name: "class", DeletionTimestamp: &now,
+			Finalizers: []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}})
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
+		// No Delete: it has been asked for, and asking again would wake this controller each pass.
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
 	})
 
-	It("should return error when DeviceClass DeleteAllOf fails", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc delete failed"))
+	It("reports a DeviceClass read failure rather than an empty cluster", func() {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				if _, ok := l.(*resourcev1.DeviceClassList); ok {
+					return fmt.Errorf("some error")
+				}
+				return nil
+			},
+		).AnyTimes()
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		done, err := drh.deleteDRAResources(ctx, mod)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+		Expect(done).To(BeFalse())
 	})
 
-	It("should aggregate errors from both DeleteAllOf calls", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds error"))
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc error"))
+	It("is not done in the pass that asks for the DaemonSet to go", func() {
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS, Name: "dra-ds", UID: "ds-uid", ResourceVersion: "9",
+		}}
+		listing([]appsv1.DaemonSet{ds}, nil, nil)
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		// The delete pins the object that was read, so a same-named replacement is left alone.
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, opts ...ctrlclient.DeleteOption) error {
+				do := &ctrlclient.DeleteOptions{}
+				for _, opt := range opts {
+					opt.ApplyToDelete(do)
+				}
+				Expect(*do.Preconditions.UID).To(Equal(ds.UID))
+				Expect(*do.Preconditions.ResourceVersion).To(Equal(ds.ResourceVersion))
+				Expect(*do.PropagationPolicy).To(Equal(metav1.DeletePropagationForeground))
+				return nil
+			},
+		)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("waits for a driver Pod that is still an object", func() {
+		listing(nil, []v1.Pod{draPod("dra-pod", true)}, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("does not wait for a Pod no DaemonSet owns", func() {
+		listing(nil, []v1.Pod{draPod("worker", false)}, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
+	})
+
+	It("is not done while a DeviceClass is still there", func() {
+		dc := resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "gpu", UID: "dc-uid"}}
+		listing(nil, nil, []resourcev1.DeviceClass{dc})
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("is not done when a read fails, so an empty answer cannot be mistaken for an empty cluster", func() {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		done, err := drh.deleteDRAResources(ctx, mod)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
-		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+		Expect(done).To(BeFalse())
+	})
+
+	It("keeps the Module when a delete fails", func() {
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: "dra-ds"}}
+		listing([]appsv1.DaemonSet{ds}, nil, nil)
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(done).To(BeFalse())
 	})
 })

--- a/internal/controllers/mock_device_plugin_reconciler.go
+++ b/internal/controllers/mock_device_plugin_reconciler.go
@@ -54,18 +54,19 @@ func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) clearDevicePluginStat
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "clearDevicePluginStatus", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).clearDevicePluginStatus), ctx, mod)
 }
 
-// deleteDevicePluginDaemonSets mocks base method.
-func (m *MockdevicePluginReconcilerHelperAPI) deleteDevicePluginDaemonSets(ctx context.Context, existingDevicePluginDS []v1.DaemonSet) error {
+// deleteDevicePluginResources mocks base method.
+func (m *MockdevicePluginReconcilerHelperAPI) deleteDevicePluginResources(ctx context.Context, mod *v1beta1.Module) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "deleteDevicePluginDaemonSets", ctx, existingDevicePluginDS)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "deleteDevicePluginResources", ctx, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// deleteDevicePluginDaemonSets indicates an expected call of deleteDevicePluginDaemonSets.
-func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS any) *gomock.Call {
+// deleteDevicePluginResources indicates an expected call of deleteDevicePluginResources.
+func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) deleteDevicePluginResources(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDevicePluginDaemonSets", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).deleteDevicePluginDaemonSets), ctx, existingDevicePluginDS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDevicePluginResources", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).deleteDevicePluginResources), ctx, mod)
 }
 
 // garbageCollect mocks base method.

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -56,17 +56,18 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) clearDRAStatus(ctx, mod any) *
 }
 
 // deleteDRAResources mocks base method.
-func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
+func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, mod *v1beta1.Module) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "deleteDRAResources", ctx, moduleName, moduleNamespace)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "deleteDRAResources", ctx, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // deleteDRAResources indicates an expected call of deleteDRAResources.
-func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRAResources(ctx, moduleName, moduleNamespace any) *gomock.Call {
+func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRAResources(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRAResources", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRAResources), ctx, moduleName, moduleNamespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRAResources", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRAResources), ctx, mod)
 }
 
 // garbageCollectDRADaemonSets mocks base method.

--- a/internal/controllers/module_finalizer.go
+++ b/internal/controllers/module_finalizer.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// setModuleFinalizer adds or removes one finalizer and reports whether it wrote anything. The patch
+// carries the resourceVersion it read, so it fails rather than dropping one added in between.
+func setModuleFinalizer(
+	ctx context.Context,
+	c client.Client,
+	mod *kmmv1beta1.Module,
+	finalizer string,
+	present bool,
+) (bool, error) {
+	if controllerutil.ContainsFinalizer(mod, finalizer) == present {
+		return false, nil
+	}
+
+	// The API server refuses a finalizer added after deletion has started.
+	if present && mod.GetDeletionTimestamp() != nil {
+		return false, fmt.Errorf("cannot add finalizer %s to deleting module %s/%s", finalizer, mod.Namespace, mod.Name)
+	}
+
+	before := mod.DeepCopy()
+	updated := mod.DeepCopy()
+
+	if present {
+		controllerutil.AddFinalizer(updated, finalizer)
+	} else {
+		controllerutil.RemoveFinalizer(updated, finalizer)
+	}
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := c.Patch(ctx, updated, patch); err != nil {
+		// A module that is gone needs no release, but it cannot protect a write either.
+		if !present && apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not patch finalizer %s on module %s/%s: %v", finalizer, mod.Namespace, mod.Name, err)
+	}
+
+	*mod = *updated
+
+	return true, nil
+}

--- a/internal/controllers/module_finalizer_test.go
+++ b/internal/controllers/module_finalizer_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+)
+
+var _ = Describe("setModuleFinalizer", func() {
+	const foreign = "example.com/someone-else"
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "ns",
+				Name:            "mod",
+				ResourceVersion: "42",
+				Finalizers:      []string{constants.ModuleFinalizer, foreign},
+			},
+		}
+	})
+
+	ctx := context.Background()
+
+	// payloadOf runs the patch the way the client would and hands back what it would send.
+	payloadOf := func() *[]byte {
+		var sent []byte
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				data, err := p.Data(o)
+				Expect(err).NotTo(HaveOccurred())
+				sent = data
+				return nil
+			},
+		)
+		return &sent
+	}
+
+	It("writes nothing when the finalizer is already as asked for", func() {
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.ModuleFinalizer, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("locks the write to the version it read, so a concurrent finalizer is not dropped", func() {
+		sent := payloadOf()
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		var patch struct {
+			Metadata struct {
+				ResourceVersion string   `json:"resourceVersion"`
+				Finalizers      []string `json:"finalizers"`
+			} `json:"metadata"`
+		}
+		Expect(json.Unmarshal(*sent, &patch)).To(Succeed())
+		Expect(patch.Metadata.ResourceVersion).To(Equal("42"))
+		Expect(patch.Metadata.Finalizers).To(ContainElements(constants.ModuleFinalizer, foreign, constants.DRAFinalizer))
+	})
+
+	It("leaves the other finalizers in place when it removes its own", func() {
+		mod.Finalizers = append(mod.Finalizers, constants.DevicePluginFinalizer)
+		sent := payloadOf()
+
+		_, err := setModuleFinalizer(ctx, clnt, mod, constants.DevicePluginFinalizer, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(string(*sent)).To(ContainSubstring(foreign))
+		Expect(string(*sent)).To(ContainSubstring(constants.ModuleFinalizer))
+		Expect(string(*sent)).NotTo(ContainSubstring(constants.DevicePluginFinalizer))
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DevicePluginFinalizer))
+	})
+
+	It("does not report protection the API server refused", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+		Expect(changed).To(BeFalse())
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DRAFinalizer))
+	})
+
+	It("refuses to add one to a module that is already going", func() {
+		now := metav1.Now()
+		mod.DeletionTimestamp = &now
+
+		// No Patch: the API server would reject it anyway.
+		_, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("does not report protection on a module that has gone", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "mod"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+		Expect(changed).To(BeFalse())
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DRAFinalizer))
+	})
+
+	It("treats a module that has already gone as done", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "mod"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.ModuleFinalizer, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+})

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -228,9 +228,11 @@ func (mrh *moduleReconcilerHelper) setFinalizerAndStatus(ctx context.Context, mo
 	logger := log.FromContext(ctx)
 	logger.Info("Adding finalizer", "module name", mod.Name, "module namespace", mod.Namespace)
 
+	// The plugins hold their own finalizers on this object, and a merge patch sends the whole
+	// list, so this write has to fail on a stale read rather than drop theirs.
 	modCopy := mod.DeepCopy()
 	controllerutil.AddFinalizer(mod, constants.ModuleFinalizer)
-	err := mrh.client.Patch(ctx, mod, client.MergeFrom(modCopy))
+	err := mrh.client.Patch(ctx, mod, client.MergeFromWithOptions(modCopy, client.MergeFromWithOptimisticLock{}))
 	if err != nil {
 		return fmt.Errorf("failed to set finalizer for module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
@@ -286,7 +288,7 @@ func (mrh *moduleReconcilerHelper) finalizeModule(ctx context.Context, mod *kmmv
 	modCopy := mod.DeepCopy()
 	controllerutil.RemoveFinalizer(mod, constants.ModuleFinalizer)
 
-	return mrh.client.Patch(ctx, mod, client.MergeFrom(modCopy))
+	return mrh.client.Patch(ctx, mod, client.MergeFromWithOptions(modCopy, client.MergeFromWithOptimisticLock{}))
 }
 
 func (mrh *moduleReconcilerHelper) getNMCsByModuleSet(ctx context.Context, mod *kmmv1beta1.Module) (sets.Set[string], error) {

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -299,8 +300,39 @@ var _ = Describe("setFinalizerAndStatus", func() {
 		err := mrh.setFinalizerAndStatus(ctx, &mod)
 		Expect(err).To(HaveOccurred())
 	})
-})
+	// A merge patch sends the whole finalizer list, so an unlocked write from a stale read would
+	// take the plugin finalizers with it. Only the payload can show the lock is there.
+	locked := func(sent []byte) {
+		var patch struct {
+			Metadata struct {
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		Expect(json.Unmarshal(sent, &patch)).To(Succeed())
+		Expect(patch.Metadata.ResourceVersion).To(Equal("7"))
+	}
 
+	It("locks the version when it adds the module finalizer", func() {
+		mod := kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: moduleName, ResourceVersion: "7",
+		}}
+
+		gomock.InOrder(
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					locked(data)
+					return nil
+				},
+			),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Update(ctx, gomock.Any()).Return(nil),
+		)
+
+		Expect(mrh.setFinalizerAndStatus(ctx, &mod)).To(Succeed())
+	})
+})
 var _ = Describe("finalizeModule", func() {
 	const (
 		moduleName      = "moduleName"
@@ -421,8 +453,42 @@ var _ = Describe("finalizeModule", func() {
 
 		Expect(err).To(HaveOccurred())
 	})
-})
+	// A merge patch sends the whole finalizer list, so an unlocked write from a stale read would
+	// take the plugin finalizers with it. Only the payload can show the lock is there.
+	locked := func(sent []byte) {
+		var patch struct {
+			Metadata struct {
+				ResourceVersion string `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+		Expect(json.Unmarshal(sent, &patch)).To(Succeed())
+		Expect(patch.Metadata.ResourceVersion).To(Equal("7"))
+	}
 
+	It("locks the version when it removes the module finalizer", func() {
+		mod := kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: moduleName, ResourceVersion: "7",
+			Finalizers: []string{constants.ModuleFinalizer, constants.DRAFinalizer},
+		}}
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					locked(data)
+					// The plugin's finalizer survives this write.
+					Expect(string(data)).To(ContainSubstring(constants.DRAFinalizer))
+					return nil
+				},
+			),
+		)
+
+		Expect(mrh.finalizeModule(ctx, &mod)).To(Succeed())
+	})
+})
 var _ = Describe("handleMIC", func() {
 
 	const (

--- a/internal/controllers/plugin_cleanup.go
+++ b/internal/controllers/plugin_cleanup.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// pluginCleanupRequeue paces a cleanup pass: nothing wakes the controller when the last Pod goes.
+const pluginCleanupRequeue = 2 * time.Second
+
+// deletePluginObjects asks the objects that are not already going to go, and reports how many it
+// saw, since one that is still finalizing has not gone. Each delete pins what was read.
+func deletePluginObjects(ctx context.Context, c client.Client, objs []client.Object) (int, error) {
+	var errs []error
+
+	for _, obj := range objs {
+		// Asking again puts the GC finalizer back, and every one of those writes wakes us again.
+		if obj.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		opts := &client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{
+				UID:             ptr.To(obj.GetUID()),
+				ResourceVersion: ptr.To(obj.GetResourceVersion()),
+			},
+			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+		}
+
+		if err := c.Delete(ctx, obj, opts); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("could not delete %s %s/%s: %v",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err))
+		}
+	}
+
+	return len(objs), errors.Join(errs...)
+}
+
+// pluginPodsRemain reports whether a Pod a plugin DaemonSet owns is still an object, whatever its
+// phase. The count a DaemonSet reports says what is wanted, not what is left.
+func pluginPodsRemain(
+	ctx context.Context,
+	reader client.Reader,
+	namespace, moduleName string,
+	roleMatches func(string) bool,
+) (bool, error) {
+	pods := v1.PodList{}
+
+	opts := []client.ListOption{
+		client.MatchingLabels{constants.ModuleNameLabel: moduleName},
+		client.InNamespace(namespace),
+	}
+	if err := reader.List(ctx, &pods, opts...); err != nil {
+		return false, fmt.Errorf("could not list pods for module %s/%s: %v", namespace, moduleName, err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		// Worker pods carry the same module label but answer to the NMC, not to a plugin.
+		owner := metav1.GetControllerOf(pod)
+		if owner == nil || owner.Kind != "DaemonSet" {
+			continue
+		}
+
+		if roleMatches(pod.GetLabels()[constants.DaemonSetRole]) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// removeNodeLabel takes one label key off every node that carries it, whatever its value. A node
+// whose label was edited would otherwise keep it for good.
+func removeNodeLabel(ctx context.Context, c client.Client, reader client.Reader, key string) error {
+	nodes := v1.NodeList{}
+	if err := reader.List(ctx, &nodes, client.HasLabels{key}); err != nil {
+		return fmt.Errorf("could not list nodes with %s: %v", key, err)
+	}
+
+	// Spelled out, not diffed: labels is omitempty, so a node left with none diffs to labels null.
+	quoted, _ := json.Marshal(key) // cannot fail for a string
+	payload := []byte(`{"metadata":{"labels":{` + string(quoted) + `:null}}}`)
+
+	var errs []error
+
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+
+		// No optimistic lock: the patch names one key, so it cannot disturb another writer.
+		err := c.Patch(ctx, node, client.RawPatch(types.MergePatchType, payload))
+		if err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("could not remove %s from node %s: %v", key, node.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/controllers/plugin_cleanup_test.go
+++ b/internal/controllers/plugin_cleanup_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+)
+
+var _ = Describe("deletePluginObjects", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	It("pins the object it read, so a replacement under the same name is left alone", func() {
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "ds", UID: "the-uid", ResourceVersion: "11",
+		}}
+
+		clnt.EXPECT().Delete(ctx, ds, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ ctrlclient.Object, opts ...ctrlclient.DeleteOption) error {
+				do := &ctrlclient.DeleteOptions{}
+				for _, opt := range opts {
+					opt.ApplyToDelete(do)
+				}
+				Expect(*do.Preconditions.UID).To(BeEquivalentTo("the-uid"))
+				Expect(*do.Preconditions.ResourceVersion).To(Equal("11"))
+				Expect(*do.PropagationPolicy).To(Equal(metav1.DeletePropagationForeground))
+				return nil
+			},
+		)
+
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{ds})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("leaves an object that is already going alone, and still counts it", func() {
+		now := metav1.Now()
+		dc := &resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{
+			Name: "class", UID: "dc-uid", ResourceVersion: "20",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}
+
+		// No Delete expectation: asking again writes to the object and wakes the controller.
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{dc})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("asks only for the ones that are not going yet, and counts both", func() {
+		now := metav1.Now()
+		going := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "going", DeletionTimestamp: &now,
+			Finalizers: []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}
+		fresh := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "fresh"}}
+
+		clnt.EXPECT().Delete(ctx, fresh, gomock.Any()).Return(nil)
+
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{going, fresh})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(2))
+	})
+
+	It("does not fail over an object that has already gone", func() {
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ds"}}
+
+		clnt.EXPECT().Delete(ctx, ds, gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "ds"))
+
+		_, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{ds})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("goes on to the rest when one delete fails", func() {
+		first := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "first"}}
+		second := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "second"}}
+
+		clnt.EXPECT().Delete(ctx, first, gomock.Any()).Return(fmt.Errorf("some error"))
+		clnt.EXPECT().Delete(ctx, second, gomock.Any()).Return(nil)
+
+		_, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{first, second})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("pluginPodsRemain", func() {
+	const (
+		namespace  = "ns"
+		moduleName = "mod"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	isDRA := func(role string) bool { return role == constants.DRARoleLabelValue }
+
+	pod := func(role string, owned bool, phase v1.PodPhase) v1.Pod {
+		p := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "pod",
+				Labels: map[string]string{
+					constants.ModuleNameLabel: moduleName,
+					constants.DaemonSetRole:   role,
+				},
+			},
+			Status: v1.PodStatus{Phase: phase},
+		}
+		if owned {
+			p.OwnerReferences = []metav1.OwnerReference{{
+				Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true),
+			}}
+		}
+		return p
+	}
+
+	listing := func(pods ...v1.Pod) {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				l.(*v1.PodList).Items = pods
+				return nil
+			},
+		)
+	}
+
+	DescribeTable("what still counts as a pod that is there",
+		func(p v1.Pod, want bool) {
+			listing(p)
+
+			remain, err := pluginPodsRemain(ctx, clnt, namespace, moduleName, isDRA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(remain).To(Equal(want))
+		},
+		Entry("running", pod(constants.DRARoleLabelValue, true, v1.PodRunning), true),
+		Entry("succeeded", pod(constants.DRARoleLabelValue, true, v1.PodSucceeded), true),
+		Entry("failed", pod(constants.DRARoleLabelValue, true, v1.PodFailed), true),
+		Entry("owned by something other than a DaemonSet", pod(constants.DRARoleLabelValue, false, v1.PodRunning), false),
+		Entry("another plugin's", pod(constants.DevicePluginRoleLabelValue, true, v1.PodRunning), false),
+	)
+
+	It("reports a read failure rather than an empty cluster", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		_, err := pluginPodsRemain(ctx, clnt, namespace, moduleName, isDRA)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("removeNodeLabel", func() {
+	const key = "kmm.node.kubernetes.io/ns.mod.device-plugin-target"
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	It("looks for the key rather than a value, and takes only that key off", func() {
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name:   "node",
+			Labels: map[string]string{key: "edited", "other": "keep"},
+		}}
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, l ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+					Expect(opts).To(HaveLen(1))
+					Expect(opts[0]).To(Equal(ctrlclient.HasLabels{key}))
+					l.(*v1.NodeList).Items = []v1.Node{node}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(`"` + key + `":null`))
+					Expect(string(data)).NotTo(ContainSubstring("other"))
+					return nil
+				},
+			),
+		)
+
+		Expect(removeNodeLabel(ctx, clnt, clnt, key)).To(Succeed())
+	})
+
+	It("names the key even when it is the last label on the node", func() {
+		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node", Labels: map[string]string{key: ""}}}
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+					l.(*v1.NodeList).Items = []v1.Node{node}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(`"` + key + `":null`))
+					return nil
+				},
+			),
+		)
+
+		Expect(removeNodeLabel(ctx, clnt, clnt, key)).To(Succeed())
+	})
+
+	It("reports a read failure rather than an empty cluster", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		Expect(removeNodeLabel(ctx, clnt, clnt, key)).NotTo(Succeed())
+	})
+
+	It("does not fail over a node that has gone", func() {
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+					l.(*v1.NodeList).Items = []v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node"}}}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, "node")),
+		)
+
+		Expect(removeNodeLabel(ctx, clnt, clnt, key)).To(Succeed())
+	})
+
+	It("reports a patch that was refused, so the module is not released", func() {
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+					l.(*v1.NodeList).Items = []v1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node"}}}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+				Return(apierrors.NewForbidden(schema.GroupResource{}, "node", fmt.Errorf("nope"))),
+		)
+
+		Expect(removeNodeLabel(ctx, clnt, clnt, key)).NotTo(Succeed())
+	})
+})

--- a/internal/controllers/pod_node_label_reconciler.go
+++ b/internal/controllers/pod_node_label_reconciler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/util/podutils"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -140,6 +141,11 @@ func (r *PodNodeLabelReconciler) deleteLabel(ctx context.Context, nodeName strin
 	node := v1.Node{}
 
 	if err := r.client.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
+		// A node that is gone carries no label; erroring here would hold the Pod finalizer for good.
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
 		return fmt.Errorf("could not get node %s: %v", nodeName, err)
 	}
 
@@ -155,7 +161,8 @@ func (r *PodNodeLabelReconciler) deleteFinalizer(ctx context.Context, pod *v1.Po
 
 	controllerutil.RemoveFinalizer(pod, constants.NodeLabelerFinalizer)
 
-	return r.client.Patch(ctx, pod, client.MergeFrom(podCopy))
+	// A merge patch sends the whole list, so a stale read here would drop what else holds the Pod.
+	return r.client.Patch(ctx, pod, client.MergeFromWithOptions(podCopy, client.MergeFromWithOptimisticLock{}))
 }
 
 func (r *PodNodeLabelReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controllers/pod_node_label_reconciler_test.go
+++ b/internal/controllers/pod_node_label_reconciler_test.go
@@ -3,6 +3,9 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	mock_client "github.com/kubernetes-sigs/kernel-module-management/internal/client"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
@@ -36,6 +39,25 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 	})
 
 	ctx := context.Background()
+
+	Context("a node that has gone", func() {
+		It("counts as unlabeled, so the pod finalizer is not held for a node that no longer exists", func() {
+			kubeClient.EXPECT().
+				Get(ctx, types.NamespacedName{Name: nodeName}, gomock.Any()).
+				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, nodeName))
+
+			// No Patch: there is nothing left to take the label off.
+			Expect(r.deleteLabel(ctx, nodeName, "some-label")).To(Succeed())
+		})
+
+		It("still reports a real read failure, so the label is not assumed gone", func() {
+			kubeClient.EXPECT().
+				Get(ctx, types.NamespacedName{Name: nodeName}, gomock.Any()).
+				Return(apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, nodeName, fmt.Errorf("nope")))
+
+			Expect(r.deleteLabel(ctx, nodeName, "some-label")).NotTo(Succeed())
+		})
+	})
 
 	Context("device-plugin pods", func() {
 		It("should return an error if the pod is not labeled", func() {
@@ -139,7 +161,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			kubeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&v1.Pod{}), gomock.Any()).Do(
 				func(_ interface{}, pod *v1.Pod, p client.Patch, _ ...client.GetOption) {
 					Expect(p.Type()).To(Equal(types.MergePatchType))
-					Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null}}`)))
+					Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null,"resourceVersion":"1"}}`)))
 				},
 			)
 
@@ -149,6 +171,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 					Finalizers:        []string{constants.NodeLabelerFinalizer},
 					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
 					Name:              podName,
+					ResourceVersion:   "1",
 				},
 			}
 
@@ -172,10 +195,11 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{constants.NodeLabelerFinalizer},
-					Labels:     map[string]string{constants.ModuleNameLabel: moduleName},
-					Name:       podName,
-					Namespace:  podNamespace,
+					Finalizers:      []string{constants.NodeLabelerFinalizer},
+					Labels:          map[string]string{constants.ModuleNameLabel: moduleName},
+					Name:            podName,
+					Namespace:       podNamespace,
+					ResourceVersion: "1",
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 				Status: v1.PodStatus{
@@ -204,7 +228,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 
 			patchRemoveFinalizerFunc := func(_ interface{}, pod *v1.Pod, p client.Patch, _ ...client.GetOption) {
 				Expect(p.Type()).To(Equal(types.MergePatchType))
-				Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null}}`)))
+				Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null,"resourceVersion":"1"}}`)))
 			}
 
 			gomock.InOrder(
@@ -220,12 +244,42 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 					Finalizers:        []string{constants.NodeLabelerFinalizer},
 					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
 					Name:              podName,
+					ResourceVersion:   "1",
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
 
 			_, err := r.Reconcile(ctx, pod)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("a pod another controller is also holding", func() {
+		It("takes only its own finalizer off, and fails on a stale read rather than dropping theirs", func() {
+			const foreign = "example.com/other-controller"
+
+			now := metav1.Now()
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+					Finalizers:        []string{constants.NodeLabelerFinalizer, foreign},
+					Name:              podName,
+					ResourceVersion:   "42",
+				},
+			}
+
+			kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o client.Object, patch client.Patch, _ ...client.PatchOption) error {
+					data, err := patch.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(foreign))
+					Expect(string(data)).NotTo(ContainSubstring(constants.NodeLabelerFinalizer))
+					Expect(string(data)).To(ContainSubstring(`"resourceVersion":"42"`))
+					return nil
+				},
+			)
+
+			Expect(r.deleteFinalizer(ctx, pod)).To(Succeed())
 		})
 	})
 
@@ -361,8 +415,9 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name:      podName,
-					Namespace: podNamespace,
+					Name:            podName,
+					Namespace:       podNamespace,
+					ResourceVersion: "1",
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 				Status: v1.PodStatus{
@@ -385,7 +440,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			kubeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&v1.Pod{}), gomock.Any()).Do(
 				func(_ interface{}, pod *v1.Pod, p client.Patch, _ ...client.GetOption) {
 					Expect(p.Type()).To(Equal(types.MergePatchType))
-					Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null}}`)))
+					Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null,"resourceVersion":"1"}}`)))
 				},
 			)
 
@@ -397,7 +452,8 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:            podName,
+					ResourceVersion: "1",
 				},
 			}
 
@@ -417,7 +473,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 
 			patchRemoveFinalizerFunc := func(_ interface{}, pod *v1.Pod, p client.Patch, _ ...client.GetOption) {
 				Expect(p.Type()).To(Equal(types.MergePatchType))
-				Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null}}`)))
+				Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null,"resourceVersion":"1"}}`)))
 			}
 
 			gomock.InOrder(
@@ -435,7 +491,8 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:            podName,
+					ResourceVersion: "1",
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}


### PR DESCRIPTION
This patch gives the DRA and device plugin reconcilers a finalizer of their own on the Module, so that a Module is not deleted before either of them has finished cleaning up.

The two plugins have the same gap and the fix is the same shape for both, so they are here together.

### Why the cleanup can be skipped today

`finalizeModule` waits on the NMC in-use labels and knows nothing about either plugin. A Module with a plugin spec and no `moduleLoader` has no NMC at all, so both of its lists come back empty and `ModuleFinalizer` is removed on the first pass after the deletion starts.

`reconcile.AsReconciler` ends its Get with `client.IgnoreNotFound(err)`, so once the object is gone the typed `Reconcile` is never called again. Returning an error to be retried does not help, because there is nothing left to retry against.

A DeviceClass is cluster scoped, so a namespaced Module cannot be a valid owner and ownerReferences do not cover it either. Nothing else would collect it.

### The shared finalizer list

`setFinalizerAndStatus` and `finalizeModule` both patch `metadata.finalizers` with `client.MergeFrom`. A merge patch sends that list whole. Computed from a read that predates the plugin finalizer, the removal sends:

```
{"metadata":{"finalizers":null}}
```

which drops every finalizer on the object, not only its own. Both writers now take `client.MergeFromWithOptimisticLock{}` and fail on a stale read instead. This is not optional for the rest of the patch to work.

The Pod node label reconciler removes its own finalizer from the plugin Pods the same way, and the Module now waits behind those Pods, so that write takes the lock too. Its test asserted the payload `{"metadata":{"finalizers":null}}`, which is right while nothing else is holding the Pod and wrong the moment something is.

### Registering the finalizer

Registration goes in before anything the finalizer protects is written, and a Module that has gone between the read and that write is not read as one that no longer needs it. Nothing would be left to run the cleanup, and the pass would carry on to write a DeviceClass, or leave target labels on nodes, with no Module to collect them. Removal still treats `NotFound` as done, since a Module that is gone has nothing left to release.

### Reporting cleanup as done

The API server accepting a DELETE is not the object having gone, and a cache that has not caught up would report an empty cluster either way, so the cleanup reads through `mgr.GetAPIReader()` and reports `done` only when it finds nothing left. A Pod counts while it is still an object, whatever its phase, and only when a DaemonSet owns it, so worker Pods are not waited for. Deletes carry the UID and resourceVersion that were read, so a replacement under the same name is left alone.

Only objects that are not already going are asked for. A repeat foreground delete puts `foregroundDeletion` back after the collector took it off, and both of those writes come back through the DeviceClass watch as another pass: on a held DeviceClass that ran the cleanup ten times a second, and the version-locked patch that releases the hold could never land between two of them. Measured on kind, the same wait now logs one pass every 2.014s rather than every 0.1s. The count still covers everything that was listed, so an object that is still finalizing keeps the Module: counting deletes sent instead would release it early.

Two existing behaviours are kept: DaemonSets and Pods written before the role label existed are still matched, per the `TODO(3.0)` in `getModuleDevicePluginDaemonSets`, and node target labels are now found by key rather than by value, so a node whose label was edited is not missed.

The patch that takes a target label off names the key rather than being diffed off the node. `Labels` is `omitempty`, so a node left with none serialises without the field and the diff becomes `{"metadata":{"labels":null}}`, which would take that node's other labels with it. A node always carries the kubelet's own labels, so this is a property of the helper rather than something reachable on a real node, but what it sends should not rest on that.

### The deadlock this would otherwise create

Waiting for a plugin Pod means waiting for `NodeLabelerFinalizer` to come off it. `deleteLabel` in the Pod node label reconciler treated a missing Node as an error, so a Pod whose node had gone would keep that finalizer for good, and now the Module behind it as well. A node that is not there carries no label, so that case returns nil.

### Not in this patch

Module UID labels on the managed resources. `standardLabels` is used for both `ds.Spec.Selector.MatchLabels` and the pod template, and a DaemonSet selector is immutable once created, so that needs its own migration story.

### Docs

A Module that stays in `Terminating` is now something an operator can be asked about, so `troubleshooting.md` says which finalizer waits for what, why a DaemonSet can still be listed while it is on its way out, and that the log line each pass writes names the DaemonSets, Pods and DeviceClasses it can still see.

### Testing

Unit tests cover both reconcilers symmetrically, and every fix has a test that fails without it, checked by reverting the fix and confirming which spec goes red.

I also ran it on kind with Kubernetes v1.35.0, against this branch and against master for comparison. With a device-plugin Module that has no `moduleLoader`, and its Pod held by a test finalizer: `ModuleFinalizer` is gone within three seconds on both, but master deletes the Module in the same window and leaves the Pod behind, while this branch keeps the Module on `device-plugin-cleanup` until the hold is released, and then everything goes. The same with a DRA Module and its DeviceClass held: the DaemonSet and Pods are already collected, the DeviceClass sits in Terminating, and the Module waits on `dra-cleanup` for it.

That second sequence is now in `ci/prow/e2e-dra`, since a Module with no `moduleLoader` is the case where the generic finalizer leaves early and there is nothing else to fall back on. It waits for the DaemonSets and Pods to have gone and for `dra-cleanup` to be the only finalizer left before it starts watching, so that the held DeviceClass is the only thing the Module can still be waiting for, and it pins the DeviceClass UID so that one which goes early or comes back under the same name fails rather than reads as the one being held.

That ordering is doing work. Against a build where the DeviceClass no longer counts toward the cleanup's remaining work, with one DRA Pod held by a test finalizer, the version without the wait passes: the held Pod keeps the Module there for the whole interval on its own, and the check never reaches the DeviceClass. The version here fails, because the Module never gets to the state the check is about. Against master it fails at the first wait, on a finalizer that is never added.

The device plugin half is in `ci/prow/e2e-incluster-build`, which needs neither DRA nor a second node. It holds one of the plugin's Pods rather than a DeviceClass, and that is the case the DRA test cannot reach: the DaemonSet is deleted with foreground propagation, so it stays until that Pod has gone, and the Pod cannot go until `NodeLabelerFinalizer` comes off it. Waiting for the DaemonSet to disappear would therefore never come true here, so the wait is that everything has been asked to go and only the held Pod cannot finish.

The test's own finalizer goes on beside `NodeLabelerFinalizer`, never over it, and the wait is for the Pod to be left holding only the test's entry: what the test watches is KMM releasing its own. `metadata.finalizers` is a list and a merge patch sends a list whole, so both scripts go through `ci/prow/finalizer-test-lib.sh`, which reads the list back and writes it with only the test's entry added or taken out, under the resourceVersion it read. Neither the release nor the trap clears the list, so a Pod that KMM is still holding stays held rather than being tidied away by the test. Against a build that never removes `NodeLabelerFinalizer`, the test fails. It starts from a Pod that is ready and a node carrying both of the labels KMM sets for it, so that neither going missing later can read as cleanup when it was never set. Those two answer to different things: the ready label is the Pod finalizer's, and has to be off the node before the Pod is left holding only the test's entry, while the target label is the Module cleanup's and is checked at the end. On master it fails at the first wait, on a finalizer that is never added.

Fixes #1331

---

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
