### PR TITLE
Put the dra-target label on the nodes a DRA Module selects

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -181,7 +181,7 @@ func main() {
 	}
 
 	if kubeVersion.AtLeast(constants.MinKubeMajorForDRA, constants.MinKubeMinorForDRA) {
-		if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+		if err = controllers.NewDRAReconciler(client, filterAPI, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 		}
 	} else {

--- a/docs/mkdocs/developer/reconciliation_loops.md
+++ b/docs/mkdocs/developer/reconciliation_loops.md
@@ -27,7 +27,10 @@ Each time a new `Module` is created, we need to find to which nodes it applies.
 A separate DRA reconciler watches `Module` resources that have `.spec.dra` set.
 
 1. When a `Module` has `.spec.dra` configured, the DRA reconciler creates a DRA driver `DaemonSet` targeting nodes
-   where the kernel module is loaded.
+   where the kernel module is loaded and that carry the `kmm.node.kubernetes.io/$namespace.$module.dra-target` label.
+   The reconciler puts that label on every schedulable node the `Module` selects and does not remove it, so a node that
+   stops being selected keeps its driver Pod. A `Module` with no `.spec.moduleLoader` has no kernel module to unload,
+   so its `DaemonSet` targets `.spec.selector` directly and no such label is written.
 
 1. It also creates and manages cluster-scoped `DeviceClass` resources as declared in `.spec.dra.deviceClasses`.
    DeviceClasses are tracked via labels (`kmm.node.kubernetes.io/module.name` and
@@ -38,3 +41,6 @@ A separate DRA reconciler watches `Module` resources that have `.spec.dra` set.
 
 1. During [ordered upgrades](../documentation/ordered_upgrade.md), a new DRA `DaemonSet` is created for the new module
    version. Once the old-version `DaemonSet` is no longer scheduled on any node, it is garbage-collected.
+
+1. We watch `Module`, owned `DaemonSet`, `DeviceClass` and nodes, since the `dra-target` label is decided from a
+   node's own labels and taints.

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	kmmv1beta1 "github.com/kubernetes-sigs/kernel-module-management/api/v1beta1"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/constants"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/filter"
+	"github.com/kubernetes-sigs/kernel-module-management/internal/module"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/node"
 	"github.com/kubernetes-sigs/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -57,17 +59,20 @@ const (
 
 type DRAReconciler struct {
 	client         client.Client
+	filter         *filter.Filter
 	reconHelperAPI draReconcilerHelperAPI
 }
 
 func NewDRAReconciler(
 	client client.Client,
+	filter *filter.Filter,
 	nodeAPI node.Node,
 	scheme *runtime.Scheme,
 ) *DRAReconciler {
 	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, scheme)
 	return &DRAReconciler{
 		client:         client,
+		filter:         filter,
 		reconHelperAPI: reconHelperAPI,
 	}
 }
@@ -80,6 +85,12 @@ func (r *DRAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&resourcev1.DeviceClass{},
 			handler.EnqueueRequestsFromMapFunc(filter.DeviceClassToModuleReconcileRequest),
 			builder.WithPredicates(filter.HasLabel(constants.ModuleNameLabel)),
+		).
+		// The target label is decided from the node's labels and taints; no other watch sees those.
+		Watches(
+			&v1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.filter.FindModulesForNode),
+			builder.WithPredicates(filter.ModuleReconcilerNodePredicate()),
 		).
 		Named(DRAReconcilerName).
 		Complete(
@@ -111,6 +122,10 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, r.reconHelperAPI.clearDRAStatus(ctx, mod)
+	}
+
+	if err = r.reconHelperAPI.handleDRATargetLabels(ctx, mod); err != nil {
+		return res, fmt.Errorf("could not reconcile dra-target labels: %v", err)
 	}
 
 	err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS)
@@ -149,6 +164,7 @@ type draReconcilerHelperAPI interface {
 	clearDRAStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error)
 	handleDeviceClasses(ctx context.Context, mod *kmmv1beta1.Module, existingDCs []resourcev1.DeviceClass) error
+	handleDRATargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 }
 
 type draReconcilerHelper struct {
@@ -167,6 +183,48 @@ func newDRAReconcilerHelper(client client.Client,
 		daemonSetHelper: daemonSetHelper,
 		nodeAPI:         nodeAPI,
 	}
+}
+
+// draTolerations is what the driver Pods end up with: the Module's own plus the pressure
+// tolerations the DaemonSet controller adds to everything it creates.
+func draTolerations(mod *kmmv1beta1.Module) []v1.Toleration {
+	return slices.Concat(mod.Spec.Tolerations, module.InternalTolerations)
+}
+
+// handleDRATargetLabels only adds the label. Nothing takes it off yet, so a node that stops being
+// selected keeps its driver Pod, as it does today.
+func (drh *draReconcilerHelper) handleDRATargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
+	// Without a loader the DaemonSet selects on the Module's own selector and never reads this
+	// label, so putting it on would leave nodes carrying something nothing looks at.
+	if mod.Spec.DRA == nil || mod.Spec.ModuleLoader == nil {
+		return nil
+	}
+
+	targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+
+	nodes, err := drh.nodeAPI.GetAllNodesBySelector(ctx, mod.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("could not list nodes targeted by module: %v", err)
+	}
+
+	tolerations := draTolerations(mod)
+
+	var errs []error
+	for i := range nodes {
+		node := &nodes[i]
+		// The DaemonSet selector asks for an exact empty value, so a key carrying
+		// anything else still has to be rewritten.
+		value, labelled := node.Labels[targetLabel]
+		if (labelled && value == "") || !drh.nodeAPI.IsNodeSchedulable(node, tolerations) {
+			continue
+		}
+
+		if err := drh.nodeAPI.UpdateLabels(ctx, node, map[string]string{targetLabel: ""}, nil); err != nil {
+			errs = append(errs, fmt.Errorf("could not add dra-target label to node %s: %v", node.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (drh *draReconcilerHelper) getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
@@ -200,8 +258,30 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 		}
 	}
 
+	targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+	creating := ds.Name == ""
+
 	opRes, err := controllerutil.CreateOrPatch(ctx, drh.client, ds, func() error {
-		return drh.daemonSetHelper.setDRAAsDesired(ctx, ds, mod)
+		// Requiring the label on an existing DaemonSet drops its Pods from every node without it,
+		// so keep whatever selector the live object already has.
+		held, wasSet := ds.Spec.Template.Spec.NodeSelector[targetLabel]
+
+		if err := drh.daemonSetHelper.setDRAAsDesired(ctx, ds, mod); err != nil {
+			return err
+		}
+
+		// Without a loader the node selector is the Module's own map, which must not be edited.
+		if creating || mod.Spec.ModuleLoader == nil {
+			return nil
+		}
+
+		if wasSet {
+			ds.Spec.Template.Spec.NodeSelector[targetLabel] = held
+		} else {
+			delete(ds.Spec.Template.Spec.NodeSelector, targetLabel)
+		}
+
+		return nil
 	})
 
 	if err == nil {
@@ -292,7 +372,7 @@ func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,
 		return nil
 	}
 
-	numTargetedNodes, err := drh.nodeAPI.GetNumTargetedNodes(ctx, mod.Spec.Selector, mod.Spec.Tolerations)
+	numTargetedNodes, err := drh.nodeAPI.GetNumTargetedNodes(ctx, mod.Spec.Selector, draTolerations(mod))
 	if err != nil {
 		return fmt.Errorf("failed to determine the number of nodes targeted by Module %s/%s selector: %v", mod.Namespace, mod.Name, err)
 	}
@@ -510,6 +590,7 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 
 	nodeSelector := map[string]string{
 		utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
+		utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name):         "",
 	}
 
 	if mod.Spec.ModuleLoader != nil {

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -70,7 +70,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, getDCError, handleDRAError, gcError, handleDCError bool) {
+	DescribeTable("check error flows", func(getDSError, getDCError, targetLabelError, handleDRAError, gcError, handleDCError bool) {
 		draDS := []appsv1.DaemonSet{{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -83,6 +83,11 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil)
+		if targetLabelError {
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod).Return(returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod).Return(nil)
 		if handleDRAError {
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(returnedError)
 			goto executeTestFunction
@@ -107,12 +112,13 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getModuleDRADaemonSets failed", true, false, false, false, false),
-		Entry("getModuleDeviceClasses failed", false, true, false, false, false),
-		Entry("handleDRA failed", false, false, true, false, false),
-		Entry("garbageCollectDRADaemonSets failed", false, false, false, true, false),
-		Entry("handleDeviceClasses failed", false, false, false, false, true),
-		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false),
+		Entry("getModuleDRADaemonSets failed", true, false, false, false, false, false),
+		Entry("getModuleDeviceClasses failed", false, true, false, false, false, false),
+		Entry("handleDRATargetLabels failed", false, false, true, false, false, false),
+		Entry("handleDRA failed", false, false, false, true, false, false),
+		Entry("garbageCollectDRADaemonSets failed", false, false, false, false, true, false),
+		Entry("handleDeviceClasses failed", false, false, false, false, false, true),
+		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false, false),
 	)
 
 	It("Good flow", func() {
@@ -120,6 +126,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRATargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
@@ -207,6 +214,221 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("DRAReconciler_setDRAAsDesired_targetSelector", func() {
+	const (
+		modName = "my-mod"
+		modNS   = "my-ns"
+	)
+
+	ctx := context.Background()
+	targetLabel := utils.GetDRATargetNodeLabel(modNS, modName)
+
+	mod := func(withLoader bool) *kmmv1beta1.Module {
+		m := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: modName},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:      &kmmv1beta1.DRASpec{Container: kmmv1beta1.CommonContainerSpec{Image: "img"}},
+				Selector: map[string]string{"kubernetes.io/os": "linux"},
+			},
+		}
+		if withLoader {
+			m.Spec.ModuleLoader = &kmmv1beta1.ModuleLoaderSpec{}
+		}
+		return m
+	}
+
+	It("selects on the target label for a Module with a moduleLoader", func() {
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: modNS}}
+
+		Expect(newDRADaemonSetCreator(scheme).setDRAAsDesired(ctx, ds, mod(true))).To(Succeed())
+		Expect(ds.Spec.Template.Spec.NodeSelector).To(HaveKey(targetLabel))
+	})
+
+	// Without a loader there is nothing to unload, so the Module's own selector is used as it is
+	// and the target label has no part to play.
+	It("leaves the Module's own selector alone when there is no moduleLoader", func() {
+		m := mod(false)
+		ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Namespace: modNS}}
+
+		Expect(newDRADaemonSetCreator(scheme).setDRAAsDesired(ctx, ds, m)).To(Succeed())
+		Expect(ds.Spec.Template.Spec.NodeSelector).NotTo(HaveKey(targetLabel))
+		Expect(m.Spec.Selector).NotTo(HaveKey(targetLabel))
+	})
+})
+
+var _ = Describe("DRAReconciler_handleDRATargetLabels", func() {
+	const (
+		modName = "my-mod"
+		modNS   = "my-ns"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		nm   *node.MockNode
+		drh  draReconcilerHelper
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		nm = node.NewMockNode(ctrl)
+		drh = draReconcilerHelper{nodeAPI: nm}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: modNS, Name: modName},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+	})
+
+	ctx := context.Background()
+
+	targetLabel := utils.GetDRATargetNodeLabel(modNS, modName)
+
+	node1 := func(labels map[string]string) v1.Node {
+		return v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: labels}}
+	}
+
+	tainted := func(key string) v1.Node {
+		n := node1(nil)
+		n.Spec.Taints = []v1.Taint{{Key: key, Effect: v1.TaintEffectNoSchedule}}
+		return n
+	}
+
+	// The real check, so a spec that hands it the wrong tolerations fails here instead of being
+	// told the answer.
+	realSchedulability := func() {
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).
+			DoAndReturn(node.NewNode(nil).IsNodeSchedulable).AnyTimes()
+	}
+
+	It("does nothing for a Module with no DRA spec", func() {
+		mod.Spec.DRA = nil
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("does nothing for a Module with no moduleLoader, whose DaemonSet ignores the label", func() {
+		mod.Spec.ModuleLoader = nil
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("labels a node under memory pressure, which the driver Pod tolerates", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).
+			Return([]v1.Node{tainted(v1.TaintNodeMemoryPressure)}, nil)
+		realSchedulability()
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("leaves a cordoned node alone, since that is what takes the driver Pod off it", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).
+			Return([]v1.Node{tainted(v1.TaintNodeUnschedulable)}, nil)
+		realSchedulability()
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("leaves a node alone when nothing tolerates its taint", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{tainted("maintenance")}, nil)
+		realSchedulability()
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("labels a node whose taint the Module itself tolerates", func() {
+		mod.Spec.Tolerations = []v1.Toleration{{
+			Key: "maintenance", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule,
+		}}
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{tainted("maintenance")}, nil)
+		realSchedulability()
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("does not write the internal tolerations into the Module's own slice", func() {
+		backing := make([]v1.Toleration, 1, 8)
+		backing[0] = v1.Toleration{Key: "maintenance", Operator: v1.TolerationOpExists}
+		mod.Spec.Tolerations = backing[:1]
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{node1(nil)}, nil)
+		realSchedulability()
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), gomock.Any(), nil).Return(nil)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+		Expect(backing[:cap(backing)][1:]).To(Equal(make([]v1.Toleration, cap(backing)-1)))
+	})
+
+	It("labels a selected node that is schedulable", func() {
+		n := node1(nil)
+
+		gomock.InOrder(
+			nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil),
+			nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true),
+			nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil),
+		)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	// Nothing takes the label off in this piece, so an unschedulable node keeps whatever it has.
+	It("leaves an unschedulable node alone", func() {
+		n := node1(nil)
+
+		gomock.InOrder(
+			nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil),
+			nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(false),
+		)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	// The DaemonSet selector matches on the empty value, so a key with anything else
+	// in it leaves the node unmatched until it is rewritten.
+	It("rewrites a target label whose value is not empty", func() {
+		n := node1(map[string]string{targetLabel: "true"})
+
+		gomock.InOrder(
+			nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil),
+			nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true),
+			nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil),
+		)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("does not write again to a node that already carries the label", func() {
+		n := node1(map[string]string{targetLabel: ""})
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{n}, nil)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).To(Succeed())
+	})
+
+	It("reports a listing failure rather than an empty cluster", func() {
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return(nil, fmt.Errorf("some error"))
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).NotTo(Succeed())
+	})
+
+	It("goes on to the rest when one node cannot be labelled", func() {
+		a := node1(nil)
+		b := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2"}}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{a, b}, nil)
+		nm.EXPECT().IsNodeSchedulable(gomock.Any(), gomock.Any()).Return(true).Times(2)
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).
+			Return(fmt.Errorf("some error"))
+		nm.EXPECT().UpdateLabels(ctx, gomock.Any(), map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		Expect(drh.handleDRATargetLabels(ctx, mod)).NotTo(Succeed())
 	})
 })
 
@@ -299,6 +521,133 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	// A DaemonSet that was already migrated keeps the label, so a Module that has been through
+	// the migration does not lose it on the next pass.
+	It("keeps the target label on a DaemonSet that already carries it", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+
+		const name = "some name"
+		targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+		existingDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name},
+		}
+
+		var patched *appsv1.DaemonSet
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{targetLabel: ""}
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).DoAndReturn(
+				func(_ context.Context, ds *appsv1.DaemonSet, _ *kmmv1beta1.Module) error {
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{"other": "x"}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					patched = o.(*appsv1.DaemonSet)
+					return nil
+				},
+			),
+		)
+
+		Expect(drh.handleDRA(ctx, &mod, []appsv1.DaemonSet{existingDS})).To(Succeed())
+		Expect(patched).NotTo(BeNil())
+		Expect(patched.Spec.Template.Spec.NodeSelector).To(HaveKey(targetLabel))
+	})
+
+	It("reports a failure from setDRAAsDesired on an existing DaemonSet", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+
+		const name = "some name"
+		existingDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name},
+		}
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).Return(fmt.Errorf("some error")),
+		)
+
+		Expect(drh.handleDRA(ctx, &mod, []appsv1.DaemonSet{existingDS})).NotTo(Succeed())
+	})
+
+	// Requiring the target label narrows what a DaemonSet selects, so an existing one keeps
+	// whatever it already had and nobody upgrading sees their driver Pods move.
+	It("does not put the target label on a DaemonSet that is already there", func() {
+		ctx := context.Background()
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "namespace"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA:          &kmmv1beta1.DRASpec{},
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+
+		const name = "some name"
+		targetLabel := utils.GetDRATargetNodeLabel(mod.Namespace, mod.Name)
+		existingDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name},
+		}
+
+		var patched *appsv1.DaemonSet
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					return nil
+				},
+			),
+			mockDSHelper.EXPECT().setDRAAsDesired(ctx, gomock.Any(), &mod).DoAndReturn(
+				func(_ context.Context, ds *appsv1.DaemonSet, _ *kmmv1beta1.Module) error {
+					// "other" makes the object differ from what was read, so CreateOrPatch has a
+					// reason to send a patch at all and the selector can be inspected in it.
+					ds.Spec.Template.Spec.NodeSelector = map[string]string{targetLabel: "", "other": "x"}
+					return nil
+				},
+			),
+			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, o ctrlclient.Object, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+					patched = o.(*appsv1.DaemonSet)
+					return nil
+				},
+			),
+		)
+
+		Expect(drh.handleDRA(ctx, &mod, []appsv1.DaemonSet{existingDS})).To(Succeed())
+		Expect(patched).NotTo(BeNil())
+		Expect(patched.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue("other", "x"))
+		Expect(patched.Spec.Template.Spec.NodeSelector).NotTo(HaveKey(targetLabel))
+	})
 })
 
 var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
@@ -383,6 +732,31 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		Entry("3 target node, 0 ds", 3, nil, 3, 0),
 		Entry("2 target node, 3 ds", 2, []int{3, 6, 8}, 2, 17),
 	)
+
+	// The count has to agree with the target-label decision, or the status reports a
+	// smaller desired number than the DaemonSet it is describing.
+	It("counts a node under memory pressure, which the driver Pods tolerate", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: &kmmv1beta1.DRASpec{}},
+		}
+		expectedMod := mod.DeepCopy()
+		expectedMod.Status.DRA.NodesMatchingSelectorNumber = 1
+		expectedMod.Status.DRA.DesiredNumber = 1
+
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *v1.NodeList, _ ...interface{}) error {
+				list.Items = []v1.Node{{Spec: v1.NodeSpec{Taints: []v1.Taint{{
+					Key:    v1.TaintNodeMemoryPressure,
+					Effect: v1.TaintEffectNoSchedule,
+				}}}}}
+				return nil
+			},
+		)
+		clnt.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
+
+		Expect(drh.moduleUpdateDRAStatus(ctx, &mod, nil)).To(Succeed())
+	})
 })
 
 var _ = Describe("DRAReconciler_clearDRAStatus", func() {

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -127,6 +127,20 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRA(ctx, mod, existingDR
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRA", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRA), ctx, mod, existingDRADS)
 }
 
+// handleDRATargetLabels mocks base method.
+func (m *MockdraReconcilerHelperAPI) handleDRATargetLabels(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDRATargetLabels", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleDRATargetLabels indicates an expected call of handleDRATargetLabels.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRATargetLabels(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRATargetLabels", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRATargetLabels), ctx, mod)
+}
+
 // handleDeviceClasses mocks base method.
 func (m *MockdraReconcilerHelperAPI) handleDeviceClasses(ctx context.Context, mod *v1beta1.Module, existingDCs []v10.DeviceClass) error {
 	m.ctrl.T.Helper()

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -84,6 +84,10 @@ func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }
 
+func GetDRATargetNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.dra-target", namespace, moduleName)
+}
+
 func GetDRANodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.dra-ready", namespace, moduleName)
 }

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -5,6 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("GetDRATargetNodeLabel", func() {
+	It("should work as expected", func() {
+		res := GetDRATargetNodeLabel("some-namespace", "some-name")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-name.dra-target"))
+	})
+})
+
 var _ = Describe("GetModuleVersionLabelName", func() {
 	It("should work as expected", func() {
 		res := GetModuleVersionLabelName("some-namespace", "some-name")


### PR DESCRIPTION
Second piece out of #1329. It puts the `dra-target` label in place and leaves everything that acts on it to the piece after.

A DaemonSet Pod carries an automatic toleration for `node.kubernetes.io/unschedulable`, so cordoning a node does nothing to the DRA driver Pod on its own, and `kubectl drain` will not evict it: it refuses to run without `--ignore-daemonsets` and skips the Pod with it. The only thing that takes the Pod away is its nodeSelector no longer matching. Today that selector asks for `kmm-ready`, which stays until the unloader succeeds, and the unloader cannot succeed while the driver still holds the kernel module. #1274 solved the same problem for the device plugin with a `device-plugin-target` label; the DRA reconciler never got the counterpart.

This adds the label and requires it in the node selector of DRA DaemonSets. `handleDRATargetLabels` puts it on every schedulable node the Module selects, which is the same shape as `handleDevicePluginTargetLabels`, minus the removal and with the two differences below.

## Which nodes count as schedulable

The check gets the Module's tolerations plus KMM's internal ones. The DaemonSet controller adds the disk, memory and PID pressure tolerations to the Pods it creates whether or not the template carries them, so judging on `spec.tolerations` alone would keep the label off a node the driver can run on perfectly well. On kind v1.35.0, a DaemonSet whose template declares no tolerations produces Pods carrying `not-ready` and `unreachable` at `NoExecute`, and `disk-pressure`, `memory-pressure`, `pid-pressure` and `unschedulable` at `NoSchedule`.

The `unschedulable` one is deliberately left out of the decision. Reacting to a cordon is what this label is for, so a cordoned node has to fall out of it.

A node whose label carries something other than the empty string is written again. The DaemonSet selector matches on that exact value, so a key holding anything else leaves the node unmatched, and skipping on the key alone would leave nothing to correct it. The device plugin's equivalent writes unconditionally and so has no such state to get stuck in.

The status count uses the same tolerations. `moduleUpdateDRAStatus` feeds `GetNumTargetedNodes` the Module's tolerations alone on master, which was consistent while the label decision did too. Now that the label follows what the Pods actually tolerate, leaving the count behind would let `AvailableNumber` come out above `DesiredNumber` on a node under pressure.

A Module with no `moduleLoader` is skipped. `setDRAAsDesired` replaces the node selector with `mod.Spec.Selector` in that case, so its DaemonSet never reads the label and writing it would leave nodes carrying something nothing looks at.

## Why nobody upgrading sees anything move

Requiring the label narrows what a DaemonSet selects, so putting it on one that already exists would drop its Pods from every node that does not have it. `handleDRA` reads the live object's selector before `setDRAAsDesired` runs and puts that state back afterwards, so an existing DaemonSet keeps what it had and only a newly created one starts out selecting on the label. Nothing removes the label either, so a node that stops being selected keeps its driver Pod, exactly as it does today.

That is also why this does not fix #1328 on its own. The removal, the ResourceClaim retention that decides when removal is safe, and the migration of DaemonSets that already exist all go together in the next piece, since none of them is safe without the others.

## Why it watches nodes

The label is read off a node's own labels and taints, and none of the reconciler's other watches see those change; #1328 names the missing Node watch for the same reason. Measured on kind v1.35.0 by counting this reconciler's passes across a node label change that left the Module and its DaemonSet alone: without the watch it did not run (5 before, 5 after) while the Module reconciler did; with the watch it ran (5 to 6). In practice the label still lands most of the time, because the same event usually changes the Module reconciler's node count and its status write brings this one round. The watch is what stops that being a dependency.

The predicate is the Module reconciler's, which fires on labels as well as taints, since both go into the decision. It also uses the shared `FindModulesForNode`, so a node event wakes this reconciler for Modules with no `spec.dra` as well; that is what the device plugin reconciler already does, and a DRA-only mapper did not seem worth a second copy. Say if you would rather have one.

## Docs

The DRA section of `docs/mkdocs/developer/reconciliation_loops.md` says the driver DaemonSet targets nodes where the kernel module is loaded, which is no longer the whole story. It now names the label, says the reconciler adds it and does not remove it, notes that a Module with no `moduleLoader` gets neither, and lists nodes among what that loop watches.

## What is deliberately not here

`IsDRATargetNodeLabel`, `GetAllNodesByLabelKey` and `UpdateLabelsWithOptimisticLock` from #1329 are not in this piece. They serve the removal path, and there is nothing here to call them, so they would land as code a reviewer has to judge without the thing that uses it. The ResourceClaim index is out for the same reason, which corrects what I said on the 8th about putting it in the first piece; `nodesUsingDRADriver` is an unexported method, so it would also fail `unused` until the claims arrive.

No RBAC change: `nodes` already carries `get`, `list`, `watch` and `patch` from the Module reconciler, and the `resourceclaims` and `events` rules #1329 adds belong with the claims.

## Testing

`DRAReconciler_handleDRATargetLabels` drives the real `IsNodeSchedulable` rather than a mocked answer, so the set of tolerations it is handed is actually under test: a node under memory pressure gets the label, a cordoned one does not, a node with a taint nobody tolerates does not, and one whose taint the Module tolerates does. There is a spec for the Module's own tolerations slice being left alone, one for the DRA-only Module being skipped, and the earlier ones for a node that already has the label, a listing failure, and one node failing while the rest go on.

`DRAReconciler_setDRAAsDesired_targetSelector` checks that a Module without a `moduleLoader` keeps its own selector untouched, since that map belongs to the Module object. `DRAReconciler_handleDRA` has one for the DaemonSet that already exists.

I also ran it on kind v1.35.0 with a Module carrying both `moduleLoader` and `dra`, which is the shape `ci/module-kmm-ci-dra.yaml` uses and the one this code actually acts on. On a fresh install the DaemonSet comes up with `nodeSelector: {"...imod.ready": "", "...imod.dra-target": ""}` and the node carries the label. For the upgrade case, a manager built from `main` first creates the DaemonSet with `nodeSelector: {"...imod.ready": ""}`; restarting on this branch leaves that DaemonSet alone, same name and same selector, and puts the node label beside it. One DaemonSet throughout, so the label write does not come back round and produce a second one.

Reverting any of these reddens one spec by name: the label leaving the selector, the schedulability check, the carry-over that keeps an existing DaemonSet where it is, the internal tolerations, the `moduleLoader` skip, the slice that must not be written through, the label value being rewritten, and the status count on a node under memory pressure. The watch is the exception, since there is no `SetupWithManager` test in this repo to extend, so the kind run above is what stands behind it. `make lint`, `make generate` and `go test ./internal/...` are clean, and `make manifests` leaves `config/` unchanged.

Part of #1328.

