### PR TITLE
Give the DRA reconciler a finalizer of its own

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	if kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
-		if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+		if err = controllers.NewDRAReconciler(client, mgr.GetAPIReader(), nodeAPI, scheme).SetupWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 		}
 	} else {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -19,6 +19,10 @@ const (
 	ModuleFinalizer   = "kmm.node.kubernetes.io/module-finalizer"
 	JobEventFinalizer = "kmm.node.kubernetes.io/job-event-finalizer"
 
+	// The DRA reconciler holds the Module itself, because ModuleFinalizer is released as soon as no
+	// NMC lists the Module as in use, which says nothing about whether the cleanup has finished.
+	DRAFinalizer = "kmm.node.kubernetes.io/dra-cleanup"
+
 	ManagedClusterModuleNameLabel  = "kmm.node.kubernetes.io/managedclustermodule.name"
 	KernelVersionsClusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 	DockerfileCMKey                = "dockerfile"

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -62,10 +62,11 @@ type DRAReconciler struct {
 
 func NewDRAReconciler(
 	client client.Client,
+	apiReader client.Reader,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) *DRAReconciler {
-	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, scheme)
+	reconHelperAPI := newDRAReconcilerHelper(client, apiReader, nodeAPI, scheme)
 	return &DRAReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -92,6 +93,42 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 
 	logger := log.FromContext(ctx)
 
+	deleting := mod.GetDeletionTimestamp() != nil
+
+	// Goes on before anything it protects is written; one cannot be added once deletion has started.
+	if !deleting && mod.Spec.DRA != nil {
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DRAFinalizer, true); err != nil {
+			return res, err
+		}
+	}
+
+	// Ahead of the reads the normal path needs, so that a failure there cannot strand the Module.
+	if deleting || mod.Spec.DRA == nil {
+		done, err := r.reconHelperAPI.deleteDRAResources(ctx, mod)
+		if err != nil {
+			return res, fmt.Errorf("could not delete DRA resources: %v", err)
+		}
+
+		if !done {
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		// A status write moves the resourceVersion, so the release waits for the next pass.
+		if mod.Status.DRA != (kmmv1beta1.DaemonSetStatus{}) {
+			if err := r.reconHelperAPI.clearDRAStatus(ctx, mod.DeepCopy()); err != nil {
+				return res, fmt.Errorf("could not clear the DRA status: %v", err)
+			}
+
+			return ctrl.Result{RequeueAfter: pluginCleanupRequeue}, nil
+		}
+
+		if _, err := setModuleFinalizer(ctx, r.client, mod, constants.DRAFinalizer, false); err != nil {
+			return res, err
+		}
+
+		return res, nil
+	}
+
 	existingDRADS, err := r.reconHelperAPI.getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("could not get DRA DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
@@ -100,17 +137,6 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 	existingDCs, err := r.reconHelperAPI.getModuleDeviceClasses(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("could not get DeviceClasses for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
-	}
-
-	if mod.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace)
-	}
-
-	if mod.Spec.DRA == nil {
-		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, r.reconHelperAPI.clearDRAStatus(ctx, mod)
 	}
 
 	err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS)
@@ -144,7 +170,7 @@ type draReconcilerHelperAPI interface {
 	getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
 	garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
-	deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error
+	deleteDRAResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error)
 	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
 	clearDRAStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error)
@@ -153,23 +179,28 @@ type draReconcilerHelperAPI interface {
 
 type draReconcilerHelper struct {
 	client          client.Client
+	apiReader       client.Reader
 	daemonSetHelper draDaemonSetCreator
 	nodeAPI         node.Node
 }
 
 func newDRAReconcilerHelper(client client.Client,
+	apiReader client.Reader,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) draReconcilerHelperAPI {
 	daemonSetHelper := newDRADaemonSetCreator(scheme)
 	return &draReconcilerHelper{
 		client:          client,
+		apiReader:       apiReader,
 		daemonSetHelper: daemonSetHelper,
 		nodeAPI:         nodeAPI,
 	}
 }
 
-func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
+// listModuleDRADaemonSets takes the reader, so that the same selector serves the cached pass and
+// the uncached check handleDRA makes before it generates a name.
+func listModuleDRADaemonSets(ctx context.Context, reader client.Reader, name, namespace string) ([]appsv1.DaemonSet, error) {
 	dsList := appsv1.DaemonSetList{}
 	opts := []client.ListOption{
 		client.MatchingLabels(map[string]string{
@@ -178,11 +209,15 @@ func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name
 		}),
 		client.InNamespace(namespace),
 	}
-	if err := drh.client.List(ctx, &dsList, opts...); err != nil {
+	if err := reader.List(ctx, &dsList, opts...); err != nil {
 		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
 	}
 
 	return dsList.Items, nil
+}
+
+func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
+	return listModuleDRADaemonSets(ctx, drh.client, name, namespace)
 }
 
 func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error {
@@ -193,6 +228,18 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 	logger := log.FromContext(ctx)
 
 	ds, version := getExistingDRADSFromVersion(existingDRADS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader)
+
+	// The finalizer registered above is a Module update, so the next pass can start before the
+	// DaemonSet informer has seen what this one created. Ask before generating another name.
+	if ds == nil {
+		fresh, err := listModuleDRADaemonSets(ctx, drh.apiReader, mod.Name, mod.Namespace)
+		if err != nil {
+			return err
+		}
+
+		ds, version = getExistingDRADSFromVersion(fresh, mod.Namespace, mod.Name, mod.Spec.ModuleLoader)
+	}
+
 	if ds == nil {
 		logger.Info("creating new DRA DaemonSet", "version", version)
 		ds = &appsv1.DaemonSet{
@@ -256,32 +303,72 @@ func isOlderVersionUnusedDRADaemonSet(ds *appsv1.DaemonSet, moduleNamespace, mod
 	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
 }
 
-// deleteDRAResources deletes all DRA-owned DaemonSets and DeviceClasses using label-based bulk deletion.
-func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
+// deleteDRAResources asks for the Module's DRA resources to go and reports whether they have,
+// reading through the API reader since a stale cache reads as an empty cluster.
+func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, mod *kmmv1beta1.Module) (bool, error) {
 	var errs []error
 
-	dsDeleteOpts := []client.DeleteAllOfOption{
+	remaining := 0
+
+	dsList := appsv1.DaemonSetList{}
+	dsOpts := []client.ListOption{
 		client.MatchingLabels{
-			constants.ModuleNameLabel: moduleName,
+			constants.ModuleNameLabel: mod.Name,
 			constants.DaemonSetRole:   constants.DRARoleLabelValue,
 		},
-		client.InNamespace(moduleNamespace),
+		client.InNamespace(mod.Namespace),
 	}
-	if err := drh.client.DeleteAllOf(ctx, &appsv1.DaemonSet{}, dsDeleteOpts...); err != nil {
-		errs = append(errs, fmt.Errorf("failed to delete DRA DaemonSets for module %s/%s: %v", moduleNamespace, moduleName, err))
+	if err := drh.apiReader.List(ctx, &dsList, dsOpts...); err != nil {
+		return false, fmt.Errorf("could not list DRA DaemonSets for module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
-	dcDeleteOpts := []client.DeleteAllOfOption{
+	daemonSets := make([]client.Object, 0, len(dsList.Items))
+	for i := range dsList.Items {
+		daemonSets = append(daemonSets, &dsList.Items[i])
+	}
+
+	stillThere, err := deletePluginObjects(ctx, drh.client, daemonSets)
+	remaining += stillThere
+	errs = append(errs, err)
+
+	podsLeft, err := pluginPodsRemain(ctx, drh.apiReader, mod.Namespace, mod.Name, func(role string) bool {
+		return role == constants.DRARoleLabelValue
+	})
+	errs = append(errs, err)
+	if podsLeft {
+		remaining++
+	}
+
+	// A DeviceClass is cluster scoped, so a namespaced Module cannot own it and the namespace is
+	// carried as a label instead. InNamespace would match nothing here.
+	dcList := resourcev1.DeviceClassList{}
+	dcOpts := []client.ListOption{
 		client.MatchingLabels{
-			constants.ModuleNameLabel:      moduleName,
-			constants.ModuleNamespaceLabel: moduleNamespace,
+			constants.ModuleNameLabel:      mod.Name,
+			constants.ModuleNamespaceLabel: mod.Namespace,
 		},
 	}
-	if err := drh.client.DeleteAllOf(ctx, &resourcev1.DeviceClass{}, dcDeleteOpts...); err != nil {
-		errs = append(errs, fmt.Errorf("failed to delete DeviceClasses for module %s/%s: %v", moduleNamespace, moduleName, err))
+	if err := drh.apiReader.List(ctx, &dcList, dcOpts...); err != nil {
+		errs = append(errs, fmt.Errorf("could not list DeviceClasses for module %s/%s: %v", mod.Namespace, mod.Name, err))
+		return false, errors.Join(errs...)
 	}
 
-	return errors.Join(errs...)
+	deviceClasses := make([]client.Object, 0, len(dcList.Items))
+	for i := range dcList.Items {
+		deviceClasses = append(deviceClasses, &dcList.Items[i])
+	}
+
+	stillThere, err = deletePluginObjects(ctx, drh.client, deviceClasses)
+	remaining += stillThere
+	errs = append(errs, err)
+
+	joined := errors.Join(errs...)
+	if joined == nil && remaining > 0 {
+		log.FromContext(ctx).Info("Waiting for the DRA resources to go before releasing the Module",
+			"daemonSets", len(daemonSets), "podsLeft", podsLeft, "deviceClasses", len(deviceClasses))
+	}
+
+	return joined == nil && remaining == 0, joined
 }
 
 func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
@@ -35,6 +36,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -42,11 +44,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var _ = Describe("NewDRAReconciler", func() {
+	It("gives the helper the API reader rather than the cached client", func() {
+		ctrl := gomock.NewController(GinkgoT())
+		clnt := client.NewMockClient(ctrl)
+		reader := client.NewMockClient(ctrl)
+
+		// The cleanup reads through the API reader on purpose, so the wiring is worth pinning.
+		r := NewDRAReconciler(clnt, reader, nil, scheme)
+
+		helper, ok := r.reconHelperAPI.(*draReconcilerHelper)
+		Expect(ok).To(BeTrue())
+		Expect(helper.client).To(BeIdenticalTo(clnt))
+		Expect(helper.apiReader).To(BeIdenticalTo(reader))
+	})
+})
+
 var _ = Describe("DRAReconciler_Reconcile", func() {
 	const draModuleName = "dra-module"
 
 	var (
 		ctrl            *gomock.Controller
+		clnt            *client.MockClient
 		mockReconHelper *MockdraReconcilerHelperAPI
 		mod             *kmmv1beta1.Module
 		dr              *DRAReconciler
@@ -54,16 +73,25 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
 		mockReconHelper = NewMockdraReconcilerHelperAPI(ctrl)
 
+		// The finalizer is already there, so these specs exercise the handlers rather than the
+		// pass that registers it. Registration has its own specs below.
 		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: draModuleName},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       namespace,
+				Name:            draModuleName,
+				ResourceVersion: "1",
+				Finalizers:      []string{constants.DRAFinalizer},
+			},
 			Spec: kmmv1beta1.ModuleSpec{
 				DRA: &kmmv1beta1.DRASpec{},
 			},
 		}
 
 		dr = &DRAReconciler{
+			client:         clnt,
 			reconHelperAPI: mockReconHelper,
 		}
 	})
@@ -134,14 +162,11 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	It("module deletion flow", func() {
 		mod.SetDeletionTimestamp(&metav1.Time{})
-		draDS := []appsv1.DaemonSet{{}}
-		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		By("good flow")
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -149,24 +174,103 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("error flow - deleteDRAResources fails")
-		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(fmt.Errorf("some error")),
-		)
+		mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(false, fmt.Errorf("some error"))
 
 		res, err = dr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("clears a leftover status in its own pass before releasing the Module", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+		mod.Status.DRA = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
+
+		// No Patch: a status write moves the resourceVersion, so the release waits for the
+		// next pass, which decides again from the spec.
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			mockReconHelper.EXPECT().clearDRAStatus(ctx, gomock.Any()).Return(nil),
+		)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("keeps the finalizer while the DRA resources are still there", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		// No Patch: nothing releases the Module until the cleanup says it is done.
+		mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(false, nil)
+
+		res, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.RequeueAfter).To(Equal(pluginCleanupRequeue))
+	})
+
+	It("registers its finalizer before it writes anything the finalizer protects", func() {
+		mod.Finalizers = nil
+
+		gomock.InOrder(
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					data, err := p.Data(o)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(data)).To(ContainSubstring(constants.DRAFinalizer))
+					Expect(string(data)).To(ContainSubstring(`"resourceVersion":"1"`))
+					return nil
+				},
+			),
+			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRA(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, nil).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, nil).Return(nil),
+		)
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("does not touch the resources when its finalizer cannot be written", func() {
+		mod.Finalizers = nil
+
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("writes nothing when the Module goes before its finalizer lands", func() {
+		mod.Finalizers = nil
+
+		// No helper expectations: a Module that has gone cannot be cleaned up later, so
+		// nothing may be written for it. Any call below is an unexpected call here.
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, mod.Name))
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("keeps hold of the Module when the release cannot be written", func() {
+		mod.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
+		gomock.InOrder(
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict")),
+		)
+
+		_, err := dr.Reconcile(ctx, mod)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("no-op when spec.dra is nil and no existing DaemonSets or DeviceClasses", func() {
 		mod.Spec.DRA = nil
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
-			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -177,14 +281,10 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	It("cleanup when spec.dra is nil but existing DaemonSets and DeviceClasses present", func() {
 		mod.Spec.DRA = nil
-		draDS := []appsv1.DaemonSet{{}}
-		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
-			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
@@ -197,11 +297,10 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		mod.Spec.DRA = nil
 
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
-			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod).Return(true, nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(fmt.Errorf("some error")),
 		)
+		mod.Status.DRA = kmmv1beta1.DaemonSetStatus{NodesMatchingSelectorNumber: 1}
 
 		res, err := dr.Reconcile(ctx, mod)
 
@@ -214,16 +313,21 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 	var (
 		ctrl         *gomock.Controller
 		clnt         *client.MockClient
+		reader       *client.MockClient
 		mockDSHelper *MockdraDaemonSetCreator
 		drh          draReconcilerHelper
 	)
 
+	// A separate mock for the API reader, so a read that went to the cached client instead shows
+	// up here as an unexpected call rather than passing.
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
+		reader = client.NewMockClient(ctrl)
 		mockDSHelper = NewMockdraDaemonSetCreator(ctrl)
 		drh = draReconcilerHelper{
 			client:          clnt,
+			apiReader:       reader,
 			daemonSetHelper: mockDSHelper,
 		}
 	})
@@ -242,6 +346,54 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("reuses the DaemonSet the last pass created, even when the cached list is empty", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{}},
+		}
+		existing := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: mod.Namespace, Name: "moduleName-dra-abcde",
+			Labels: map[string]string{
+				constants.ModuleNameLabel: mod.Name,
+				constants.DaemonSetRole:   constants.DRARoleLabelValue,
+			},
+		}}
+
+		// No Create: a second one under a generated name is what this guards against.
+		gomock.InOrder(
+			reader.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+					l.(*appsv1.DaemonSetList).Items = []appsv1.DaemonSet{*existing.DeepCopy()}
+					return nil
+				},
+			),
+			clnt.EXPECT().Get(ctx, ctrlclient.ObjectKeyFromObject(&existing), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ ctrlclient.ObjectKey, o ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+					existing.DeepCopyInto(o.(*appsv1.DaemonSet))
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).Return(nil),
+		)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		Expect(drh.handleDRA(ctx, &mod, nil)).To(Succeed())
+	})
+
+	It("creates nothing when it cannot confirm what is already there", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec:       kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{}},
+		}
+
+		// No Create: a failed read is not an empty cluster.
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		Expect(drh.handleDRA(ctx, &mod, nil)).NotTo(Succeed())
+	})
+
 	It("new daemonset", func() {
 		ctx := context.Background()
 		mod := kmmv1beta1.Module{
@@ -258,6 +410,20 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-dra-"},
 		}
 		gomock.InOrder(
+			// Asked before a name is generated, and asked of the API server: the cached list can
+			// still be empty when the pass that registered the finalizer has already created one.
+			reader.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, _ ctrlclient.ObjectList, opts ...ctrlclient.ListOption) error {
+					got := &ctrlclient.ListOptions{}
+					for _, o := range opts {
+						o.ApplyToList(got)
+					}
+					Expect(got.Namespace).To(Equal(mod.Namespace))
+					Expect(got.LabelSelector.String()).To(ContainSubstring(mod.Name))
+					Expect(got.LabelSelector.String()).To(ContainSubstring(constants.DRARoleLabelValue))
+					return nil
+				},
+			),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			mockDSHelper.EXPECT().setDRAAsDesired(ctx, newDS, &mod).Return(nil),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
@@ -315,7 +481,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		drh = newDRAReconcilerHelper(clnt, mn, nil)
+		drh = newDRAReconcilerHelper(clnt, clnt, mn, nil)
 	})
 
 	ctx := context.Background()
@@ -1348,55 +1514,217 @@ var _ = Describe("DRAReconciler_handleDeviceClasses", func() {
 })
 
 var _ = Describe("DRAReconciler_deleteDRAResources", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		drh  draReconcilerHelper
+	const (
+		modName = "my-mod"
+		modNS   = "my-ns"
 	)
 
+	var (
+		ctrl   *gomock.Controller
+		clnt   *client.MockClient
+		reader *client.MockClient
+		drh    draReconcilerHelper
+		mod    *kmmv1beta1.Module
+	)
+
+	// A separate mock for the API reader, so a read that went to the cached client instead shows
+	// up here as an unexpected call rather than passing.
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		drh = draReconcilerHelper{
-			client: clnt,
-		}
+		reader = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{client: clnt, apiReader: reader}
+		mod = &kmmv1beta1.Module{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: modName}}
 	})
 
 	ctx := context.Background()
 
-	It("should delete all DaemonSets and DeviceClasses via DeleteAllOf", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+	// listing feeds one call per list type, so a spec only has to name what it wants back.
+	listing := func(dss []appsv1.DaemonSet, pods []v1.Pod, dcs []resourcev1.DeviceClass) {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				switch typed := l.(type) {
+				case *appsv1.DaemonSetList:
+					typed.Items = dss
+				case *v1.PodList:
+					typed.Items = pods
+				case *resourcev1.DeviceClassList:
+					typed.Items = dcs
+				}
+				return nil
+			},
+		).AnyTimes()
+	}
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+	draPod := func(name string, owned bool) v1.Pod {
+		pod := v1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS,
+			Name:      name,
+			Labels: map[string]string{
+				constants.ModuleNameLabel: modName,
+				constants.DaemonSetRole:   constants.DRARoleLabelValue,
+			},
+		}}
+		if owned {
+			pod.OwnerReferences = []metav1.OwnerReference{{
+				Kind: "DaemonSet", Name: "ds", Controller: ptr.To(true),
+			}}
+		}
+		return pod
+	}
+
+	It("is done once nothing is left", func() {
+		listing(nil, nil, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
 	})
 
-	It("should return error when DaemonSet DeleteAllOf fails", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds delete failed"))
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+	// A DeviceClass is cluster scoped, so the namespace label is all that keeps this Module away
+	// from a same-named one in another namespace.
+	It("selects DeviceClasses by both Module labels rather than by namespace", func() {
+		var dcOpts ctrlclient.ListOptions
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, o ...ctrlclient.ListOption) error {
+				if _, ok := l.(*resourcev1.DeviceClassList); ok {
+					for _, opt := range o {
+						opt.ApplyToList(&dcOpts)
+					}
+				}
+				return nil
+			},
+		).Times(3)
+
+		_, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dcOpts.Namespace).To(BeEmpty())
+		Expect(dcOpts.LabelSelector.String()).To(Equal(labels.SelectorFromSet(map[string]string{
+			constants.ModuleNameLabel:      modName,
+			constants.ModuleNamespaceLabel: modNS,
+		}).String()))
 	})
 
-	It("should return error when DeviceClass DeleteAllOf fails", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc delete failed"))
+	It("is not done while a DeviceClass it asked for is still finalizing", func() {
+		now := metav1.Now()
+		listing(nil, nil, []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{
+			Name: "class", DeletionTimestamp: &now,
+			Finalizers: []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}})
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+		// No Delete: it has been asked for, and asking again would wake this controller each pass.
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
 	})
 
-	It("should aggregate errors from both DeleteAllOf calls", func() {
-		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds error"))
-		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc error"))
+	It("reports a DeviceClass read failure rather than an empty cluster", func() {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				if _, ok := l.(*resourcev1.DeviceClassList); ok {
+					return fmt.Errorf("some error")
+				}
+				return nil
+			},
+		).AnyTimes()
 
-		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		done, err := drh.deleteDRAResources(ctx, mod)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
-		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+		Expect(done).To(BeFalse())
+	})
+
+	It("is not done in the pass that asks for the DaemonSet to go", func() {
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: modNS, Name: "dra-ds", UID: "ds-uid", ResourceVersion: "9",
+		}}
+		listing([]appsv1.DaemonSet{ds}, nil, nil)
+
+		// The delete pins the object that was read, so a same-named replacement is left alone.
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, opts ...ctrlclient.DeleteOption) error {
+				do := &ctrlclient.DeleteOptions{}
+				for _, opt := range opts {
+					opt.ApplyToDelete(do)
+				}
+				Expect(*do.Preconditions.UID).To(Equal(ds.UID))
+				Expect(*do.Preconditions.ResourceVersion).To(Equal(ds.ResourceVersion))
+				Expect(*do.PropagationPolicy).To(Equal(metav1.DeletePropagationForeground))
+				return nil
+			},
+		)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("waits for a driver Pod that is still an object", func() {
+		listing(nil, []v1.Pod{draPod("dra-pod", true)}, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("does not wait for a Pod no DaemonSet owns", func() {
+		listing(nil, []v1.Pod{draPod("worker", false)}, nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeTrue())
+	})
+
+	It("is not done while a DeviceClass is still there", func() {
+		dc := resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "gpu", UID: "dc-uid"}}
+		listing(nil, nil, []resourcev1.DeviceClass{dc})
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(nil)
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("is not done when a read fails, so an empty answer cannot be mistaken for an empty cluster", func() {
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("keeps the Module when a delete fails", func() {
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: "dra-ds"}}
+		listing([]appsv1.DaemonSet{ds}, nil, nil)
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(done).To(BeFalse())
+	})
+
+	It("reports the delete that failed as well as the read that came after it", func() {
+		ds := appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: "dra-ds"}}
+
+		reader.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				switch typed := l.(type) {
+				case *appsv1.DaemonSetList:
+					typed.Items = []appsv1.DaemonSet{ds}
+				case *resourcev1.DeviceClassList:
+					return fmt.Errorf("device class read failed")
+				}
+				return nil
+			},
+		).AnyTimes()
+
+		clnt.EXPECT().Delete(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("daemonset delete failed"))
+
+		done, err := drh.deleteDRAResources(ctx, mod)
+		Expect(done).To(BeFalse())
+		Expect(err).To(MatchError(ContainSubstring("daemonset delete failed")))
+		Expect(err).To(MatchError(ContainSubstring("device class read failed")))
 	})
 })

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -56,17 +56,18 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) clearDRAStatus(ctx, mod any) *
 }
 
 // deleteDRAResources mocks base method.
-func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
+func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, mod *v1beta1.Module) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "deleteDRAResources", ctx, moduleName, moduleNamespace)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "deleteDRAResources", ctx, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // deleteDRAResources indicates an expected call of deleteDRAResources.
-func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRAResources(ctx, moduleName, moduleNamespace any) *gomock.Call {
+func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRAResources(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRAResources", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRAResources), ctx, moduleName, moduleNamespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRAResources", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRAResources), ctx, mod)
 }
 
 // garbageCollectDRADaemonSets mocks base method.

--- a/internal/controllers/module_finalizer.go
+++ b/internal/controllers/module_finalizer.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// setModuleFinalizer adds or removes one finalizer and reports whether it wrote anything. The patch
+// carries the resourceVersion it read, so it fails rather than dropping one added in between.
+func setModuleFinalizer(
+	ctx context.Context,
+	c client.Client,
+	mod *kmmv1beta1.Module,
+	finalizer string,
+	present bool,
+) (bool, error) {
+	if controllerutil.ContainsFinalizer(mod, finalizer) == present {
+		return false, nil
+	}
+
+	// The API server refuses a finalizer added after deletion has started.
+	if present && mod.GetDeletionTimestamp() != nil {
+		return false, fmt.Errorf("cannot add finalizer %s to deleting module %s/%s", finalizer, mod.Namespace, mod.Name)
+	}
+
+	before := mod.DeepCopy()
+	updated := mod.DeepCopy()
+
+	if present {
+		controllerutil.AddFinalizer(updated, finalizer)
+	} else {
+		controllerutil.RemoveFinalizer(updated, finalizer)
+	}
+
+	patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+	if err := c.Patch(ctx, updated, patch); err != nil {
+		// A module that is gone needs no release, but it cannot protect a write either.
+		if !present && apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("could not patch finalizer %s on module %s/%s: %v", finalizer, mod.Namespace, mod.Name, err)
+	}
+
+	*mod = *updated
+
+	return true, nil
+}

--- a/internal/controllers/module_finalizer_test.go
+++ b/internal/controllers/module_finalizer_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+)
+
+var _ = Describe("setModuleFinalizer", func() {
+	const foreign = "example.com/someone-else"
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       "ns",
+				Name:            "mod",
+				ResourceVersion: "42",
+				Finalizers:      []string{constants.ModuleFinalizer, foreign},
+			},
+		}
+	})
+
+	ctx := context.Background()
+
+	// payloadOf runs the patch the way the client would and hands back what it would send.
+	payloadOf := func() *[]byte {
+		var sent []byte
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, o ctrlclient.Object, p ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				data, err := p.Data(o)
+				Expect(err).NotTo(HaveOccurred())
+				sent = data
+				return nil
+			},
+		)
+		return &sent
+	}
+
+	It("writes nothing when the finalizer is already as asked for", func() {
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.ModuleFinalizer, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("locks the write to the version it read, so a concurrent finalizer is not dropped", func() {
+		sent := payloadOf()
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		var patch struct {
+			Metadata struct {
+				ResourceVersion string   `json:"resourceVersion"`
+				Finalizers      []string `json:"finalizers"`
+			} `json:"metadata"`
+		}
+		Expect(json.Unmarshal(*sent, &patch)).To(Succeed())
+		Expect(patch.Metadata.ResourceVersion).To(Equal("42"))
+		Expect(patch.Metadata.Finalizers).To(ContainElements(constants.ModuleFinalizer, foreign, constants.DRAFinalizer))
+	})
+
+	It("leaves the other finalizers in place when it removes its own", func() {
+		mod.Finalizers = append(mod.Finalizers, constants.DRAFinalizer)
+		sent := payloadOf()
+
+		_, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(string(*sent)).To(ContainSubstring(foreign))
+		Expect(string(*sent)).To(ContainSubstring(constants.ModuleFinalizer))
+		Expect(string(*sent)).NotTo(ContainSubstring(constants.DRAFinalizer))
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DRAFinalizer))
+	})
+
+	It("does not report protection the API server refused", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("conflict"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+		Expect(changed).To(BeFalse())
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DRAFinalizer))
+	})
+
+	It("refuses to add one to a module that is already going", func() {
+		now := metav1.Now()
+		mod.DeletionTimestamp = &now
+
+		// No Patch: the API server would reject it anyway.
+		_, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("does not report protection on a module that has gone", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "mod"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.DRAFinalizer, true)
+		Expect(err).To(HaveOccurred())
+		Expect(changed).To(BeFalse())
+		Expect(mod.Finalizers).NotTo(ContainElement(constants.DRAFinalizer))
+	})
+
+	It("treats a module that has already gone as done", func() {
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "mod"))
+
+		changed, err := setModuleFinalizer(ctx, clnt, mod, constants.ModuleFinalizer, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+})

--- a/internal/controllers/plugin_cleanup.go
+++ b/internal/controllers/plugin_cleanup.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// pluginCleanupRequeue paces a cleanup pass: nothing wakes the controller when the last Pod goes.
+const pluginCleanupRequeue = 2 * time.Second
+
+// deletePluginObjects asks the objects that are not already going to go, and reports how many it
+// saw, since one that is still finalizing has not gone. Each delete pins what was read.
+func deletePluginObjects(ctx context.Context, c client.Client, objs []client.Object) (int, error) {
+	var errs []error
+
+	for _, obj := range objs {
+		// Asking again puts the GC finalizer back, and every one of those writes wakes us again.
+		if obj.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		opts := &client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{
+				UID:             ptr.To(obj.GetUID()),
+				ResourceVersion: ptr.To(obj.GetResourceVersion()),
+			},
+			PropagationPolicy: ptr.To(metav1.DeletePropagationForeground),
+		}
+
+		if err := c.Delete(ctx, obj, opts); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("could not delete %s %s/%s: %v",
+				obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName(), err))
+		}
+	}
+
+	return len(objs), errors.Join(errs...)
+}
+
+// pluginPodsRemain reports whether a Pod a plugin DaemonSet owns is still an object, whatever its
+// phase. The count a DaemonSet reports says what is wanted, not what is left.
+func pluginPodsRemain(
+	ctx context.Context,
+	reader client.Reader,
+	namespace, moduleName string,
+	roleMatches func(string) bool,
+) (bool, error) {
+	pods := v1.PodList{}
+
+	opts := []client.ListOption{
+		client.MatchingLabels{constants.ModuleNameLabel: moduleName},
+		client.InNamespace(namespace),
+	}
+	if err := reader.List(ctx, &pods, opts...); err != nil {
+		return false, fmt.Errorf("could not list pods for module %s/%s: %v", namespace, moduleName, err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		// Worker pods carry the same module label but answer to the NMC, not to a plugin.
+		owner := metav1.GetControllerOf(pod)
+		if owner == nil || owner.Kind != "DaemonSet" {
+			continue
+		}
+
+		if roleMatches(pod.GetLabels()[constants.DaemonSetRole]) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/controllers/plugin_cleanup_test.go
+++ b/internal/controllers/plugin_cleanup_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubernetes-sigs/kernel-module-management/internal/client"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
+)
+
+var _ = Describe("deletePluginObjects", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	It("pins the object it read, so a replacement under the same name is left alone", func() {
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "ds", UID: "the-uid", ResourceVersion: "11",
+		}}
+
+		clnt.EXPECT().Delete(ctx, ds, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ ctrlclient.Object, opts ...ctrlclient.DeleteOption) error {
+				do := &ctrlclient.DeleteOptions{}
+				for _, opt := range opts {
+					opt.ApplyToDelete(do)
+				}
+				Expect(*do.Preconditions.UID).To(BeEquivalentTo("the-uid"))
+				Expect(*do.Preconditions.ResourceVersion).To(Equal("11"))
+				Expect(*do.PropagationPolicy).To(Equal(metav1.DeletePropagationForeground))
+				return nil
+			},
+		)
+
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{ds})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("leaves an object that is already going alone, and still counts it", func() {
+		now := metav1.Now()
+		dc := &resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{
+			Name: "class", UID: "dc-uid", ResourceVersion: "20",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}
+
+		// No Delete expectation: asking again writes to the object and wakes the controller.
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{dc})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(1))
+	})
+
+	It("asks only for the ones that are not going yet, and counts both", func() {
+		now := metav1.Now()
+		going := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns", Name: "going", DeletionTimestamp: &now,
+			Finalizers: []string{"tests.kmm.sigs.x-k8s.io/hold"},
+		}}
+		fresh := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "fresh"}}
+
+		clnt.EXPECT().Delete(ctx, fresh, gomock.Any()).Return(nil)
+
+		count, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{going, fresh})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(count).To(Equal(2))
+	})
+
+	It("does not fail over an object that has already gone", func() {
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ds"}}
+
+		clnt.EXPECT().Delete(ctx, ds, gomock.Any()).
+			Return(apierrors.NewNotFound(schema.GroupResource{}, "ds"))
+
+		_, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{ds})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("goes on to the rest when one delete fails", func() {
+		first := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "first"}}
+		second := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "second"}}
+
+		clnt.EXPECT().Delete(ctx, first, gomock.Any()).Return(fmt.Errorf("some error"))
+		clnt.EXPECT().Delete(ctx, second, gomock.Any()).Return(nil)
+
+		_, err := deletePluginObjects(ctx, clnt, []ctrlclient.Object{first, second})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("pluginPodsRemain", func() {
+	const (
+		namespace  = "ns"
+		moduleName = "mod"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	isDRA := func(role string) bool { return role == constants.DRARoleLabelValue }
+
+	pod := func(role, ownerKind string, phase v1.PodPhase) v1.Pod {
+		p := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "pod",
+				Labels: map[string]string{
+					constants.ModuleNameLabel: moduleName,
+					constants.DaemonSetRole:   role,
+				},
+			},
+			Status: v1.PodStatus{Phase: phase},
+		}
+		if ownerKind != "" {
+			p.OwnerReferences = []metav1.OwnerReference{{
+				Kind: ownerKind, Name: "owner", Controller: ptr.To(true),
+			}}
+		}
+		return p
+	}
+
+	listing := func(pods ...v1.Pod) {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, l ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+				l.(*v1.PodList).Items = pods
+				return nil
+			},
+		)
+	}
+
+	DescribeTable("what still counts as a pod that is there",
+		func(p v1.Pod, want bool) {
+			listing(p)
+
+			remain, err := pluginPodsRemain(ctx, clnt, namespace, moduleName, isDRA)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(remain).To(Equal(want))
+		},
+		Entry("running", pod(constants.DRARoleLabelValue, "DaemonSet", v1.PodRunning), true),
+		Entry("succeeded", pod(constants.DRARoleLabelValue, "DaemonSet", v1.PodSucceeded), true),
+		Entry("failed", pod(constants.DRARoleLabelValue, "DaemonSet", v1.PodFailed), true),
+		Entry("nothing owns it", pod(constants.DRARoleLabelValue, "", v1.PodRunning), false),
+		Entry("owned by something other than a DaemonSet", pod(constants.DRARoleLabelValue, "ReplicaSet", v1.PodRunning), false),
+		Entry("another plugin's", pod(constants.DevicePluginRoleLabelValue, "DaemonSet", v1.PodRunning), false),
+	)
+
+	It("reports a read failure rather than an empty cluster", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		_, err := pluginPodsRemain(ctx, clnt, namespace, moduleName, isDRA)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Second of the smaller pieces of #1342. It gives the DRA reconciler a finalizer of its own, and leaves the device plugin side, the e2e and the docs to the pieces after it.

This one builds on #1343 and should land after it. Without the version lock that #1343 puts on the two writers of `ModuleFinalizer`, a write from a stale read takes the finalizer added here off with it, and the cleanup below never runs.

## Why the cleanup can be skipped today

`finalizeModule` waits on the NMC in-use labels and knows nothing about DRA. A Module with a DRA spec and no `moduleLoader` has no NMC at all, so both of its lists come back empty and `ModuleFinalizer` is removed on the first pass after the deletion starts.

`reconcile.AsReconciler` ends its Get with `client.IgnoreNotFound(err)`, so once the object is gone the typed `Reconcile` is never called again. Returning an error to be retried does not help, because there is nothing left to retry against.

A DeviceClass is cluster scoped, so a namespaced Module cannot be a valid owner and ownerReferences do not cover it either. Nothing else would collect it.

## Registering it

Registration goes in before anything the finalizer protects is written, and a Module that has gone between the read and that write is not read as one that no longer needs it. Nothing would be left to run the cleanup, and the pass would carry on to write a DeviceClass with no Module to collect it. Removal still treats `NotFound` as done, since a Module that is gone has nothing left to release.

## Reporting cleanup as done

The API server accepting a DELETE is not the object having gone, and a cache that has not caught up would report an empty cluster either way, so the cleanup reads through `mgr.GetAPIReader()` and reports `done` only when it finds nothing left. Deletes carry the UID and resourceVersion that were read, so a replacement under the same name is left alone.

An object that is already going is counted rather than asked for again. A repeat foreground delete puts `foregroundDeletion` back after the collector has taken it off, and both of those writes come back through the DeviceClass watch as another pass. On kind that ran the cleanup ten times a second for as long as a DeviceClass was held; with the guard it is one pass every two seconds, which is the requeue the code asks for.

A Pod counts while it is still an object, whatever its phase, and only when a DaemonSet owns it, so worker Pods are not waited for.

A pass reports every failure it hit, not the last one. The DeviceClass read comes after the DaemonSets have been asked to go, and returning only its error would drop a delete that had already failed.

## Creating the DaemonSet only once

Registering the finalizer is a write to the Module, so the pass that does it queues another one. That next pass can reach `handleDRA` before the DaemonSet informer has seen what this one created, and the cached list it works from would still be empty. `CreateOrPatch` looks the object up by name, so an empty list means a second `GenerateName` and a second DaemonSet for the same version. Garbage collection only takes DaemonSets whose version label differs, so nothing collects it.

`handleDRA` now asks the API server before it decides to generate a name. Both reads go through the same selector, so a mistake in one of them cannot make the other look at something else.

## About the shared file

`plugin_cleanup.go` holds the two helpers this uses. The device plugin side in the next piece uses the same two, plus a third for its node labels, which is why they are not inlined here.

## Testing

Unit tests cover the registration and release paths, both callers of the cleanup, the terminating-object case, and the scope of each list the cleanup makes. That last one matters because a DeviceClass is cluster scoped, so the namespace label on it is all that keeps this Module away from a same-named one somewhere else. Every fix has a test that fails without it, checked by reverting the fix and confirming which spec goes red.

I also ran it on kind with Kubernetes v1.35.0. With a DRA Module that has no `moduleLoader` and its DeviceClass held by a test finalizer, `ModuleFinalizer` is off the Module about a tenth of a second after the delete, leaving `dra-cleanup` as the only one left; the Module stays there until the hold is released, and then everything goes. On main the Module is deleted in the same window and the DeviceClass is left behind.

Part of #1331.

---

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.



