### PR TITLE
Reject a rename of spec.dra.driverName and removal of spec.dra

### DIFF
--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -94,6 +94,17 @@ func (m *ModuleValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		}
 	}
 
+	// Renaming the driver stops matching the claims allocated under the old name, and dropping
+	// spec.dra then putting it back is how a rename would otherwise get through.
+	if oldMod.Spec.DRA != nil {
+		if newMod.Spec.DRA == nil {
+			return nil, errors.New("spec.dra cannot be removed; delete the Module once no ResourceClaim consumer is left")
+		}
+		if oldMod.Spec.DRA.DriverName != newMod.Spec.DRA.DriverName {
+			return nil, errors.New("spec.dra.driverName is immutable; delete the Module once no ResourceClaim consumer is left")
+		}
+	}
+
 	return validateModule(newMod, m.kubeVersion)
 }
 

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -630,6 +630,90 @@ var _ = Describe("ValidateUpdate", func() {
 	})
 
 	DescribeTable(
+		"DRA driver name updates",
+		func(oldDriver, newDriver string, errorExpected bool) {
+			old := validModule
+			old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: oldDriver}
+
+			new := validModule
+			new.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: newDriver}
+
+			_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+			if errorExpected {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// Nothing reconciles the name away, so a rename leaves the Module describing a driver that
+		// is not the one the claims were allocated against.
+		Entry(nil, "a.example.com", "b.example.com", true),
+		Entry(nil, "a.example.com", "a.example.com", false),
+	)
+
+	It("allows the rest of the DRA spec to change", func() {
+		old := validModule
+		old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+		old.Spec.DRA.Container.Image = "registry.example.com/driver:v1"
+
+		new := validModule
+		new.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+		new.Spec.DRA.Container.Image = "registry.example.com/driver:v2"
+
+		_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// The plugin cleanups add and remove their own finalizers, which arrive here as an update whose
+	// spec has not moved.
+	It("allows an update that only changes the finalizers", func() {
+		old := validModule
+		old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+
+		new := old
+		new.Finalizers = []string{"kmm.node.kubernetes.io/dra-cleanup"}
+
+		_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable(
+		"DRA presence updates",
+		func(oldHasDRA, newHasDRA, errorExpected bool) {
+			old := validModule
+			new := validModule
+			if oldHasDRA {
+				old.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+			} else {
+				old.Spec.DRA = nil
+			}
+			if newHasDRA {
+				new.Spec.DRA = &kmmv1beta1.DRASpec{DriverName: "a.example.com"}
+			} else {
+				new.Spec.DRA = nil
+			}
+
+			_, err := moduleWebhook.ValidateUpdate(ctx, &old, &new)
+
+			if errorExpected {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		// Dropping spec.dra deletes the driver without checking for reserved claims, and putting it
+		// back under another name is how a rename would otherwise get through. Adding it to a
+		// Module that never had one has no driver to pull out from under a claim.
+		Entry(nil, true, false, true),
+		Entry(nil, false, true, false),
+		Entry(nil, true, true, false),
+		Entry(nil, false, false, false),
+	)
+
+	DescribeTable(
 		"version updates",
 		func(oldVersion, newVersion string, errorExpected bool) {
 			old := validModule


### PR DESCRIPTION
Split out of #1329, which @TomerNewman asked me to break up. This is the piece that stands on its own.

`spec.dra.driverName` is the name the driver registers with kubelet, and ResourceClaims are allocated against that name. KMM does not write the field anywhere: it is not in the DaemonSet, the Pod spec or the DeviceClass, so renaming it changes nothing on the node and nothing reconciles the difference away. What is left is a Module naming a driver that is not the one running, and claims allocated against the old name that are held by workloads KMM does not own.

Removing `spec.dra` is refused for the same reason. Dropping the field and putting it back is a rename with an extra step, so allowing it would leave the check with a hole the size of two edits.

## What reads the field today

Only its own validation. The driver container registers whatever its image is built to register, and KMM never passes it the value. The piece after this one uses it to find the ResourceClaims allocated against the driver before it takes a node's `dra-target` label off, and a name that can change under that lookup answers "none" for the wrong reason.

That does put the guard in ahead of its consumer. If you would rather it landed with the retention check that uses it, say so and I will move it.

## What is still allowed

Everything else about the DRA spec stays mutable: the image, the init container, the device classes, the service account. Creating a Module with `spec.dra` is untouched, and so is deleting one. The error message says what to do instead, which is to delete the Module once no consumer is left.

## How this sits with #1344

#1344 gives the DRA reconciler a finalizer and runs its cleanup when `spec.dra` is nil. That path is not made unreachable by this: it is the one that runs when the Module is deleted, and it also covers a Module whose `spec.dra` was dropped before this check existed. The webhook is configured `failurePolicy: Fail`, so an edit cannot slip past it while it is down; what it cannot do is reach backwards. What changes is that dropping the field is no longer the way you are meant to get there.

## Testing

Two `DescribeTable`s in `internal/webhook/module_test.go`, one for the driver name and one for the presence of `spec.dra`. Reverting either half of the check reddens one of them by name.

Two positive cases sit beside them, since a guard on an identity field is as easy to get wrong by being too wide. One changes the container image under the same driver name, and widening the check to the whole DRA spec reddens it. The other is an update that touches only the finalizers, which is what #1344's cleanup sends and what a spec-only check has to let through. `make lint` and `go test ./internal/...` are clean.

I also ran the webhook itself, on kind v1.35.0, with a `ValidatingWebhookConfiguration` pointed at a local `webhook-server` and scoped by `namespaceSelector` to one namespace. Creating the Module is allowed. Renaming `driverName` comes back as `admission webhook "vmodule.kb.io" denied the request: spec.dra.driverName is immutable`, and removing `spec.dra` with the matching message. Changing the container image under the same driver name is allowed, and so is a patch that only sets a finalizer, which is the one #1344 needs to get through.

I have not changed the CRD, so an older KMM reading a Module written under this one sees nothing new.

