### PR TITLE
Authenticate the Codecov upload for main with OIDC

### DIFF
--- a/.github/workflows/test-codecov.yml
+++ b/.github/workflows/test-codecov.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test-build:
     name: Test and upload to Codecov
@@ -27,3 +31,8 @@ jobs:
 
     - name: Upload the coverage to Codecov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        use_oidc: true
+        # A failed upload is the problem this is fixing, so let it show on main.
+        # A Codecov outage should still not block a contributor's pull request.
+        fail_ci_if_error: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Follows #1348, where the logs are. Short version: every push to `main` has been failing to upload coverage since at least 2026-07-07, and the step reports success anyway, so Codecov has been measuring every pull request in this repository against a base from 2024-01-31.

From the run on `f1d9ae3`:

```
 -> Token length: 0
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
##[end-action id=__codecov_codecov-action.__run_8;outcome=success;conclusion=success]
```

## Why OIDC rather than a token

Both work. A `CODECOV_TOKEN` repository secret would need someone with admin here, and I cannot add one, so this is the half a contributor can send. `codecov-action` reads a GitHub identity token instead when `use_oidc` is set, and Codecov documents no setup on its side for it.

The route did have a bug on protected branches, reported through 2025 in codecov/codecov-action#1791, #1806 and #1817, and fixed in 5.4.3. We pin 6.0.0, so we are past it. The one still open, #1918, is about tokenless uploads from forks, which is a different path and the one that already works here.

## Why this does not disturb pull requests

Fork pull requests upload without a token today, and that is the only part of this that has been working. The action guards the OIDC step itself:

```js
if (process.env.CC_USE_OIDC === 'true' && process.env.CC_FORK != 'true') {
```

so a fork keeps the path it has. A fork does not get the permission either way: on this pull request's own run GitHub granted the job `Contents: read` and `Metadata: read` and nothing else, despite the workflow asking for `id-token: write`. The guard is on the fork rather than on the event, so a branch pushed to this repository and opened as a pull request takes the identity token as well; that is the same authenticated path `main` will use, not the tokenless one. That is also why `use_oidc` is set plainly rather than conditioned on the event.

## Making a failed upload visible

Authenticating the upload removes the cause we know about. It does not make the next one visible, and a step that ends green while nothing was uploaded is half of what #1348 is about. `fail_ci_if_error` is therefore on for a push to main and off everywhere else: main is the branch whose report is missing, and a Codecov outage should not turn someone's pull request red. If you would rather keep main non-blocking too, dropping that line leaves the OIDC half intact.

## The permissions block

There was none, so the job ran with whatever the repository default is. Naming `id-token: write` means naming everything else too, and the only other thing this job needs is `contents: read` for the checkout.

## What a fork run shows, and what it does not

I put this workflow on my own fork's `main` and pushed, which is the nearest thing to the run that matters. `CC_FORK` came out `false`, the identity token was fetched, and the upload went through: `Token length: 1995`, against the `Token length: 0` this repository's `main` gets today, and Codecov took it rather than answering `Token required because branch is protected`. That run is [34375853246](https://github.com/thc1006/kernel-module-management/actions/runs/34375853246); I reset the branch afterwards.

So the mechanics hold: `permissions: id-token: write` is enough for the step to fetch a token, the step does not fail, and Codecov accepts an OIDC upload on a default branch. What it cannot show is whether Codecov accepts the identity for this repository, which depends on settings on their side I cannot see.

If the identity token cannot be fetched, the `Get OIDC token` step fails and the job goes red rather than reporting success: that step is `actions/github-script` and is not covered by the uploader's own `fail_ci_if_error: false`. Fork pull requests never reach it. The thing to look for after a merge is the base commit in the next Codecov comment: right now every one of them says `fa23a9b` and `419 commits behind head on main`.

## One thing this does not fix

The pinned 6.0.0 fetches the uploader's signing key from `keybase.io/codecovsecurity`, an account Codecov has since deleted, so on this pull request's own run the signature check failed and the uploader ran regardless:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
==> CLI integrity verified
```

#1281 is the bump to 7.0.0, the release that moves the key to `codecovsecops`. It is green and already carries `approved`, so I have left it there rather than duplicating the same one-line change here. Whether `fail_ci_if_error` should be turned on as well is a separate call, since it would make a Codecov outage fail the job.

6.0.1 in between carries the VULN-1652 template injection fix, which our pin predates. The only input this workflow passes is a literal, and it sets no token, so nothing untrusted reaches the expansions that fix removed.


