### PR TITLE
Scope the replacement Pod lookup to the Module namespace

### DIFF
--- a/internal/controllers/pod_node_label_reconciler.go
+++ b/internal/controllers/pod_node_label_reconciler.go
@@ -74,7 +74,7 @@ func (r *PodNodeLabelReconciler) Reconcile(ctx context.Context, pod *v1.Pod) (ct
 			fieldSelector := client.MatchingFields{"spec.nodeName": nodeName}
 
 			var podsList v1.PodList
-			if err := r.client.List(ctx, &podsList, labelSelector, fieldSelector); err != nil {
+			if err := r.client.List(ctx, &podsList, client.InNamespace(pod.Namespace), labelSelector, fieldSelector); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to get list of pods for module %s on node %s: %v", moduleName, nodeName, err)
 			}
 

--- a/internal/controllers/pod_node_label_reconciler_test.go
+++ b/internal/controllers/pod_node_label_reconciler_test.go
@@ -46,13 +46,14 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 		It("should return an error if we failed to get the list of pods", func() {
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{constants.ModuleNameLabel: moduleName},
-					Name:   podName,
+					Labels:    map[string]string{constants.ModuleNameLabel: moduleName},
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
 
-			kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+			kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 			_, err := r.Reconcile(ctx, pod)
 			Expect(err).To(HaveOccurred())
@@ -68,7 +69,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			)
 
 			gomock.InOrder(
-				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Return(nil),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
 					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
 						node.SetLabels(map[string]string{utils.GetDevicePluginNodeLabel(podNamespace, moduleName): ""})
@@ -104,7 +105,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
 			)
 
-			kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Do(
+			kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Do(
 				func(_ interface{}, modulePodsList *v1.PodList, _ ...client.ListOption) {
 					modulePodsList.Items = []v1.Pod{
 						{
@@ -123,8 +124,9 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{constants.ModuleNameLabel: moduleName},
-					Name:   podName,
+					Labels:    map[string]string{constants.ModuleNameLabel: moduleName},
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
@@ -149,6 +151,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 					Finalizers:        []string{constants.NodeLabelerFinalizer},
 					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
 					Name:              podName,
+					Namespace:         podNamespace,
 				},
 			}
 
@@ -192,6 +195,68 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		// The node label carries the Module namespace, so a Module of the same name in another
+		// namespace is not a replacement for this one. The mock applies the namespace option the
+		// way a real client would, so a list that is not scoped sees the other namespace's Pod.
+		It("should ignore a Ready Pod of a same-named Module in another namespace", func() {
+			other := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.ModuleNameLabel: moduleName,
+						constants.DaemonSetRole:   constants.DevicePluginRoleLabelValue,
+					},
+					Name:      "other-namespace-pod",
+					Namespace: "other-namespace",
+				},
+				Spec:   v1.PodSpec{NodeName: nodeName},
+				Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}},
+			}
+
+			// One gomock.Any() for the whole variadic tail, so a list without the namespace option
+			// reaches the callback instead of being turned away on its argument count.
+			gomock.InOrder(
+				kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						o := client.ListOptions{}
+						for _, opt := range opts {
+							opt.ApplyToList(&o)
+						}
+						if o.Namespace == "" || o.Namespace == other.Namespace {
+							list.(*v1.PodList).Items = []v1.Pod{other}
+						}
+						return nil
+					},
+				),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
+						node.SetLabels(map[string]string{
+							utils.GetDevicePluginNodeLabel(podNamespace, moduleName):    "",
+							utils.GetDevicePluginNodeLabel(other.Namespace, moduleName): "",
+						})
+					},
+				),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, node *v1.Node, p client.Patch, _ ...client.GetOption) {
+						Expect(p.Data(node)).To(Equal([]byte(
+							`{"metadata":{"labels":{"` + utils.GetDevicePluginNodeLabel(podNamespace, moduleName) + `":null}}}`,
+						)))
+					},
+				),
+			)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:    map[string]string{constants.ModuleNameLabel: moduleName},
+					Name:      podName,
+					Namespace: podNamespace,
+				},
+				Spec: v1.PodSpec{NodeName: nodeName},
+			}
+
+			_, err := r.Reconcile(ctx, pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("should remove the pod finalizer when the pod is being deleted", func() {
 			now := metav1.Now()
 			var (
@@ -208,7 +273,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			}
 
 			gomock.InOrder(
-				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Return(nil),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(patchRemoveFinalizerFunc),
@@ -220,6 +285,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 					Finalizers:        []string{constants.NodeLabelerFinalizer},
 					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
 					Name:              podName,
+					Namespace:         podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
@@ -248,12 +314,13 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
 
-			kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+			kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error"))
 
 			_, err := r.Reconcile(ctx, pod)
 			Expect(err).To(HaveOccurred())
@@ -269,7 +336,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			)
 
 			gomock.InOrder(
-				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Return(nil),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
 					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
 						node.SetLabels(map[string]string{utils.GetDRANodeLabel(podNamespace, moduleName): ""})
@@ -308,7 +375,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
 			)
 
-			kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Do(
+			kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Do(
 				func(_ interface{}, draPodsList *v1.PodList, _ ...client.ListOption) {
 					draPodsList.Items = []v1.Pod{
 						{
@@ -331,7 +398,68 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:      podName,
+					Namespace: podNamespace,
+				},
+				Spec: v1.PodSpec{NodeName: nodeName},
+			}
+
+			_, err := r.Reconcile(ctx, pod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should ignore a Ready DRA Pod of a same-named Module in another namespace", func() {
+			other := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.ModuleNameLabel: moduleName,
+						constants.DaemonSetRole:   constants.DRARoleLabelValue,
+					},
+					Name:      "other-namespace-pod",
+					Namespace: "other-namespace",
+				},
+				Spec:   v1.PodSpec{NodeName: nodeName},
+				Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}},
+			}
+
+			gomock.InOrder(
+				kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						o := client.ListOptions{}
+						for _, opt := range opts {
+							opt.ApplyToList(&o)
+						}
+						if o.Namespace == "" || o.Namespace == other.Namespace {
+							list.(*v1.PodList).Items = []v1.Pod{other}
+						}
+						return nil
+					},
+				),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
+						node.SetLabels(map[string]string{
+							utils.GetDRANodeLabel(podNamespace, moduleName):    "",
+							utils.GetDRANodeLabel(other.Namespace, moduleName): "",
+						})
+					},
+				),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, node *v1.Node, p client.Patch, _ ...client.GetOption) {
+						Expect(p.Data(node)).To(Equal([]byte(
+							`{"metadata":{"labels":{"` + utils.GetDRANodeLabel(podNamespace, moduleName) + `":null}}}`,
+						)))
+					},
+				),
+			)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.ModuleNameLabel: moduleName,
+						constants.DaemonSetRole:   constants.DRARoleLabelValue,
+					},
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}
@@ -397,7 +525,8 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 			}
 
@@ -421,7 +550,7 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 			}
 
 			gomock.InOrder(
-				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), client.InNamespace(podNamespace), labelSelector, fieldSelector).Return(nil),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(patchRemoveFinalizerFunc),
@@ -435,7 +564,8 @@ var _ = Describe("PodNodeLabelReconciler_Reconcile", func() {
 						constants.ModuleNameLabel: moduleName,
 						constants.DaemonSetRole:   constants.DRARoleLabelValue,
 					},
-					Name: podName,
+					Name:      podName,
+					Namespace: podNamespace,
 				},
 				Spec: v1.PodSpec{NodeName: nodeName},
 			}


### PR DESCRIPTION
`PodNodeLabelReconciler` removes the plugin ready label from a node once the plugin Pod has gone, and before it does that it looks for a replacement Pod so a rolling DaemonSet update does not make the label flap. That lookup was not scoped to a namespace, so a Module of the same name in another namespace kept the label alive after its own Pods had gone. #1346 has the reproduction and the output.

The production change is one option on the list:

```go
if err := r.client.List(ctx, &podsList, client.InNamespace(pod.Namespace), labelSelector, fieldSelector); err != nil {
```

## Why the label is namespaced but the list was not

`utils.GetDevicePluginNodeLabel(pod.Namespace, moduleName)` builds `kmm.node.kubernetes.io/<namespace>.<module>.device-plugin-ready`, and `GetDRANodeLabel` has the same shape, so what is being protected is per namespace. The list that decides whether to remove it matched on `module.name` and the role label only, and `GetManagerOptionsFromConfig` sets no `Cache` field, so the client is not narrowed either.

`getSchedulePods` in `node_label_module_version_reconciler.go` also lists across namespaces, but that one wants every plugin Pod on the node whatever Module it belongs to, so it is left alone.

## About the test changes

The existing specs assert the list arguments exactly, so adding an option breaks them and they now name the namespace too. Their Pods carried no `.metadata.namespace` at all, which is part of why the mismatch stayed invisible: the label under test came out as `kmm.node.kubernetes.io/.module-name.device-plugin-ready` and nothing looked at it. Those Pods now have `podNamespace`.

There is one new spec on each plugin path, and they are the ones that would catch a regression on their own. gomock does not filter, so the callback applies the namespace option the way a real client would, and a Ready Pod belonging to another namespace reaches the reconciler only when the list is unscoped. Their expectation deliberately leaves the variadic options to a single `gomock.Any()`: pinning them to an exact count would make gomock reject the unscoped call on its argument count before the callback ever ran, which reddens the spec without exercising anything. The Node they are handed carries both namespaces' ready labels, and the patch assertion names only this Module's key, so the other one is not taken along.

## Testing

`make lint` and `go test ./internal/...` are clean. Reverting the one production line reddens both new specs, and gomock reports them as a missing call to the Node read that `deleteLabel` starts with, rather than as a wrong argument count, so the label removal really is what did not happen. Making `deleteLabel` clear the whole label map instead of one key reddens exactly those two and nothing else.

On kind with Kubernetes v1.35.0, a Module named `gpu` in `team-a` and another in `team-b`, both with a `devicePlugin` and no `moduleLoader`, both on the single node, deleting only `team-a`:

On `f1d9ae3`:

```
before delete:  team-a-ready=true  team-b-ready=true
team-a pods gone
after delete:   team-a-ready=true  team-b-ready=true
```

Same run with this patch:

```
before delete:  team-a-ready=true  team-b-ready=true
team-a pods gone
after delete:   team-a-ready=false  team-b-ready=true
```

## Overlap with the other open PRs

This is based on `f1d9ae3` and does not depend on #1343 or #1344. #1343 also edits this file, at `deleteLabel` and `deleteFinalizer` rather than here, so the production sides do not overlap, but both add specs to `pod_node_label_reconciler_test.go` and whichever lands second will need a rebase there. Either order is fine by me.

Fixes #1346

---

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


